### PR TITLE
Document how to download data for analyis.  Fixes #822

### DIFF
--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -302,6 +302,77 @@ The following search parameters are supported:
 See app/controllers/project_controllers.rb for how these
 are implemented.
 
+## Downloading the database
+
+We encourage analysis of OSS trends.
+We do provide some search capabilities, but for most analysis
+you will typically need to download the database.
+We can't anticipate all possible uses, and we're trying to keep the
+software relatively small & focused.
+
+You can download the project data in JSON and CSV format using typical
+Rails REST conventions.
+Just add ".json" or ".csv" to the URL (or include an Accept statement,
+like "Accept: application/json", in the HTTP header).
+You can even do this on a search if we already support the search (e.g.,
+by name).  Similarly, you can download user data in JSON format using
+".json" at the end of the URL.
+
+There is a current technical limitation in that you must
+request project and user data page-by-page.
+This isn't hard, just provide a page parameter (e.g., "page=2").
+This is because Rails does not stream JSON or CSV data by default,
+so if we allowed this the application would download
+the entire database into memory to process it.
+Rails applications *can* stream data (there are even web pages explaining
+how to do it), but the call for it is rare and there are some
+complications in its implementation, so we just haven't implemented it yet.
+
+So you can download the projects by repeatedly requesting this
+(changing "1" into 2, 3, etc. until all is loaded):
+
+> https://bestpractices.coreinfrastructure.org/projects.json?page=1
+
+You can similarly load the user data starting from here:
+
+> https://bestpractices.coreinfrastructure.org/users.json?page=1
+
+To directly download the user list you must be logged in, and we
+intentionally restrict the information we share about users.
+We only provide basic public information such as name, nickname, and such.
+In particular, we only provide email addresses to
+BadgeApp administrators, because we value the privacy of our users.
+
+As we note about privacy and legal issues,
+please see our <a href="https://www.linuxfoundation.org/privacy">privacy
+policy</a> and <a href="https://www.linuxfoundation.org/terms">terms of
+use</a>.
+All publicly-available non-code content is released under at least the
+<a href="https://creativecommons.org/licenses/by/3.0/">Creative Commons
+Attribution License version 3.0 (CC-BY-3.0)</a>;
+newer non-code content is released under
+CC-BY version 3.0 or later (CC-BY-3.0+).
+If referencing collectively or
+not otherwise noted, please credit the
+"CII Best Practices badge contributors" and note the license.
+You should also note the website URL as the data source, which is
+<https://bestpractices.coreinfrastructure.org>.
+
+If you are doing research, we urge you do to it responsibly and reproducibly.
+Please be sure to capture the date and time when you began and completed
+capturing this dataset
+(you need both, because the data could be changing
+while you're downloading it).
+Do what you can to ensure that your research can be
+[replicated](https://en.wikipedia.org/wiki/Replication_crisis).
+Consider the points in
+[Good Enough Practices in Scientific Computing](https://arxiv.org/pdf/1609.00037v2.pdf), a "set of computing tools and techniques
+that every researcher can and should adopt."
+For example, "Where possible, save data as originally generated (i.e.
+by an instrument or from a survey."
+These aren't requirements for using this data, but they are well
+worth considering.
+
 ## Changing criteria
 
 To modify the text of the criteria, edit these files:


### PR DESCRIPTION
Other researchers will want to download the project data
for further analysis.  Yannick Moy, in particular,
wanted to analyze the data further.  We want to encourage
research - the more analysis that can occur, the more everyone
can understand FLOSS better.

We already support download, but it wasn't as clearly documented.

This commit documents exactly how to download the key project data.
Of course, we do *not* provide some data
(like user email addresses and hashed user passwords),
and this is intentional - so we document that too.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>