### PR TITLE
Add links on home page to easily share on social media. Fixes #927

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -16,7 +16,50 @@
 
       <p class="no-padding best-practices-main-text">
         <%= t('static_pages.home.p3_html') %>
-      </p>
+        <%= t('static_pages.home.share_header_html') %>
+        <%
+          # See https://jonsuh.com/blog/social-share-links/#use-share-urls
+          # Make URLs for Twitter Reddit Facebook LinkedIn Google+
+          twitter_url = 'https://twitter.com/intent/tweet/?' +
+            {
+              text: t('static_pages.home.check_us_out'),
+              url: request.original_url
+            }.to_param.html_safe
+          reddit_url =
+            'http://www.reddit.com/submit/?' +
+            { url: request.original_url }.to_param.html_safe
+          facebook_url =
+            'https://www.facebook.com/sharer/sharer.php?' +
+            { u: request.original_url }.to_param.html_safe
+          linkedin_url =
+            'https://www.linkedin.com/shareArticle?' +
+            {
+              mini: true,
+              url: request.original_url,
+              title: t('static_pages.home.check_us_out'),
+              source: request.original_url,
+              summary: t('static_pages.home.check_us_out')
+            }.to_param.html_safe
+          googleplus_url =
+            'https://plus.google.com/share?' +
+            { url: request.original_url }.to_param.html_safe
+        %>
+
+        <a href="<%= twitter_url %>" class="btn btn-primary btn-lg btn-main-margin"
+        target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.twitter') %></a>
+
+        <a href="<%= reddit_url %>" class="btn btn-primary btn-lg btn-main-margin"
+        target="_blank"><i class="fa fa-reddit-alien" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.reddit') %></a>
+
+        <a href="<%= facebook_url %>" class="btn btn-primary btn-lg btn-main-margin"
+        target="_blank"><i class="fa fa-facebook" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.facebook') %></a>
+
+        <a href="<%= linkedin_url %>" class="btn btn-primary btn-lg btn-main-margin"
+        target="_blank"><i class="fa fa-linkedin" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.linkedin') %></a>
+
+        <a href="<%= googleplus_url %>" class="btn btn-primary btn-lg btn-main-margin"
+        target="_blank"><i class="fa fa-google-plus" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.googleplus') %></a>
+
     </div>
     <div class="col-md-4 col-sm-5">
       <div class="home-badge pull-right"></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,7 @@ en:
     home:
       badge_program: CII Best Practices Badge Program
       get_your_badge: Get Your Badge Now!
+      check_us_out: Check out the CII Best Practices Badge website!
       p1_html: >-
         The <a href="https://www.linuxfoundation.org/">Linux Foundation
         (LF)</a> <a href="https://www.coreinfrastructure.org/">Core
@@ -107,13 +108,27 @@ en:
       p3_html: >-
         <em>Privacy and legal issues</em>: Please see our <a href="https://www.linuxfoundation.org/privacy">privacy
         policy</a> and <a href="https://www.linuxfoundation.org/terms">terms
-        of use</a>. All publicly-available non-code content is
+        of use</a>.
+        The code for the badging application itself is released under the
+        <a href="https://opensource.org/licenses/MIT">MIT</a> license
+        (projects pursuing a badge are under their respective licenses).
+        All publicly-available non-code content
+        managed by the badging application is
         released under at least the <a href="https://creativecommons.org/licenses/by/3.0/">Creative
         Commons Attribution License version 3.0 (CC-BY-3.0)</a>;
         newer non-code content is released under CC-BY version
         3.0 or later (CC-BY-3.0+). If referencing collectively
         or not otherwise noted, please credit the CII Best Practices
         badge contributors.
+      share_header_html: >-
+        <p>
+        Please share this:
+        </p>
+      twitter: Twitter
+      reddit: Reddit
+      facebook: Facebook
+      linkedin: LinkedIn
+      googleplus: Google+
     criteria:
       criteria: Criteria
       detailed_criteria_on_github: The detailed criteria are on


### PR DESCRIPTION
This commit modified the front page to add links (as buttons)
to easily share on various social media sites.

I have resisted adding social share links because of
potential privacy concerns, in addition to performance problems.
Sadly, traditional "like" buttons and similar are fundamentally
tracking devices.  We want to respect the privacy of our users, and
certainly do not want to scare off people from using our site.

However, the page "Responsible Social Share Links" provides a solution:
https://jonsuh.com/blog/social-share-links/#use-share-urls
That page describes how to add share links *without* privacy
concerns. If you don't press the link (button), nothing is tracked.

Now people can share when they *want* to do so, without being tracked
by other services when they don't choose to share.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>