### PR TITLE
Fix "remember me" local user functionality, fixes #937

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -48,7 +48,9 @@ module SessionsHelper
     elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
       if user&.authenticated?(:remember, cookies[:remember_token])
+        # Automatically re-log back in, and set timestamp
         log_in user
+        persist_session_timestamp
         @current_user = user
       end
     end

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -14,6 +14,7 @@ class SessionsHelperTest < ActionView::TestCase
 
   test 'current_user returns right user when session is nil' do
     assert_equal @user, current_user
+    assert_not session[:time_last_used].nil?
     assert user_logged_in?
   end
 


### PR DESCRIPTION
The "remember me" functionality wasn't working
(when enabled this adds a *persistent* cookie, so that
closing the browser leaves you logged in).
This fixes the bug and the test to match.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>