### PR TITLE
Don't sanitize criterion description

### DIFF
--- a/app/models/criteria.rb
+++ b/app/models/criteria.rb
@@ -101,7 +101,10 @@ class Criteria
   def description
     key = "criteria.#{level}.#{name}.description"
     return nil unless I18n.exists?(key)
-    I18n.t(key)
+    # Descriptions only come from trusted data source, so we can safely disable
+    # rubocop:disable Rails/OutputSafety
+    I18n.t(key).html_safe
+    # rubocop:enable Rails/OutputSafety
   end
 
   def details

--- a/app/views/projects/_status_chooser.html.erb
+++ b/app/views/projects/_status_chooser.html.erb
@@ -76,7 +76,7 @@
   <div class='col-md-10 col-sm-9 col-xs-12 criteria-desc'>
     <br>
     <% if criterion.future? %>(<%= t('projects.misc.future_criterion') %>) <% end %>
-    <%= sanitize criterion.description %>
+    <%= criterion.description %>
     <% if criterion.met_url_required? %>(<%= t('projects.misc.url_required') %>) <% end %>
     <sup>[<%= criterion %>]</sup>
     <%= if criterion.details


### PR DESCRIPTION
The criterion description text is from a trusted source, so don't
sanitize every description on every use at run-time.
(We could check once on start-up, if a check is desired; that way,
we would only have to pay for the check once on start-up.)

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>