### PR TITLE
Omit less-useful statistics for non-admins

### DIFF
--- a/app/views/project_stats/index.html.erb
+++ b/app/views/project_stats/index.html.erb
@@ -8,7 +8,8 @@
   Rails.cache.delete ActiveSupport::Cache.expand_cache_key(
     ['project_stats', locale, ProjectStat.all.size-1]
   )
-  cache ['project_stats', locale, ProjectStat.all.size] do
+  cache ['project_stats', locale, ProjectStat.all.size,
+         !!current_user&.admin? ] do
 %>
 
 <p id="notice"><%= notice %></p>
@@ -60,6 +61,7 @@
   line_chart dataset, library: date_chart_options, defer: true
 %>
 
+<% if current_user&.admin? %>
 <br><br><br>
 
 <h2><%= t '.projects_silver' %></h2>
@@ -128,9 +130,9 @@
   # Done transforming data; display it.
   line_chart dataset, library: date_chart_options, defer: true
 %>
+<% end # if current_user&.admin? %>
 
 <br><br><br>
-
 
 <h2><%= t '.projects_activity_30' %></h2>
 <%=


### PR DESCRIPTION
Some of the new project_stats are probably less useful right now,
so only bother showing them to admins.   This makes loading
project_stats faster for typical users and guests.
The data is made available to the public via JSON,
so no data is lost & anyone can recreate these graphics if they want to.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>