### PR TITLE
Use locale in markdown_embedding and html_embedding. Fixes #824

### DIFF
--- a/app/views/projects/_form_early.html.erb
+++ b/app/views/projects/_form_early.html.erb
@@ -37,8 +37,8 @@
   <%= render(partial: "details", locals: {
          criterion: "got_badge",
          details: t('projects.form_early.got_badge.details_html',
-                    markdown_embedding: %{<code>[![CII Best Practices](https://#{ badge_hostname }/projects/#{ project.id }/badge)](https://#{ badge_hostname }/projects/#{ project.id })</code>}.html_safe,
-                    html_embedding: %{<code>&lt;a href="https://#{badge_hostname}/projects/#{ project.id }"&gt;&lt;img src="https://#{ badge_hostname }/projects/#{ project.id }/badge"&gt;&lt;/a&gt; </code>}.html_safe)
+                    markdown_embedding: %{<code>[![CII Best Practices](https://#{ badge_hostname }/projects/#{ project.id }/badge)](#{ project_url(project) })</code>}.html_safe,
+                    html_embedding: %{<code>&lt;a href="#{ project_url(project) }"&gt;&lt;img src="https://#{ badge_hostname }/projects/#{ project.id }/badge"&gt;&lt;/a&gt; </code>}.html_safe)
       }) %>
 <% else %>
   <% next_level_prefix = edit_project_path %>


### PR DESCRIPTION
This fixes a subtle locale issue - we suggest a particular HTML for
embedding the badge, but didn't include the current locale.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>