### PR TITLE
Add version information to migrations

### DIFF
--- a/db/migrate/20150903180310_create_users.rb
+++ b/db/migrate/20150903180310_create_users.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string :provider

--- a/db/migrate/20150903194908_create_projects.rb
+++ b/db/migrate/20150903194908_create_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateProjects < ActiveRecord::Migration
+class CreateProjects < ActiveRecord::Migration[4.2]
   def change
     # rubocop:disable Metrics/BlockLength
     create_table :projects do |t|

--- a/db/migrate/20151005140708_default_status.rb
+++ b/db/migrate/20151005140708_default_status.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class DefaultStatus < ActiveRecord::Migration
+class DefaultStatus < ActiveRecord::Migration[4.2]
   def change
     change_column_default :projects, :project_url_status, '?'
     change_column_default :projects, :project_url_https_status, '?'

--- a/db/migrate/20151013175357_create_versions.rb
+++ b/db/migrate/20151013175357_create_versions.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateVersions < ActiveRecord::Migration
+class CreateVersions < ActiveRecord::Migration[4.2]
   # The largest text column available in all supported RDBMS is
   # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
   # so that MySQL will use `longtext` instead of `text`.  Otherwise,

--- a/db/migrate/20151023200819_add_role_to_users.rb
+++ b/db/migrate/20151023200819_add_role_to_users.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddRoleToUsers < ActiveRecord::Migration
+class AddRoleToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :role, :string
   end

--- a/db/migrate/20151026190431_crypto_weaknesses_alternatives.rb
+++ b/db/migrate/20151026190431_crypto_weaknesses_alternatives.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CryptoWeaknessesAlternatives < ActiveRecord::Migration
+class CryptoWeaknessesAlternatives < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :crypto_weaknesses_status, :string, default: '?'
     add_column :projects, :crypto_weaknesses_justification, :text

--- a/db/migrate/20151027231812_add_continuous_migration.rb
+++ b/db/migrate/20151027231812_add_continuous_migration.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddContinuousMigration < ActiveRecord::Migration
+class AddContinuousMigration < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :test_continuous_integration_status, :string, default: '?'
     add_column :projects, :test_continuous_integration_justification, :text

--- a/db/migrate/20151104160449_rename_project_url.rb
+++ b/db/migrate/20151104160449_rename_project_url.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RenameProjectUrl < ActiveRecord::Migration
+class RenameProjectUrl < ActiveRecord::Migration[4.2]
   def change
     # rename_column :projects, :old_column, :new_column
     rename_column :projects, :project_url, :project_homepage_url

--- a/db/migrate/20160119195552_add_remember_digest_to_users.rb
+++ b/db/migrate/20160119195552_add_remember_digest_to_users.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddRememberDigestToUsers < ActiveRecord::Migration
+class AddRememberDigestToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :remember_digest, :string
   end

--- a/db/migrate/20160121190453_rename_changelog_to_release_notes.rb
+++ b/db/migrate/20160121190453_rename_changelog_to_release_notes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RenameChangelogToReleaseNotes < ActiveRecord::Migration
+class RenameChangelogToReleaseNotes < ActiveRecord::Migration[4.2]
   def change
     rename_column :projects, :changelog_status,
                   :release_notes_status

--- a/db/migrate/20160123040035_add_project_cpe_field.rb
+++ b/db/migrate/20160123040035_add_project_cpe_field.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddProjectCpeField < ActiveRecord::Migration
+class AddProjectCpeField < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :cpe, :string
   end

--- a/db/migrate/20160123144005_add_user_indexes.rb
+++ b/db/migrate/20160123144005_add_user_indexes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddUserIndexes < ActiveRecord::Migration
+class AddUserIndexes < ActiveRecord::Migration[4.2]
   def change
     add_index :users, :uid
     add_index :users, :email

