### PR TITLE
Show additional rights and admin privilege in user page. Fixes #915

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -392,8 +392,8 @@ class ProjectsController < ApplicationController
   # rubocop:enable Style/MethodCalledOnDoEndBlock
 
   HTML_INDEX_FIELDS = 'projects.id, projects.name, description, ' \
-    'homepage_url, repo_url, license, user_id, achieved_passing_at, ' \
-    'updated_at, badge_percentage_0'
+    'homepage_url, repo_url, license, projects.user_id, ' \
+    'achieved_passing_at, projects.updated_at, badge_percentage_0'
 
   # rubocop:disable Metrics/PerceivedComplexity
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,17 +16,26 @@
      </section>
    </aside>
   <div class="col-md-12">
+
   <% if @user.projects.any? %>
-  <br><br>
+    <br><br>
+    <h2><%= t '.projects_owned' %></h2>
     <%= render 'projects/table', projects: @projects %>
     <%= will_paginate @projects %>
   <% end %>
 
+  <% if @projects_additional_rights.present? %>
+    <br>
+    <h2><%= t '.projects_additional_rights' %></h2>
+    <br>
+    <%= render 'projects/table', projects: @projects_additional_rights %>
+  <% end %>
+
   <% if @edit_projects.present? %>
-  <br>
-  <h2><%= t '.other_projects_edit' %></h2>
-  <br>
-   <%= render 'projects/table', projects: @edit_projects %>
+    <br>
+    <h2><%= t '.other_projects_edit' %></h2>
+    <br>
+    <%= render 'projects/table', projects: @edit_projects %>
   <% end %>
 
   <% if @user.provider == 'github' && @user.nickname? %>
@@ -41,6 +50,11 @@
       <a href="mailto:<%= CGI::escape(@user.email).html_safe %>"><%=
         t('.send_email_to') + @user.email.to_s %></a> |
     <% end %>
+
+    <% if @user.admin? %>
+      <p><%= t '.is_admin' %></p>
+    <% end %>
+
     <%= link_to t('.delete_link_name'), @user, method: :delete,
                 data: { confirm: t('.confirm_delete') } %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -167,8 +167,11 @@ en:
       profile_updated: Profile updated
     show:
       edit_user: Edit user
-      other_projects_edit: Other Projects you can edit
+      projects_owned: 'Projects owned:'
+      projects_additional_rights: 'Projects with additional rights:'
+      other_projects_edit: 'Other editable projects per GitHub:'
       see_external: See this user's external page.
+      is_admin: This user is a badge application administrator.
       as_admin: 'as an admin, you may also:'
       send_email_to: 'send email to:'
       delete_link_name: delete

--- a/doc/security.md
+++ b/doc/security.md
@@ -1214,6 +1214,13 @@ and how it helps make the software more secure:
     - a user page does not display its email address when the user is
       either (1) not logged in or (2) is logged in but not as an admin.
       (see "test/controllers/users_controller_test.rb")
+    - a user page does not display if the user is an admin if
+      the user isn't logged in, or is logged in as a non-admin user
+      (see "test/controllers/users_controller_test.rb").
+      This makes it slightly harder for attackers to figure out
+      the individuals to target (they have additional privileges), while
+      still allowing *administrators* to easily see if a user has
+      administrator privileges.
 * The software has a strong test suite; our policy requires
   at least 90% statement coverage.
   In practice our coverage is much higher, indeed it has been 100%

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -26,6 +26,63 @@ class UsersControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'should show additional rights on user page when present' do
+    project = projects(:one)
+
+    get :show, params: { id: @other_user }
+    assert_response :success
+    refute_includes @response.body, project.name
+    refute_includes @response.body,
+                    I18n.t('users.show.projects_additional_rights')
+
+    # Create additional rights during test, not as a fixture.
+    # The fixture would require correct references to *other* fixture ids.
+    new_right = AdditionalRight.new(
+      user_id: @other_user.id,
+      project_id: project.id
+    )
+    new_right.save!
+
+    get :show, params: { id: @other_user }
+    assert_response :success
+    assert_includes @response.body, project.name
+    assert_includes @response.body,
+                    I18n.t('users.show.projects_additional_rights')
+  end
+
+  test 'indicate admin is admin to admin' do
+    log_in_as(@admin)
+    get :show, params: { id: @admin }
+    assert_response :success
+    assert I18n.t('users.show.is_admin').present?
+    assert_includes @response.body,
+                    I18n.t('users.show.is_admin')
+  end
+
+  test 'do NOT indicate non-admin is admin to admin' do
+    log_in_as(@admin)
+    get :show, params: { id: @user }
+    assert_response :success
+    refute_includes @response.body,
+                    I18n.t('users.show.is_admin')
+  end
+
+  test 'do NOT indicate admin is admin to non-admin' do
+    log_in_as(@user)
+    get :show, params: { id: @admin }
+    assert_response :success
+    refute_includes @response.body,
+                    I18n.t('users.show.is_admin')
+  end
+
+  test 'do NOT indicate admin is admin if not logged in' do
+    # No log_in_as
+    get :show, params: { id: @admin }
+    assert_response :success
+    refute_includes @response.body,
+                    I18n.t('users.show.is_admin')
+  end
+
   test 'should NOT show email address when not logged in' do
     get :show, params: { id: @user }
     assert_response :success


### PR DESCRIPTION
On the user page show the user's "additional rights".
These determine the specific rights of
a user, but up to now have not been shown on the user page.
Show them, so that it's completely obvious what rights the user does
(and does not) have.

If you're a logged-in admin, also show on the user's page
if that user is an admin.  It's probably not hard to figure out
who at least some of the administrators are, but this is data
about *people* instead of system *design*.

Add tests, including a number of negative tests
to verify that this data is *only* shown to admins, and document
these negative tests in security.md (we expressly note that we do
negative tests, and this is another good example of this).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>