### PR TITLE
Trust "details" source (don't bother sanitizing)

### DIFF
--- a/app/models/criteria.rb
+++ b/app/models/criteria.rb
@@ -165,7 +165,11 @@ class Criteria
     Criteria.get_levels(name).reverse.each do |l|
       next if l.to_i > level.to_i
       t_key = "criteria.#{l}.#{name}.#{field}"
-      return I18n.t(t_key) if I18n.exists?(t_key)
+      # Disable HTML output safety. I18n translations are internal data
+      # and are considered a trusted source.
+      # rubocop:disable Rails/OutputSafety
+      return I18n.t(t_key).html_safe if I18n.exists?(t_key)
+      # rubocop:enable Rails/OutputSafety
     end
     nil
   end

--- a/app/views/projects/_details.html.erb
+++ b/app/views/projects/_details.html.erb
@@ -3,11 +3,5 @@
             details_text_id = criterion.to_s + "_details_text" %>
          <button class="btn btn-simple details-toggler hidden-print" title="<%= t('projects.misc.toggle_details_title') %>" type="button" id='<%= details_toggler_id %>'><%= t('projects.misc.details') %></button>
          <div class="details-text" id="<%= details_text_id %>">
-         <%# Although we provide details, sanitize here provides belt and
-             suspenders protection and shows brakeman that it's safe.
-             ONLY the tags and attributes listed below will be allowed
-             in "details". %>
-         <%= sanitize details,
-                      tags: %w(a strong em i b ol ul li br small p),
-                      attributes: %w(href) %>
+         <%= details %>
          </div>


### PR DESCRIPTION
This commit accepts the "details" text as html_safe, instead of
doing a more-expensive sanitize on every single detail text
every time it's requested at run-time.  The source of the details
text is trusted, so the "sanitize" is not necessary.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>