--- a/db/migrate/20160130165746_add_discussion.rb
+++ b/db/migrate/20160130165746_add_discussion.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddDiscussion < ActiveRecord::Migration
+class AddDiscussion < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :discussion_status, :string, default: '?'
     add_column :projects, :discussion_justification, :text

--- a/db/migrate/20160131030706_add_activation_to_users.rb
+++ b/db/migrate/20160131030706_add_activation_to_users.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddActivationToUsers < ActiveRecord::Migration
+class AddActivationToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :activation_digest, :string
     add_column :users, :activated, :boolean, default: false

--- a/db/migrate/20160205054718_add_reset_to_users.rb
+++ b/db/migrate/20160205054718_add_reset_to_users.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddResetToUsers < ActiveRecord::Migration
+class AddResetToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :reset_digest, :string
     add_column :users, :reset_sent_at, :datetime

--- a/db/migrate/20160215180800_remove_crypto_alternatives.rb
+++ b/db/migrate/20160215180800_remove_crypto_alternatives.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RemoveCryptoAlternatives < ActiveRecord::Migration
+class RemoveCryptoAlternatives < ActiveRecord::Migration[4.2]
   def up
     remove_column :projects, :crypto_alternatives_status
     remove_column :projects, :crypto_alternatives_justification

--- a/db/migrate/20160215195756_rename_oss_to_floss.rb
+++ b/db/migrate/20160215195756_rename_oss_to_floss.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RenameOssToFloss < ActiveRecord::Migration
+class RenameOssToFloss < ActiveRecord::Migration[4.2]
   def change
     rename_column :projects, :oss_license_status, :floss_license_status
     rename_column :projects,

--- a/db/migrate/20160224021902_rename_repo_url_to_repo_public.rb
+++ b/db/migrate/20160224021902_rename_repo_url_to_repo_public.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RenameRepoUrlToRepoPublic < ActiveRecord::Migration
+class RenameRepoUrlToRepoPublic < ActiveRecord::Migration[4.2]
   def change
     rename_column :projects, :repo_url_status, :repo_public_status
     rename_column :projects, :repo_url_justification, :repo_public_justification

--- a/db/migrate/20160229153025_create_no_leaked_credentials.rb
+++ b/db/migrate/20160229153025_create_no_leaked_credentials.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateNoLeakedCredentials < ActiveRecord::Migration
+class CreateNoLeakedCredentials < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :no_leaked_credentials_status, :string, default: '?'
     add_column :projects, :no_leaked_credentials_justification, :text

--- a/db/migrate/20160305175953_rename_contribution_criteria_to_contribution_requirements.rb
+++ b/db/migrate/20160305175953_rename_contribution_criteria_to_contribution_requirements.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class RenameContributionCriteriaToContributionRequirements <
-      ActiveRecord::Migration
+      ActiveRecord::Migration[4.2]
   def change
     rename_column :projects,
                   :contribution_criteria_status,

--- a/db/migrate/20160305194843_rename.rb
+++ b/db/migrate/20160305194843_rename.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Rename < ActiveRecord::Migration
+class Rename < ActiveRecord::Migration[4.2]
   def change
     rename_column :projects,
                   :description_sufficient_status,

--- a/db/migrate/20160311164125_add_english.rb
+++ b/db/migrate/20160311164125_add_english.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddEnglish < ActiveRecord::Migration
+class AddEnglish < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :english_status, :string, default: '?'
     add_column :projects, :english_justification, :text

--- a/db/migrate/20160318220017_add_index_repo_url.rb
+++ b/db/migrate/20160318220017_add_index_repo_url.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddIndexRepoUrl < ActiveRecord::Migration
+class AddIndexRepoUrl < ActiveRecord::Migration[4.2]
   def change
     add_index :projects, :repo_url
   end

--- a/db/migrate/20160402164125_add_hardening.rb
+++ b/db/migrate/20160402164125_add_hardening.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddHardening < ActiveRecord::Migration
+class AddHardening < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :hardening_status, :string, default: '?'
     add_column :projects, :hardening_justification, :text

