### PR TITLE
Minor optimization: get criterion_result in status_chooser

### DIFF
--- a/app/views/projects/_status_chooser.html.erb
+++ b/app/views/projects/_status_chooser.html.erb
@@ -1,15 +1,17 @@
-<% criterion_result = project.get_criterion_result(criterion)
+<%
    status_symbol = (criterion.to_s + '_status').to_sym
    justification_symbol = (criterion.to_s + '_justification').to_sym
    project_criterion_status = project[status_symbol]
    project_criterion_justification = project[justification_symbol] %>
 
 <% cache [criterion.to_s, criteria_level, is_disabled, locale,
-          project_criterion_status, project_criterion_justification ] do %>
-  <% passing_class = ''
+          project_criterion_status, project_criterion_justification ] do
+     criterion_result = project.get_criterion_result(criterion)
+     passing_class = ''
       if criterion_result == :criterion_passing && is_disabled
        passing_class = ' criterion-passing'
-     end %>
+     end
+  %>
   <div id="<%= criterion.to_s %>" class="row criterion-data<%= passing_class %>">
     <% is_crypto = criterion.to_s.match(/^crypto_/)
        crypto_class = is_crypto ? ' criterion-is-crypto' : '' %>


### PR DESCRIPTION
Partial view status_chooser is the largest consumer of time and memory
as reported by the "Scout" performance monitor.  This makes sense because
it is repeatedly called many times in a loop in project#show and
project#edit.

A minor but easy optimization is to delay calculation of value
criterion_result, so that we only calculate it when we need it
(we don't need it if we're retrieving a cached value).
This doesn't help that much, but it does no harm and from a logical
viewpoint it makes sense to calculate it around the first location of use.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>