### PR TITLE
Improved locale_name's

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -41,7 +41,7 @@
                 <li><a href="<%=
                   # TODO: This doesn't include the anchor.
                   force_locale_url(request.original_url, loc)
-                  %>"><%= t("locale_name.#{loc}") %></a>
+                  %>"><%= t("locale_name.#{loc} (#{loc})") %></a>
                 </li>
               <% end %>
             </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,12 +29,12 @@ en:
   feed_title: CII Best Practices BadgeApp Updated Projects
   project_name_unknown: "(Name unknown)"
   locale_name:
-    en: English (en)
-    de: German / Deutsch (de)
-    fr: French / Français (fr)
-    ja: Japanese / 日本語 (ja)
-    ru: Russian / русский (ru)
-    zh-CN: Chinese (Simplified) / 简体中文 (zh-CN)
+    en: English
+    de: German / Deutsch
+    fr: French / Français
+    ja: Japanese / 日本語
+    ru: Russian / русский
+    zh-CN: Chinese (Simplified) / 简体中文
   layouts:
     cii_best_practices: CII Best Practices
     projects: Projects

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,10 +30,10 @@ en:
   project_name_unknown: "(Name unknown)"
   locale_name:
     en: English (en)
-    de: German / Deutsche (de)
+    de: German / Deutsch (de)
     fr: French / Français (fr)
     ja: Japanese / 日本語 (ja)
-    ru: Russian / русский язык (ru)
+    ru: Russian / русский (ru)
     zh-CN: Chinese (Simplified) / 简体中文 (zh-CN)
   layouts:
     cii_best_practices: CII Best Practices


### PR DESCRIPTION
There are two fixes here - the commit messages say it all. I'm not quite sure whether this will also work with RTL languages but upon reading the [W3C article](https://www.w3.org/International/articles/inline-bidi-markup/index.en) I have an impression that things will "just work" (that is, the language code will automagically travel to the other side of the string) thanks to the Unicode Bidi Algorithm. I'm really not a specialist in the area though.
As a quite a reasonable option - the language code might be entirely omitted from the UI (though it mandates reasonable distinction between locales in their names - but it's a good idea anyway).