### PR TITLE
Translate reminder emails (fixes #932)

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,4 +1,9 @@
+<!DOCTYPE html>
 <html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+    <meta name=viewport content="width=device-width, initial-scale=1">
+  </head>
   <body>
     <%= yield %>
   </body>

--- a/app/views/report_mailer/email_new_project_owner.html.erb
+++ b/app/views/report_mailer/email_new_project_owner.html.erb
@@ -1,10 +1,3 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-    <meta name=viewport content="width=device-width, initial-scale=1">
-  </head>
-<body>
 <h1><%= t 'report_mailer.new_project_heading' %></h1>
 <p>
 <%= t 'report_mailer.new_project_part1' %>
@@ -20,5 +13,3 @@
 <p>
 <%= t 'report_mailer.ending' %>
 </p>
-</body>
-</html>

--- a/app/views/report_mailer/email_reminder_owner.html.erb
+++ b/app/views/report_mailer/email_reminder_owner.html.erb
@@ -5,52 +5,11 @@
     <meta name=viewport content="width=device-width, initial-scale=1">
   </head>
   <body>
-<h1>Automated Best Practices Badge Reminder for <%= @project.name %></h1>
-<p>
-This is an automated reminder that your project
-"<%= @project.name %>"
-does not currently have a "best practices" badge,
-and its badge entry has not been updated in a while.
-</p>
-
-<p>
-Your best practices badge entry is at
-<a href="<%= @project_info_url %>"><%= @project_info_url %></a>
-and was last updated on <%= @project.updated_at %>.
-It is currently at <%= @project.badge_percentage_0 %>% (out of 100%).
-</p>
-
-<p>
-We encourage you to keep making progress.
-Please visit your badge entry at
-<a href="<%= @project_info_url %>"><%= @project_info_url %></a>
-to complete the information and get your badge!
-</p>
-
-<p>
-If you want to see <em>only</em> what you're missing, visit your badge entry,
-select the button near the top labelled "Expand all panels", and
-then select the button near the top labelled "Hide met or N/A criteria".
-If you have questions, or need help, please contact
-<a href="mailto:&#99;ii&#45;badges&#45;questions&#45;own&#101;r&#64;lists&#46;coreinfrastructure&#46;or&#103;">&#99;ii&#45;badges&#45;questions&#45;own&#101;r&#64;lists&#46;coreinfrastructure&#46;or&#103;</a>
-or file an issue at
-<a href="https://github.com/coreinfrastructure/best-practices-badge/issues">https://github.com/coreinfrastructure/best-practices-badge/issues</a>
-(click on "new issue").
-</p>
-
-<p>
-We don't send reminders if you continue to update your badge entry,
-and we only send reminders approximately every 30-60 days.  However,
-if you want to disable these reminder messages, edit your badge entry at
-<a href="<%= @project_info_url %>"><%= @project_info_url %></a>
-to turn on "disable inactivity reminder".
-We hope you'll instead keep working at it
-and eventually earn the badge.
-</p>
-
-<p>
-Thank you for your time.
-</p>
+<%= t 'report_mailer.reminder_body_html',
+      project_name: @project.name,
+      project_info_url: @project_info_url,
+      project_updated_at: @project.updated_at,
+      project_badge_percentage_0: @project.badge_percentage_0 %>
 
 <p>
 <%= t 'report_mailer.ending' %>

--- a/app/views/report_mailer/email_reminder_owner.html.erb
+++ b/app/views/report_mailer/email_reminder_owner.html.erb
@@ -1,10 +1,3 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-    <meta name=viewport content="width=device-width, initial-scale=1">
-  </head>
-  <body>
 <%= t 'report_mailer.reminder_body_html',
       project_name: @project.name,
       project_info_url: @project_info_url,
@@ -14,5 +7,3 @@
 <p>
 <%= t 'report_mailer.ending' %>
 </p>
-  </body>
-</html>

--- a/app/views/report_mailer/email_reminder_owner.text.erb
+++ b/app/views/report_mailer/email_reminder_owner.text.erb
@@ -1,35 +1,7 @@
-This is an automated reminder that your project
-"<%= @project.name %>"
-does not currently have a "best practices" badge,
-and its badge entry has not been updated in a while.
-
-Your best practices badge entry is at
-<%= @project_info_url %>
-and was last updated on <%= @project.updated_at %>.
-It is currently at <%= @project.badge_percentage_0 %>% (out of 100%).
-
-We encourage you to keep making progress.
-Please visit your badge entry at
-<%= @project_info_url %>
-to complete the information and get your badge!
-
-If you want to see only what you're missing, visit your badge entry,
-select the button near the top labelled "Expand all panels", and
-then select the button near the top labelled "Hide met or N/A criteria".
-If you have questions, or need help, please contact
-cii-badges-questions-owner@lists.coreinfrastructure.org
-or file an issue at
-https://github.com/coreinfrastructure/best-practices-badge/issues
-(click on "new issue").
-
-We don't send reminders if you continue to update your badge entry,
-and we only send reminders approximately every 30-60 days.  However,
-if you want to disable these reminder messages, edit your badge entry at
-<%= @project_info_url %>
-to turn on "disable inactivity reminder".
-We hope you'll instead keep working at it
-and eventually earn the badge.
-
-Thank you for your time.
+<%= t 'report_mailer.reminder_body_text',
+      project_name: @project.name,
+      project_info_url: @project_info_url,
+      project_updated_at: @project.updated_at,
+      project_badge_percentage_0: @project.badge_percentage_0 %>
 
 <%= t 'report_mailer.ending' %>

--- a/app/views/report_mailer/project_status_change.html.erb
+++ b/app/views/report_mailer/project_status_change.html.erb
@@ -1,10 +1,3 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-    <meta name=viewport content="width=device-width, initial-scale=1">
-  </head>
-  <body>
     <h1>Project status change in project <%= @project.id %></h1>
     <p>
       Project <%= @project.id %> named <%= @project.name %>
@@ -17,5 +10,3 @@
       See <a href="<%= @project_info_url %>"><%= @project_info_url %></a>
       for more.
     </p>
-  </body>
-</html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -625,7 +625,7 @@ en:
       <p>
       Your best practices badge entry is at
       <a href="%{project_info_url}">%{project_info_url}</a>
-      and was last updated on %{project_updated_at%}.
+      and was last updated on %{project_updated_at}.
       It is currently at %{project_badge_percentage_0}% (out of 100%).
       </p>
 
@@ -662,7 +662,7 @@ en:
       </p>
     reminder_body_text: |-
       This is an automated reminder that your project
-      "%{project.name}"
+      "%{project_name}"
       does not currently have a "best practices" badge,
       and its badge entry has not been updated in a while.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -613,6 +613,87 @@ en:
       https://github.com/coreinfrastructure/best-practices-badge/issues
       (click on "new issue").
       Thank you for your time.
+    reminder_body_html: |-
+      <h1>Automated Best Practices Badge Reminder for %{project_name}</h1>
+      <p>
+      This is an automated reminder that your project
+      "%{project_name}"
+      does not currently have a "best practices" badge,
+      and its badge entry has not been updated in a while.
+      </p>
+
+      <p>
+      Your best practices badge entry is at
+      <a href="%{project_info_url}">%{project_info_url}</a>
+      and was last updated on %{project_updated_at%}.
+      It is currently at %{project_badge_percentage_0}% (out of 100%).
+      </p>
+
+      <p>
+      We encourage you to keep making progress.
+      Please visit your badge entry at
+      <a href="%{project_info_url}">%{project_info_url}</a>
+      to complete the information and get your badge!
+      </p>
+
+      <p>
+      If you want to see <em>only</em> what you're missing, visit your badge entry,
+      select the button near the top labelled "Expand all panels", and
+      then select the button near the top labelled "Hide met or N/A criteria".
+      If you have questions, or need help, please contact
+      <a href="mailto:&#99;ii&#45;badges&#45;questions&#45;own&#101;r&#64;lists&#46;coreinfrastructure&#46;or&#103;">&#99;ii&#45;badges&#45;questions&#45;own&#101;r&#64;lists&#46;coreinfrastructure&#46;or&#103;</a>
+      or file an issue at
+      <a href="https://github.com/coreinfrastructure/best-practices-badge/issues">https://github.com/coreinfrastructure/best-practices-badge/issues</a>
+      (click on "new issue").
+      </p>
+
+      <p>
+      We don't send reminders if you continue to update your badge entry,
+      and we only send reminders approximately every 30-60 days.  However,
+      if you want to disable these reminder messages, edit your badge entry at
+      <a href="%{project_info_url}">%{project_info_url}</a>
+      to turn on "disable inactivity reminder".
+      We hope you'll instead keep working at it
+      and eventually earn the badge.
+      </p>
+
+      <p>
+      Thank you for your time.
+      </p>
+    reminder_body_text: |-
+      This is an automated reminder that your project
+      "%{project.name}"
+      does not currently have a "best practices" badge,
+      and its badge entry has not been updated in a while.
+
+      Your best practices badge entry is at
+      %{project_info_url}
+      and was last updated on %{project_updated_at}
+      It is currently at %{project_badge_percentage_0}% (out of 100%).
+
+      We encourage you to keep making progress.
+      Please visit your badge entry at
+      %{project_info_url}
+      to complete the information and get your badge!
+
+      If you want to see only what you're missing, visit your badge entry,
+      select the button near the top labelled "Expand all panels", and
+      then select the button near the top labelled "Hide met or N/A criteria".
+      If you have questions, or need help, please contact
+      cii-badges-questions-owner@lists.coreinfrastructure.org
+      or file an issue at
+      https://github.com/coreinfrastructure/best-practices-badge/issues
+      (click on "new issue").
+
+      We don't send reminders if you continue to update your badge entry,
+      and we only send reminders approximately every 30-60 days.  However,
+      if you want to disable these reminder messages, edit your badge entry at
+      %{project_info_url}
+      to turn on "disable inactivity reminder".
+      We hope you'll instead keep working at it
+      and eventually earn the badge.
+
+      Thank you for your time.
     gained_level_part1: |-
       Congratulations!
       According to the information that you've provided,


### PR DESCRIPTION
Reminder emails were originally being only sent in English.
Add the reminder text to config/locales, and send the *translated* text.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>