### PR TITLE
Delete monkey patch initializer

### DIFF
--- a/config/initializers/monkey_patches.rb
+++ b/config/initializers/monkey_patches.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-# Copyright 2015-2017, the Linux Foundation, IDA, and the
-# CII Best Practices badge contributors
-# SPDX-License-Identifier: MIT
-
-Dir[Rails.root.join('lib', 'ext', '**', '*.rb')].each { |file| require file }


### PR DESCRIPTION
Signed-off-by: Dan Kohn <dan@dankohn.com>

As discussed, concerns are a good substitute for monkey patches and we can add this back in the future if we need it.