### PR TITLE
Test: All text values (all locales) incl. only acceptable HTML

### DIFF
--- a/test/models/translations_test.rb
+++ b/test/models/translations_test.rb
@@ -48,7 +48,7 @@ class TranslationsTest < ActiveSupport::TestCase
       sanitized = sanitize_html(x)
       regularized = regularize_html(x)
       if sanitized != regularized
-        p "Unacceptable HTML.\nSan=<#{sanitized}>\nReg=#{regularized}"
+        p "Unacceptable HTML.\nSan=<#{sanitized}>\nReg=<#{regularized}>"
       end
       sanitized != regularized
       # else

--- a/test/models/translations_test.rb
+++ b/test/models/translations_test.rb
@@ -17,4 +17,50 @@ class TranslationsTest < ActiveSupport::TestCase
                    Translations.instance.for_js[l].keys.sort
     end
   end
+
+  # What tags & attributes are allowed?
+  ACCEPTABLE_TAGS = %w[h1 a strong em i b small tt ol ul li br p span].freeze
+  # Class can cause trouble, but we need it for glyphicons, etc.
+  ACCEPTABLE_ATTRS = %w[href name class target].freeze
+
+  def sanitize_html(x)
+    html_sanitizer = Rails::Html::WhiteListSanitizer.new
+    html_sanitizer.sanitize(
+      x, tags: ACCEPTABLE_TAGS,
+         attributes: ACCEPTABLE_ATTRS
+    ).to_s
+  end
+
+  def regularize_html(x)
+    regularizer = Rails::Html::TargetScrubber.new
+    Loofah.fragment(x).scrub!(regularizer).to_s
+  end
+
+  # Return first unacceptable HTML in x (recursively), else nil
+  # To recurse we really want kind_of?, not is_a?, so disable rubocop rule
+  # rubocop:disable Style/ClassCheck
+  def find_unacceptable_html(x)
+    if x.kind_of?(Array) || x.kind_of?(Hash)
+      x.find { |part| find_unacceptable_html(part) }
+    elsif x.kind_of?(String) # includes safe_html
+      # Text considered okay if the results of "sanitizing" it are
+      # same as when we simply "regularize" the text without sanitizing it.
+      sanitized = sanitize_html(x)
+      regularized = regularize_html(x)
+      if sanitized != regularized
+        p "Unacceptable HTML.\nSan=<#{sanitized}>\nReg=#{regularized}"
+      end
+      sanitized != regularized
+      # else
+      # x.is_a?(Symbol) || x.is_a?(Numeric) || x.in?([true, false, nil]) ||
+      # x.is_a?(Proc)
+    end
+  end
+  # rubocop:enable Style/ClassCheck
+
+  test 'All text values (all locales) include only acceptable HTML' do
+    I18n.available_locales.each do |loc|
+      assert_not find_unacceptable_html(I18n.t('.', locale: loc))
+    end
+  end
 end

--- a/test/models/translations_test.rb
+++ b/test/models/translations_test.rb
@@ -23,17 +23,17 @@ class TranslationsTest < ActiveSupport::TestCase
   # Class can cause trouble, but we need it for glyphicons, etc.
   ACCEPTABLE_ATTRS = %w[href name class target].freeze
 
-  def sanitize_html(x)
+  def sanitize_html(text)
     html_sanitizer = Rails::Html::WhiteListSanitizer.new
     html_sanitizer.sanitize(
-      x, tags: ACCEPTABLE_TAGS,
-         attributes: ACCEPTABLE_ATTRS
+      text, tags: ACCEPTABLE_TAGS,
+            attributes: ACCEPTABLE_ATTRS
     ).to_s
   end
 
-  def regularize_html(x)
+  def regularize_html(text)
     regularizer = Rails::Html::TargetScrubber.new
-    Loofah.fragment(x).scrub!(regularizer).to_s
+    Loofah.fragment(text).scrub!(regularizer).to_s
   end
 
   # Return true if x is a "simple" (non-compound) non-string type
@@ -45,21 +45,21 @@ class TranslationsTest < ActiveSupport::TestCase
   # Return first unacceptable HTML in x (recursively), else (nil|false)
   # To recurse we really want kind_of?, not is_a?, so disable rubocop rule
   # rubocop:disable Style/ClassCheck, Metrics/MethodLength
-  def find_unacceptable_html(x)
-    if x.kind_of?(Array) || x.kind_of?(Hash)
-      x.find { |part| find_unacceptable_html(part) }
-    elsif x.kind_of?(String) # includes safe_html
-      return nil unless x.include?('<') # Can't be a problem, no '<'
-      # Text considered okay if the results of "sanitizing" it are
+  def find_unacceptable_html(translation)
+    if translation.kind_of?(Array) || translation.kind_of?(Hash)
+      translation.find { |part| find_unacceptable_html(part) }
+    elsif translation.kind_of?(String) # includes safe_html
+      return nil unless translation.include?('<') # Can't be a problem, no '<'
+      # Translation text is okay if the results of "sanitizing" it are
       # same as when we simply "regularize" the text without sanitizing it.
-      sanitized = sanitize_html(x)
-      regularized = regularize_html(x)
+      sanitized = sanitize_html(translation)
+      regularized = regularize_html(translation)
       if sanitized != regularized
         p "Unacceptable HTML.\nSan=<#{sanitized}>\nReg=<#{regularized}>"
       end
       sanitized != regularized
     else
-      !simple_type(x) # Require that it be simple: symbol, number, etc.
+      !simple_type(translation) # else must be simple: symbol, number, etc.
     end
   end
   # rubocop:enable Style/ClassCheck, Metrics/MethodLength


### PR DESCRIPTION
This commit adds a test to ensure that all text values,
in all locales, include only acceptable HTML.  We determine this by
sanitizing (which only accepts a whitelist of tags and attributes),
and then seeing if that's the same as simply regularizing the text
(without removing anything).

If we pass the test, then we can omit sanitization or escaping of
the locale text at run-time with confidence, since we know
that it can only include the permitted tags and attributes.
We also know that *all* the text has been checked ahead-of-time.
That's better for performance (at run-time we definitely don't
need any of those checks) and for error detection (we detect
an unexpected tag or attribute much earlier, and more thoroughly).
Strictly speaking the locale text is trusted anyway, but
adding a test to check for problems seems reasonable.

This commit does add a non-trivial amount to test time.
This one test takes about 10 seconds locally.
But while that longer test time is not ideal, it's not
a show-stopping amount of test time.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>