### PR TITLE
Enforce in DBMS that local emails are unique. Fixes #719

### DIFF
--- a/db/migrate/20170617151458_unique_email.rb
+++ b/db/migrate/20170617151458_unique_email.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Force email addresses to be unique if they are local.
+# We depend on this, because we use the email address to identify users
+# if they are local.  It doesn't matter for non-local users, since we depend
+# on that provider to distinguish the users.
+class UniqueEmail < ActiveRecord::Migration[5.1]
+  def change
+    add_index :users, :email, name: 'unique_local_email', unique: true,
+                              where: "provider = 'local'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170616200439) do
+ActiveRecord::Schema.define(version: 20170617151458) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -367,6 +367,7 @@ ActiveRecord::Schema.define(version: 20170616200439) do
     t.datetime "reset_sent_at"
     t.string "preferred_locale", default: "en"
     t.index ["email"], name: "index_users_on_email"
+    t.index ["email"], name: "unique_local_email", unique: true, where: "((provider)::text = 'local'::text)"
     t.index ["uid"], name: "index_users_on_uid"
   end
 


### PR DESCRIPTION
Modify the schema so that the *database* enforces uniqueness
of email addresses when the provider is 'local'.
We depend on this, because we use the email address as the
identifier during login.

We enforce this at the Rails level, but that is subject to a race
condition because different Rails processes or threads might not
see this.  Also, enforcing important data structure requirements
at the DBMS level means that even if the code has a bug, it can't
violate this condition.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>