--- a/db/migrate/20160404172439_add_tls_criteria.rb
+++ b/db/migrate/20160404172439_add_tls_criteria.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddTlsCriteria < ActiveRecord::Migration
+class AddTlsCriteria < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :crypto_used_network_status, :string, default: '?'
     add_column :projects, :crypto_used_network_justification, :text

--- a/db/migrate/20160405012958_add_hardened_site.rb
+++ b/db/migrate/20160405012958_add_hardened_site.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddHardenedSite < ActiveRecord::Migration
+class AddHardenedSite < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :hardened_site_status, :string, default: '?'
     add_column :projects, :hardened_site_justification, :text

--- a/db/migrate/20160405014948_add_installation_common.rb
+++ b/db/migrate/20160405014948_add_installation_common.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddInstallationCommon < ActiveRecord::Migration
+class AddInstallationCommon < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :installation_common_status, :string, default: '?'
     add_column :projects, :installation_common_justification, :text

--- a/db/migrate/20160405021824_add_build_reproducible.rb
+++ b/db/migrate/20160405021824_add_build_reproducible.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddBuildReproducible < ActiveRecord::Migration
+class AddBuildReproducible < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :build_reproducible_status, :string, default: '?'
     add_column :projects, :build_reproducible_justification, :text

--- a/db/migrate/20160408151639_rename_project_homepage_https_to_project_sites_https.rb
+++ b/db/migrate/20160408151639_rename_project_homepage_https_to_project_sites_https.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RenameProjectHomepageHttpsToProjectSitesHttps < ActiveRecord::Migration
+class RenameProjectHomepageHttpsToProjectSitesHttps < ActiveRecord::Migration[4.2]
   def change
     rename_column :projects,
                   :project_homepage_https_status,

--- a/db/migrate/20160409184200_fill_project_sites_https.rb
+++ b/db/migrate/20160409184200_fill_project_sites_https.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class FillProjectSitesHttps < ActiveRecord::Migration
+class FillProjectSitesHttps < ActiveRecord::Migration[4.2]
   def change
     # Previous rename was misleading, change to follow conventions:
     rename_column :projects,

--- a/db/migrate/20160411134222_rename_project_prefix.rb
+++ b/db/migrate/20160411134222_rename_project_prefix.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RenameProjectPrefix < ActiveRecord::Migration
+class RenameProjectPrefix < ActiveRecord::Migration[4.2]
   def change
     rename_column :projects,
                   :project_sites_https_status,

--- a/db/migrate/20160501143232_add_badge_status_to_projects.rb
+++ b/db/migrate/20160501143232_add_badge_status_to_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddBadgeStatusToProjects < ActiveRecord::Migration
+class AddBadgeStatusToProjects < ActiveRecord::Migration[4.2]
   def up
     add_column :projects, :badge_status, :string
     add_index :projects, :badge_status

--- a/db/migrate/20160501224428_add_project_index.rb
+++ b/db/migrate/20160501224428_add_project_index.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddProjectIndex < ActiveRecord::Migration
+class AddProjectIndex < ActiveRecord::Migration[4.2]
   def change
     add_index :projects, :name
     add_index :projects, :homepage_url

--- a/db/migrate/20160503195329_add_stats_extension.rb
+++ b/db/migrate/20160503195329_add_stats_extension.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddStatsExtension < ActiveRecord::Migration
+class AddStatsExtension < ActiveRecord::Migration[4.2]
   def change
     enable_extension 'pg_stat_statements'
   end

--- a/db/migrate/20160511222530_add_index_updated_at.rb
+++ b/db/migrate/20160511222530_add_index_updated_at.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddIndexUpdatedAt < ActiveRecord::Migration
+class AddIndexUpdatedAt < ActiveRecord::Migration[4.2]
   def change
     add_index :projects, :updated_at
   end

