### PR TITLE
Modify update_all_badge_percentages to update specified levels

### DIFF
--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -425,7 +425,11 @@ end
 # gain/lose a badge because of the changes.
 desc 'Run to recalculate all badge percentages for all projects'
 task :update_all_badge_percentages do
-  Project.update_all_badge_percentages
+  Project.update_all_badge_percentages(Criteria.keys)
+end
+
+task :update_higher_level_badge_percentages do
+  Project.update_all_badge_percentages(Criteria.keys - ['0'])
 end
 
 Rake::Task['test:run'].enhance ['test:features']

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -428,7 +428,7 @@ task :update_all_badge_percentages do
   Project.update_all_badge_percentages(Criteria.keys)
 end
 
-task :update_higher_level_badge_percentages do
+task :update_all_higher_level_badge_percentages do
   Project.update_all_badge_percentages(Criteria.keys - ['0'])
 end
 

--- a/test/integration/recalc_test.rb
+++ b/test/integration/recalc_test.rb
@@ -11,27 +11,82 @@ class RecalcTest < ActionDispatch::IntegrationTest
     @project = projects(:one)
   end
 
-  test 'Recalc percentages' do
-    # Check starting badge_percentage is zero, as expected
-    old_percentage = Project.find(projects(:one).id).badge_percentage_0
+  test 'Make sure recalc percentages only updates levels specified' do
+    old_percentage = Project.find(projects(:one).id).badge_percentage_1
     assert old_percentage.zero?
     # Update some columns without triggering percentage calculation
     # or change in updated_at
-    assert_no_difference(
+    assert_no_difference [
       'Project.find(projects(:one).id).badge_percentage_0',
+      'Project.find(projects(:one).id).badge_percentage_1',
+      'Project.find(projects(:one).id).badge_percentage_2',
       'Project.find(projects(:one).id).updated_at'
-    ) do
-      @project.update_column(:homepage_url_status, 'Met')
-      @project.update_column(:description_good_status, 'Met')
+    ] do
+      @project.update_column(:crypto_weaknesses_status, 'Met')
+      @project.update_column(:crypto_weaknesses_justification, 'It is good')
+      @project.update_column(:warnings_strict_status, 'Met')
+      @project.update_column(:warnings_strict_justification, 'It is good')
     end
-    # Run the update task, make sure updated_at doesnt change
-    assert_no_difference 'Project.find(projects(:one).id).updated_at' do
-      Project.update_all_badge_percentages
+    # Run the update task, make sure updated_at and others don't change
+    assert_no_difference [
+      'Project.find(projects(:one).id).updated_at',
+      'Project.find(projects(:one).id).badge_percentage_0',
+      'Project.find(projects(:one).id).badge_percentage_2'
+    ] do
+      Project.update_all_badge_percentages(['1'])
+    end
+    # Check the badge percentage changed
+    assert_not_equal(
+      Project.find(projects(:one).id).badge_percentage_1,
+      old_percentage
+    )
+  end
+
+  # rubocop:disable Metrics/BlockLength
+  test 'Make sure recalc percentages only updates levels affected' do
+    old_percentage0 = Project.find(projects(:one).id).badge_percentage_0
+    old_percentage1 = Project.find(projects(:one).id).badge_percentage_1
+    assert old_percentage0.zero?
+    assert old_percentage1.zero?
+    # Update some columns without triggering percentage calculation
+    # or change in updated_at
+    assert_no_difference [
+      'Project.find(projects(:one).id).badge_percentage_0',
+      'Project.find(projects(:one).id).badge_percentage_1',
+      'Project.find(projects(:one).id).badge_percentage_2',
+      'Project.find(projects(:one).id).updated_at'
+    ] do
+      @project.update_column(:crypto_weaknesses_status, 'Met')
+      @project.update_column(:crypto_weaknesses_justification, 'It is good')
+      @project.update_column(:warnings_strict_status, 'Met')
+      @project.update_column(:warnings_strict_justification, 'It is good')
+    end
+    # Run the update task, make sure updated_at and others don't change
+    assert_no_difference [
+      'Project.find(projects(:one).id).updated_at',
+      'Project.find(projects(:one).id).badge_percentage_2'
+    ] do
+      # Level 2 does not depend on these keys
+      # so it's percentage should not change
+      Project.update_all_badge_percentages(Criteria.keys)
     end
     # Check the badge percentage changed
     assert_not_equal(
       Project.find(projects(:one).id).badge_percentage_0,
-      old_percentage
+      old_percentage0
     )
+    assert_not_equal(
+      Project.find(projects(:one).id).badge_percentage_1,
+      old_percentage1
+    )
+  end
+  # rubocop:enable Metrics/BlockLength
+
+  test 'Raises TypeError' do
+    assert_raises(TypeError) { Project.update_all_badge_percentages('1') }
+  end
+
+  test 'Raises ArgumentError' do
+    assert_raises(ArgumentError) { Project.update_all_badge_percentages(['3']) }
   end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -190,4 +190,38 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal '13/13', quality[:text]
     assert_equal 'hsl(120, 100%, 50%)', quality[:color]
   end
+
+  # rubocop:disable Metrics/BlockLength
+  test 'test :skip_callbacks works as spected' do
+    project_one = projects(:one)
+    Project.skip_callbacks = true
+    # With skip_callbacks = true there should be
+    # no change to percentages on save.
+    assert_no_difference [
+      'Project.find(projects(:one).id).badge_percentage_0',
+      'Project.find(projects(:one).id).badge_percentage_1'
+    ] do
+      project_one.update_attributes!(
+        crypto_weaknesses_status: 'Met',
+        crypto_weaknesses_justification: 'It is good'
+      )
+    end
+    Project.skip_callbacks = false
+    old_percentage0 = Project.find(projects(:one).id).badge_percentage_0
+    old_percentage1 = Project.find(projects(:one).id).badge_percentage_1
+    project_one.update_attributes!(
+      warnings_strict_status: 'Met',
+      warnings_strict_justification: 'It is good'
+    )
+    # Check the badge percentage changed
+    assert_not_equal(
+      Project.find(projects(:one).id).badge_percentage_0,
+      old_percentage0
+    )
+    assert_not_equal(
+      Project.find(projects(:one).id).badge_percentage_1,
+      old_percentage1
+    )
+  end
+  # rubocop:enable Metrics/BlockLength
 end


### PR DESCRIPTION
With the addition of the new levels, we will need to update
the higher level badge percentages for all the projects without
affecting the passing level status or modifying the updated at
entry.  These changes allow that and a rake task is added to perform
the action.  The command:

~~~~sh
rake update_all_badge_percentages
~~~~

still updates all levels while:

~~~~sh
rake update_all_higher_level_badge_percentages
~~~~

updates all but the passing level.

This PR provides numerous tests to make sure the methods being
called perform as expected.

Signed-off-by: Jason Dossett <jdossett@utdallas.edu>