### PR TITLE
Index percentages for higher-level badges

### DIFF
--- a/db/migrate/20170617213336_index_higher_levels.rb
+++ b/db/migrate/20170617213336_index_higher_levels.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class IndexHigherLevels < ActiveRecord::Migration[5.1]
+  def change
+    add_index :projects, :badge_percentage_1
+    add_index :projects, :badge_percentage_2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170617151458) do
+ActiveRecord::Schema.define(version: 20170617213336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -335,6 +335,8 @@ ActiveRecord::Schema.define(version: 20170617151458) do
     t.text "assurance_case_justification"
     t.index ["achieved_passing_at"], name: "index_projects_on_achieved_passing_at"
     t.index ["badge_percentage_0"], name: "index_projects_on_badge_percentage_0"
+    t.index ["badge_percentage_1"], name: "index_projects_on_badge_percentage_1"
+    t.index ["badge_percentage_2"], name: "index_projects_on_badge_percentage_2"
     t.index ["created_at"], name: "index_projects_on_created_at"
     t.index ["homepage_url"], name: "index_projects_on_homepage_url"
     t.index ["last_reminder_at"], name: "index_projects_on_last_reminder_at"


### PR DESCRIPTION
This indexing is key for efficiently querying higher levels
(e.g., for recording the number of silver/gold projects).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>