### PR TITLE
In /criteria show information about all levels

### DIFF
--- a/app/views/static_pages/criteria.html.erb
+++ b/app/views/static_pages/criteria.html.erb
@@ -1,26 +1,37 @@
+<% cache locale do %>
 <div class="center jumbotron">
   <h1><%= t '.criteria' %></h1>
   <!-- This page quickly shows some information about the Criteria. -->
   <p><a href='https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/criteria.md'>
   <%= t '.detailed_criteria_on_github' %></a></p>
-  <p>
-  <% future_criteria, active_criteria =
-       Criteria['0'].values.partition(&:future?) %>
-  <%= t '.current_criteria', active: active_criteria.count,
-                             future: future_criteria.count,
-                             total: Criteria['0'].count %>
-  <br>
-  <%= t '.criteria_must_should_suggested',
-        must: active_criteria.count(&:must?),
-        should: active_criteria.count(&:should?),
-        suggested: active_criteria.count(&:suggested?) %>
-  <%= t '.criteria_na_met_details',
-        na_allowed: active_criteria.count(&:na_allowed?),
-        met_url_required: active_criteria.count(&:met_url_required?),
-        details_present: active_criteria.count(&:details_present?) %>
-  </p>
-  <p><%= t '.project_counts', projects: Project.count,
-                              passing: Project.passing.count,
-                              in_progress: Project.in_progress.count %></p>
+  <table class="table table-bordered table-striped table-responsive">
+    <tr>
+      <th><%= t '.level' %></th>
+      <th><%= t '.total_active' %></th>
+      <th><%= t '.must' %></th>
+      <th><%= t '.should' %></th>
+      <th><%= t '.suggested' %></th>
+      <th><%= t '.allow_na' %></th>
+      <th><%= t '.require_url' %></th>
+      <th><%= t '.details' %></th>
+      <th><%= t '.future' %></th>
+    </tr>
+    <% ['0', '1', '2'].each do |level| %>
+      <tr>
+        <% future_criteria, active_criteria =
+             Criteria[level].values.partition(&:future?) %>
+        <td><%= t "projects.form_early.level.#{level}" %></td>
+        <td><%= active_criteria.count %></td>
+        <td><%= active_criteria.count(&:must?) %></td>
+        <td><%= active_criteria.count(&:should?) %></td>
+        <td><%= active_criteria.count(&:suggested?) %></td>
+        <td><%= active_criteria.count(&:na_allowed?) %></td>
+        <td><%= active_criteria.count(&:met_url_required?) %></td>
+        <td><%= active_criteria.count(&:details_present?) %></td>
+        <td><%= future_criteria.count %></td>
+      </tr>
+    <% end %>
+  </table>
   <p><%= t '.project_stats_html' %></p>
 </div>
+<% end %>

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1497610916
+timestamp: 1497634724

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,9 +129,15 @@ en:
     criteria:
       criteria: Criteria
       detailed_criteria_on_github: The detailed criteria are on GitHub.
-      current_criteria: 'Current number of criteria: %{active} (active) + %{future} (future) = %{total} (total).'
-      criteria_must_should_suggested: Among active criteria, there are %{must} MUST, %{should} SHOULD, and %{suggested} SUGGESTED criteria.
-      criteria_na_met_details: Among active criteria, %{na_allowed} allow N/A, %{met_url_required} require a URL when met, and %{details_present} have details in their description.
+      level: Level
+      must: MUST
+      should: SHOULD
+      suggested: SUGGESTED
+      total_active: Total active
+      allow_na: Allow N/A
+      require_url: Require URL
+      details: Includes details
+      future: Future
       project_counts: There are %{projects} project entries; %{passing} are passing and %{in_progress} are in progress.
       project_stats_html: You can see statistics about projects over time at the <a href="/project_stats">project stats page</a>.
   users:

--- a/config/locales/translation.ja.yml
+++ b/config/locales/translation.ja.yml
@@ -38,7 +38,7 @@ ja:
     profile: プロフィール
     settings: 設定
     logout_html: <span class = "glyphicon glyphicon-log-out"> </ span>ログアウト
-    signup_html: <span class = "glyphicon glyphicon-log-in"> </ span>ログイン
+    signup_html: <span class = "glyphicon glyphicon-user"> </ span>ログイン
     login_html: <span class = "glyphicon glyphicon-log-in"> </ span>ログイン
     footer_text_html: '<small> <strong>ヘルプが必要ですか？質問があります？問題がありますか？ <em> <a href="mailto:&#99;ii&#45;badges&#45;questions&#45;own&#101;r&#64;lists&#46;coreinfrastructure&#46;or&#103;">送信してください電子メール</a>
       </ em>または<em> <a href="https://github.com/linuxfoundation/cii-best-practices-badge/issues"

--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -35,6 +35,7 @@ RemoveUnusedMethodsInModelsCheck: { except_methods: [
   'Project#created_since', # Scope called dynamincally
   'Project#updated_since', # Scope called dynamincally
   'Project#in_progress', # Scope used for search & in test, but tool misses it
+  'Project#passing', # Scope used for search & in test, but tool misses it
   'Criterion#must?', # Used in ERB template; doesn't notice.
   'User#digest'
   ] }

--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -25,7 +25,7 @@ RemoveTrailingWhitespaceCheck: { }
 RemoveUnusedMethodsInControllersCheck: { except_methods: [
   'ApplicationController#append_info_to_payload' # hook called by Rails
   ] }
-RemoveUnusedMethodsInHelpersCheck: { except_methods: [] }
+RemoveUnusedMethodsInHelpersCheck: { }
 RemoveUnusedMethodsInModelsCheck: { except_methods: [
   'Criteria#to_h', # Used by tests
   'Criteria#must?', # Used in ERB template; doesn't notice.
@@ -34,6 +34,7 @@ RemoveUnusedMethodsInModelsCheck: { except_methods: [
   'Criteria#suggested?', # Used in ERB template; doesn't notice.
   'Project#created_since', # Scope called dynamincally
   'Project#updated_since', # Scope called dynamincally
+  'Project#in_progress', # Scope used for search & in test, but tool misses it
   'Criterion#must?', # Used in ERB template; doesn't notice.
   'User#digest'
   ] }


### PR DESCRIPTION
This uses a table, which should be much easier to localize.
Previously we had used running text, which is especially problematic
for languages like Russian that have different endings for different
cardinal numbers (not just singular/plural).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>