### PR TITLE
Sort locales alphabetically for English

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -17,7 +17,7 @@
 # :de, :"en-au-ocker", :"en-NZ", :"zh-TW", :"pt-BR", :nep, :uk, :ro, :da,
 # :hu, :cs]
 
-I18n.available_locales = %i[en fr zh-CN de ja ru]
+I18n.available_locales = %i[zh-CN en fr de ja ru]
 
 # If we don't have text, fall back to English.  That obviously isn't
 # ideal, but it's better to show *some* text to the user than leave it


### PR DESCRIPTION
We need to pick one sort order for locales. I could see the argument for English-first, but there's no reason why Chinese should go after French. This sorts alphabetically in English (so Chinese comes before English).

Signed-off-by: Dan Kohn <dan@dankohn.com>