### PR TITLE
Allow download of user index by non-admins

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,8 +6,8 @@
 
 # rubocop: disable Metrics/ClassLength
 class UsersController < ApplicationController
-  before_action :require_admin,  only: %i[index destroy]
-  before_action :logged_in_user, only: %i[edit update]
+  before_action :require_admin,  only: %i[destroy]
+  before_action :logged_in_user, only: %i[edit update index]
   before_action :correct_user,   only: %i[edit update]
   include SessionsHelper
 

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 json.array!(@users) do |user|
-  json.call(user, :id, :name) # Add :provider, :nickname ?
+  json.call(
+    user, :id, :name, :id, :name, :nickname, :uid, :provider,
+    :created_at, :updated_at
+  )
+  # ONLY show email to admins
+  json.email user.email if current_user&.admin?
   # json.url users_url(user, format: :json)
 end

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -2,4 +2,8 @@
 
 # Only show specific approved user attributes
 # json.merge! @user.attributes
-json.call(@user, :id, :name) # add :provider, :nickname ?
+json.call(
+  @user, :id, :name, :nickname, :uid, :provider, :created_at, :updated_at
+)
+# ONLY show email to admins
+json.email user.email if current_user&.admin?

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -12,16 +12,31 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     @admin_user = users(:admin_user)
   end
 
-  test 'unsuccessful index' do
-    log_in_as(@user)
+  test 'unsuccessful index without logging in' do
     get users_path
-    assert_redirected_to root_url
+    assert_redirected_to login_url
   end
 
-  test 'successful index' do
+  test 'Can request index, but non-admins do not get email addresses' do
+    log_in_as(@user)
+    get users_path
+    assert_response :success
+    assert_template 'index'
+    refute @response.body.include?(@user.email)
+  end
+
+  test 'Can request index.json, but non-admins do not get email addresses' do
+    log_in_as(@user)
+    get users_path + '.json'
+    assert_response :success
+    refute @response.body.include?(@user.email)
+  end
+
+  test 'successful index as admin, admins do get email addresses' do
     log_in_as(@admin_user)
     get users_path
     assert_response :success
     assert_template 'index'
+    assert @response.body.include?(@user.email)
   end
 end


### PR DESCRIPTION
We take privacy seriously, so in the past we have only allowed admins
to get the user index.  However, in retrospect this was really
more security theater than real security.  The index information
is available publicly anyway through various means.
The user information (id and name) is easily determined via show
one-by-one.  Whether or not a user is on GitHub, and their nickname,
can be inferred by the external page reference.  And the GitHub uid
is easily determined from GitHub using the nickname and GitHub APIs.
So in short, we're overprotecting information already publicly available.

This is a problem, because we *want* to encourage people to analyze
our data about OSS, and the user list is a key part of that data.
We're just making it hard for legitimate uses.

So, this lets download the user index even if they aren't an admin.
It's still subject to the usual limitations (e.g., pagination).

This change still requires that users be logged in to get the data.
This seems fair enough (register yourself before getting a list
of users), and may help us detect abuses.

The tests use "refute ..." instead of "assert !..." per a suggestion
from Jason Dossett.

Note that we still *ONLY* release email addresses to admins, and
we NEVER include the hashed passwords. Those remain sensitive,
and we continue to protect them per our security policy.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>