### PR TITLE
Add info about cookies to comply with EU and UK "cookie laws". Fixes #938

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -32,7 +32,8 @@
       <%= f.label :remember_me, t('sessions.remember_me'),
                   class: "checkbox inline" do %>
         <%= f.check_box :remember_me %>
-        <span><%= t('sessions.remember_me') %></span>
+        <span><%= t('sessions.remember_me') %>
+              <%= t('sessions.cookie_details_html') %></span>
       <% end %>
 
       <%= f.hidden_field :provider, value: "local" %>

--- a/app/views/static_pages/cookies.html.erb
+++ b/app/views/static_pages/cookies.html.erb
@@ -1,0 +1,9 @@
+<% cache locale do %>
+<div class="row">
+<div class="col-md-12">
+  <h1 class="center"><%= t '.cookies_header' %></h1>
+  <p>
+  <%= t '.cookies_info_html' %>
+  </p>
+</div></div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,7 +66,9 @@ en:
     email: Email
     password: Password
     forgot_password: Forgot your password?
-    remember_me: Remember me
+    remember_me: Keep me logged in (using a permanent cookie)
+    cookie_details_html: >
+      <a href="/cookies" target="_blank"><i>Learn more about cookies.</i></a>
     login_custom: Log in using custom account
     no_custom: No custom account? Sign up now!
     already_logged_in: You are already logged in.
@@ -114,6 +116,55 @@ en:
         3.0 or later (CC-BY-3.0+). If referencing collectively
         or not otherwise noted, please credit the CII Best Practices
         badge contributors.
+    cookies:
+      cookies_header: About Cookies
+      cookies_info_html: >
+        <p>
+        To make this site work properly, we sometimes place small data files
+        called cookies on your device. Many websites do this.
+        </p>
+        <p>
+        A cookie is a small text file that a website saves on your
+        computer (including your mobile device) when you visit the site.
+        It enables the website to remember your actions and preferences
+        (such as login, language, font size and other display preferences)
+        over a period of time, so you don’t have to keep re-entering
+        them whenever you come back to the site or browse from one page
+        to another.
+        Cookies are a standard part of the HTTP protocol that implements
+        the World Wide Web (WWW), and are specified in
+        <a href="https://tools.ietf.org/html/rfc6265">RFC 6265</a>.
+        </p>
+        <p>
+        We use first-party "session" cookies whenever you log in.
+        By definition, session cookies are designed to expire
+        when you exit your browser or log off.
+        If you enable "Keep me logged in" (aka "Remember me"),
+        we also store information in a first-party "permanent" cookie on your
+        browser so that we can automatically log you back in when you
+        visit our site even after you exit your browser.
+        If you choose to use other sites (such as GitHub) for
+        authentication to this site, then that other site will probably
+        use cookies (and thus what they do with cookies will also apply).
+        Please note that we can't control what other sites do.
+        </p>
+        <p>
+        The cookies we set are only used to support capabilities
+        related to this site. Consent can be withdrawn - just
+        delete the cookies on your browser. You can control
+        and/or delete cookies as you wish.  For details, see <a
+        href="https://www.aboutcookies.org">cookies.org</a>.  You can
+        delete all cookies that are already on your computer and you can
+        set most browsers to prevent them from being placed. If you do
+        this, however, you may have to manually adjust some preferences
+        every time you visit a site and some services and functionalities
+        may not work.
+        In particular, logging into this site depends on session cookies
+        (on this and many other sites).
+        </p>
+        <p>
+        This text is intended to comply with UK and EU "Cookie laws".
+        </p>
     criteria:
       criteria: Criteria
       detailed_criteria_on_github: The detailed criteria are on

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     get 'signup' => 'users#new'
     get 'home' => 'static_pages#home'
     get 'criteria' => 'static_pages#criteria'
+    get 'cookies' => 'static_pages#cookies'
     get 'robots' => 'static_pages#robots', defaults: { format: 'text' }
 
     get 'feed' => 'projects#feed', defaults: { format: 'atom' }

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -13,6 +13,13 @@ class StaticPagesControllerTest < ActionController::TestCase
     assert_template 'home'
   end
 
+  test 'should get cookie page' do
+    get :cookies
+    assert_response :success
+    assert_includes @response.body, 'About Cookies'
+    assert_includes @response.body, 'small data files'
+  end
+
   test 'should get robots.txt' do
     get :robots, format: :text
     assert_response :success


### PR DESCRIPTION
The EU and UK have "cookie laws".
More information about the EU cookie laws, from a formal EU site, are here:

* [(EU) Information Providers Guide - Cookies](http://ec.europa.eu/ipg/basics/legal/cookies/index_en.htm)
* [ePrivacy directive, especially Article 5(3)](http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:32002L0058:EN:HTML)

It's not clear that these laws applies to the site:  I'm a US citizen,
this site is run in the US, and the primary organization running the
site (the Linux Foundation) is a US organization.  In addition,
[NoCookieLaw](http://nocookielaw.com/) has a valid point: these laws seem
to be completely pointless, since they doesn't actually provide any *real*
privacy (and ignore the *real* and serious privacy problems).

However, in our case, it looks like all we *need* to do is to add a
little text and connect it what was named "Remember Me" to
explain the basics of what it does.  That doesn't appear to be hard to do.

So instead of wondering if we really need to comply or not, we'll just
make an honest effort to comply, which is what this commit attempts to do.

The text is based on "cookie-notice-template.zip"
file "cookie-notice-template_en.doc", which additions that attempt
to explain the specific circumstance here.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>