--- a/db/migrate/20160513111843_badge_status_to_percentage.rb
+++ b/db/migrate/20160513111843_badge_status_to_percentage.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class BadgeStatusToPercentage < ActiveRecord::Migration
+class BadgeStatusToPercentage < ActiveRecord::Migration[4.2]
   def up
     rename_column :projects, :badge_status, :badge_percentage
     Project.find_each do |project|

--- a/db/migrate/20160519214417_create_project_stats.rb
+++ b/db/migrate/20160519214417_create_project_stats.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateProjectStats < ActiveRecord::Migration
+class CreateProjectStats < ActiveRecord::Migration[4.2]
   def change
     create_table :project_stats do |t|
       # The data columns can't be null.  This forces the data to be cleaner,

--- a/db/migrate/20160810204829_add_transition_datetimes.rb
+++ b/db/migrate/20160810204829_add_transition_datetimes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTransitionDatetimes < ActiveRecord::Migration
+class AddTransitionDatetimes < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :achieved_passing_at, :datetime
     add_column :projects, :lost_passing_at, :datetime

--- a/db/migrate/20160819204955_create_pg_search_documents.rb
+++ b/db/migrate/20160819204955_create_pg_search_documents.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreatePgSearchDocuments < ActiveRecord::Migration
+class CreatePgSearchDocuments < ActiveRecord::Migration[4.2]
   def self.up
     say_with_time('Creating table for pg_search multisearch') do
       create_table :pg_search_documents do |t|

--- a/db/migrate/20160823211834_index_achieved_passing_at_to_projects.rb
+++ b/db/migrate/20160823211834_index_achieved_passing_at_to_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class IndexAchievedPassingAtToProjects < ActiveRecord::Migration
+class IndexAchievedPassingAtToProjects < ActiveRecord::Migration[4.2]
   def change
     add_index :projects, :achieved_passing_at
   end

--- a/db/migrate/20160902221520_reminders.rb
+++ b/db/migrate/20160902221520_reminders.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Add fields to support sending reminders to inactive badging projects.
-class Reminders < ActiveRecord::Migration
+class Reminders < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :last_reminder_at, :datetime
     add_index :projects, :last_reminder_at

--- a/db/migrate/20160908201830_add_stats.rb
+++ b/db/migrate/20160908201830_add_stats.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddStats < ActiveRecord::Migration
+class AddStats < ActiveRecord::Migration[4.2]
   def change
     # Number of reminders sent within 24 hours
     add_column :project_stats, :reminders_sent, :integer,

--- a/db/migrate/20160911193415_add_updating_metrics.rb
+++ b/db/migrate/20160911193415_add_updating_metrics.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddUpdatingMetrics < ActiveRecord::Migration
+class AddUpdatingMetrics < ActiveRecord::Migration[4.2]
   def change
     # Add metrics recording project counts where created_at < updated_at.
     # A lot of projects get started and don't edit later - we'd like to

--- a/db/migrate/20161102170815_change_email_column_type.rb
+++ b/db/migrate/20161102170815_change_email_column_type.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class ChangeEmailColumnType < ActiveRecord::Migration
+class ChangeEmailColumnType < ActiveRecord::Migration[4.2]
   # Change user email to citext this is not reversible so must use
   # up/down instead of change.
   def up

--- a/db/migrate/20161229185811_add_implementation_languages.rb
+++ b/db/migrate/20161229185811_add_implementation_languages.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddImplementationLanguages < ActiveRecord::Migration
+class AddImplementationLanguages < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :implementation_languages, :string, default: ''
   end

--- a/db/migrate/20161230160523_add_lock_version_to_projects.rb
+++ b/db/migrate/20161230160523_add_lock_version_to_projects.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddLockVersionToProjects < ActiveRecord::Migration
+class AddLockVersionToProjects < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :lock_version, :integer, default: 0
   end


### PR DESCRIPTION
In newer versions of Rails, trying to load migrations without version
information reports the error "Directly inheriting from ActiveRecord::Migration
is not supported. Please specify the Rails release the migration was written for".

This commit adds version information so migrations can be re-run from scratch.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>