### PR TITLE
Add user interface for editing project additional rights. Fixes #93

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -91,9 +91,8 @@ module SessionsHelper
   end
 
   # Returns true iff the current_user can *control* the @project.
-  # This includes the right to delete & change users who can edit,
-  # in addition to being able to edit the project.
-  # Only the project badge entry owner or admins *control* the project entry.
+  # This includes the right to delete the entry & to remove users who can edit.
+  # Only the project badge entry owner and admins *control* the project entry.
   def can_control?
     return false if current_user.nil?
     return true if current_user.admin?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -29,7 +29,7 @@ class Project < ApplicationRecord
   PROJECT_OTHER_FIELDS = %i[
     name description homepage_url repo_url cpe implementation_languages
     license general_comments user_id disabled_reminders lock_version
-    level
+    level additional_rights_changes
   ].freeze
   ALL_CRITERIA_STATUS = Criteria.all.map(&:status).freeze
   ALL_CRITERIA_JUSTIFICATION = Criteria.all.map(&:justification).freeze
@@ -182,6 +182,16 @@ class Project < ApplicationRecord
                 length: { maximum: MAX_TEXT_LENGTH },
                 text: true
     end
+  end
+
+  # Return a string representing the additional rights on this project.
+  # Currently it's just a (possibly empty) list of user ids from
+  # AdditionalRight.  If AdditionalRights gains different kinds of rights
+  # (e.g., to spec additional owners), this method will need to be tweaked.
+  def additional_rights_to_s
+    # "distinct" shouldn't be needed; it's purely defensive here
+    list = AdditionalRight.where(project_id: id).distinct.pluck(:user_id)
+    list.sort.to_s # Use list.sort.to_s[1..-2] to remove surrounding [ and ]
   end
 
   # Return string representing badge level; assumes badge_percentage correct.

--- a/app/views/projects/_form_0.html.erb
+++ b/app/views/projects/_form_0.html.erb
@@ -285,6 +285,28 @@
       </div>
       </div>
 
+      <div class="row">
+      <div class="col-xs-12">
+        <%= t 'projects.form_basics.additional_rights_changes.description',
+              current_rights: project.additional_rights_to_s %>
+        <%= render(partial: "details", locals: {
+          criterion: "additional_rights_changes",
+          details:
+            t('projects.form_basics.additional_rights_changes.details_html') })
+        %>
+        <% unless is_disabled %>
+        <%# text_field_tag isn't flexible enough, so create this directly.
+            The client-side pattern here prevents some mistakes,
+            but since it's client-side we don't depend on it for security. %>
+          <input type="text" name="additional_rights_changes"
+                 id="additional_rights_changes" class="form-control"
+                 value="" spellcheck="false"
+                 pattern="^(| *[+-] *(\d+( *, *\d+)*)+)$"
+                 placeholder="<%= t('projects.form_basics.additional_rights_changes.placeholder')%>">
+        <% end # is_disabled %>
+      </div>
+      </div>
+
       <br><br>
       <%= f.label :general_comments,
                   t('projects.misc.general_comments.description') %><br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -474,6 +474,30 @@ en:
         placeholder: >
           Implementation language(s) used as a comma-separated list,
           sorted by amount of use
+      additional_rights_changes:
+        description: >
+          (Advanced) What other users have additional
+          rights to edit this badge entry? Currently: %{current_rights}
+        details_html: >
+          Most projects should ignore this field.
+          Project badge entries can always be edited by the badge entry owner
+          (creator),
+          BadgeApp administrators, and anyone who can commit to the GitHub
+          repository (if it's on GitHub).  If you want someone else to be
+          able to edit this badge entry, and you already have edit rights
+          to this project badge entry, you can additional users with edit rights.
+          Just enter "+" followed by a comma-separated list of integer user ids.
+          Those users will then also be allowed to edit this project entry.
+          If you're the owner of the badge entry or a BadgeApp administrator,
+          you can remove users from this list by entering "-" followed by a
+          comma-separated list of integer user ids.
+          This application uses optimistic locking
+          to prevent saving stale data if multiple users
+          try to edit simultaneously.
+          Only owners of this project entry and BadgeApp administrators
+          can change this field.
+        placeholder: >
+          Change using + or - followed by a comma-separated user id list
       cpe:
         description_html: >
           What is the


### PR DESCRIPTION
This adds a user interface so that users can allow *additional*
other users to edit project entries, beyond those already allowed
(owner, BadgeApp admins, and those who can edit that GitHub repo where
that applies).

We expect that in nearly all projects this functionality
will not be used, but that when it's needed it's important.
We've contemplated this functionality for a while,
but most projects haven't asked for it.  However, the PostgreSQL project
informed us that this functionality was important to them, and that
created a clear situation where there *was* a need.
Since this is a rare but important need, this commit implements
a minimal UI that "gets the job done".

The authorization rules implemented here are straightforward:
* If you control a project (are the owner or a BadgeApp admin), you can
  remove users from the additional_rights list.
* If you can edit a project, you can add other users to the project
  with additional rights.  You can edit a project if you control that project
  *or* are on that project's additional_rights list of users.
  This means that people can add their friends without trouble, but
  the owner of the badge entry can remove everyone else if there's a problem.

This version has separate "add" and "remove" subcommands, instead of
simply setting the value to a list (as an earlier version did).
There are two reasons for this:
1. It avoids race conditions.
2. Removing users seems more privileged than adding them, so this
   approach makes it easy to be more stringent on who can remove users.

We could have only allowed adding or removing a single user at a time,
but it's not much harder to support a list.  Since lists can be useful,
we support lists.

The tests specifically include a security check: a users on the
additional_rights list cannot remove people from the list.
In the future we may allow people to remove themselves, but for now
that seems unnecessary; the owner or a BadgeApp admin can remove people.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>