### PR TITLE
Record statistics for higher-level badges.

### DIFF
--- a/app/models/project_stat.rb
+++ b/app/models/project_stat.rb
@@ -26,12 +26,12 @@ class ProjectStat < ApplicationRecord
         next if completion.to_i.zero?
         public_send "percent_1_ge_#{completion}=",
                     Project.where(
-                      'badge_percentage_1 > ?',
+                      'badge_percentage_1 >= ?',
                       completion.to_i
                     ).count
         public_send "percent_2_ge_#{completion}=",
                     Project.where(
-                      'badge_percentage_2 > ?',
+                      'badge_percentage_2 >= ?',
                       completion.to_i
                     ).count
       end

--- a/app/models/project_stat.rb
+++ b/app/models/project_stat.rb
@@ -16,13 +16,24 @@ class ProjectStat < ApplicationRecord
   before_create :stamp
 
   # Stamp (fill in) the current values into a ProjectStat. Uses database.
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/BlockLength
   def stamp
     # Use a transaction to get values from a single consistent point in time.
     Project.transaction do
       # Count projects at different levels of completion
       STAT_VALUES.each do |completion|
         public_send "percent_ge_#{completion}=", Project.gteq(completion).count
+        next if completion.to_i.zero?
+        public_send "percent_1_ge_#{completion}=",
+                    Project.where(
+                      'badge_percentage_1 > ?',
+                      completion.to_i
+                    ).count
+        public_send "percent_2_ge_#{completion}=",
+                    Project.where(
+                      'badge_percentage_2 > ?',
+                      completion.to_i
+                    ).count
       end
       self.projects_edited = Project.where('created_at < updated_at').count
 
@@ -63,7 +74,7 @@ class ProjectStat < ApplicationRecord
     end
     self # Return self to support method chaining
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/BlockLength
 
   # Return the last ProjectStat value available in the month of "date";
   # returns nil if no ProjectStat is available in that month.

--- a/db/migrate/20170617215652_record_higher_levels.rb
+++ b/db/migrate/20170617215652_record_higher_levels.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Record progress in higher levels
+class RecordHigherLevels < ActiveRecord::Migration[5.1]
+  def change
+    # progress in silver
+    add_column :project_stats, :percent_1_ge_25, :integer
+    add_column :project_stats, :percent_1_ge_50, :integer
+    add_column :project_stats, :percent_1_ge_75, :integer
+    add_column :project_stats, :percent_1_ge_90, :integer
+    add_column :project_stats, :percent_1_ge_100, :integer
+
+    # progress in gold
+    add_column :project_stats, :percent_2_ge_25, :integer
+    add_column :project_stats, :percent_2_ge_50, :integer
+    add_column :project_stats, :percent_2_ge_75, :integer
+    add_column :project_stats, :percent_2_ge_90, :integer
+    add_column :project_stats, :percent_2_ge_100, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170617213336) do
+ActiveRecord::Schema.define(version: 20170617215652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,16 @@ ActiveRecord::Schema.define(version: 20170617213336) do
     t.integer "projects_edited"
     t.integer "active_edited_projects"
     t.integer "active_edited_in_progress"
+    t.integer "percent_1_ge_25"
+    t.integer "percent_1_ge_50"
+    t.integer "percent_1_ge_75"
+    t.integer "percent_1_ge_90"
+    t.integer "percent_1_ge_100"
+    t.integer "percent_2_ge_25"
+    t.integer "percent_2_ge_50"
+    t.integer "percent_2_ge_75"
+    t.integer "percent_2_ge_90"
+    t.integer "percent_2_ge_100"
     t.index ["created_at"], name: "index_project_stats_on_created_at"
   end
 


### PR DESCRIPTION
This partly addresses #813 by recording data in table project_stats.
This commit does not *display* any of this data - but we
have to record it before we display it.

It's not clear we'll report the 25%, 50%, 75%, or 90% levels for
silver or gold, but it's easier to simply start recording it & then
we can show subsets if desired.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>