### PR TITLE
Fix caching in status_chooser; fixes #885

### DIFF
--- a/app/views/projects/_status_chooser.html.erb
+++ b/app/views/projects/_status_chooser.html.erb
@@ -3,8 +3,8 @@
  project_criterion_status = project[status_symbol]
  criterion_result = project.get_criterion_result(criterion)
 
- cache ['buttons', criterion.to_s, criteria_level, is_disabled, locale,
-        project_criterion_status ] do
+ cache ['buttons', criterion.to_s, criteria_level, criterion_result,
+        is_disabled, locale, project_criterion_status ] do
    passing_class = if (criterion_result == :criterion_passing && is_disabled)
                      ' criterion-passing'
                    else


### PR DESCRIPTION
The "buttons" cache in _status_chooser was no longer  storing
any information on the criterion_result (which is influenced by
the justification text).  This was causing the result_symbol
for various projects to display incorrectly.

This is hard to set up a regression test for, so I have not
made one.  We could perhaps make a long feature test where
we change a criterion's justification text, save and compare
with expected results.

Signed-off-by: Jason Dossett <jdossett@utdallas.edu>