### PR TITLE
Cache justification markdown

### DIFF
--- a/app/views/projects/_status_chooser.html.erb
+++ b/app/views/projects/_status_chooser.html.erb
@@ -83,8 +83,9 @@
                      details: criterion.details.html_safe})
         end %>
     <% if (is_disabled) %>
-      <% if project_criterion_justification %>
-        <% cache ['markdown', project_criterion_justification] do %>
+      <% if project_criterion_justification&.presence %>
+        <% cache ['markdown', project.id, criterion.to_s,
+                  project.lock_version] do %>
           <div class="justification-markdown">
             <%= markdown(project_criterion_justification) %>
           </div>

--- a/app/views/projects/_status_chooser.html.erb
+++ b/app/views/projects/_status_chooser.html.erb
@@ -84,9 +84,11 @@
         end %>
     <% if (is_disabled) %>
       <% if project_criterion_justification %>
-        <div class="justification-markdown">
-          <%= markdown(project_criterion_justification) %>
-        </div>
+        <% cache ['markdown', project_criterion_justification] do %>
+          <div class="justification-markdown">
+            <%= markdown(project_criterion_justification) %>
+          </div>
+        <% end %>
       <% end %>
       <% if criterion_result == :criterion_url_required %>
         <p class="bg-warning"><%= t('projects.misc.url_required_warning') %></p>


### PR DESCRIPTION
Cache the generated markdown for project justifications.
Note that these can be *reused* across locales, and when they are
identical these can even be reused across projects
(this can happen when people accept the system-created justifications).
The markdown is generated as part of file
app/views/projects/_status_chooser.html.erb, which is the biggest
user of time and memory allocations, so optimizing this file
is sensible in general.

We use the justification text as the cache key.
This can result in rediculously-long cache keys, but those are exactly
the cases where the cache would be most useful, so we permit it.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>