### PR TITLE
Force "share" links to bottom of home page, regardless of width

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -16,63 +16,8 @@
 
       <p class="no-padding best-practices-main-text">
         <%= t('static_pages.home.p3_html') %>
-        <%= t('static_pages.home.share_header_html') %>
-        <%
-          # See https://jonsuh.com/blog/social-share-links/#use-share-urls
-          # Make URLs for Twitter Reddit Facebook LinkedIn Google+
-          twitter_url = 'https://twitter.com/intent/tweet/?' +
-            {
-              text: t('static_pages.home.check_us_out'),
-              url: request.original_url
-            }.to_param.html_safe
-          reddit_url =
-            'https://www.reddit.com/submit/?' +
-            { url: request.original_url }.to_param.html_safe
-          facebook_url =
-            'https://www.facebook.com/sharer/sharer.php?' +
-            { u: request.original_url }.to_param.html_safe
-          linkedin_url =
-            'https://www.linkedin.com/shareArticle?' +
-            {
-              mini: true,
-              url: request.original_url,
-              title: t('static_pages.home.check_us_out'),
-              source: request.original_url,
-              summary: t('static_pages.home.check_us_out')
-            }.to_param.html_safe
-          googleplus_url =
-            'https://plus.google.com/share?' +
-            { url: request.original_url }.to_param.html_safe
-          mailto_url =
-            'mailto:?' +
-            {
-              subject: t('static_pages.home.check_us_out') + ' ' +
-                       request.original_url,
-              body: t('static_pages.home.check_us_out') + "\n" +
-                       request.original_url
-            }.to_param.html_safe
-        %>
-
-        <a href="<%= twitter_url %>" class="btn btn-primary btn-lg btn-main-margin"
-        target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.twitter') %></a>
-
-        <a href="<%= reddit_url %>" class="btn btn-primary btn-lg btn-main-margin"
-        target="_blank"><i class="fa fa-reddit-alien" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.reddit') %></a>
-
-        <a href="<%= facebook_url %>" class="btn btn-primary btn-lg btn-main-margin"
-        target="_blank"><i class="fa fa-facebook" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.facebook') %></a>
-
-        <a href="<%= linkedin_url %>" class="btn btn-primary btn-lg btn-main-margin"
-        target="_blank"><i class="fa fa-linkedin" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.linkedin') %></a>
-
-        <a href="<%= googleplus_url %>" class="btn btn-primary btn-lg btn-main-margin"
-        target="_blank"><i class="fa fa-google-plus" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.googleplus') %></a>
-
-        <a href="<%= mailto_url %>" class="btn btn-primary btn-lg btn-main-margin"
-        target="_blank"><i class="fa fa-envelope" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.email') %></a>
-
-
-    </div>
+      </p>
+    </div><%# end of column with banner and main text %>
     <div class="col-md-4 col-sm-5">
       <div class="home-badge center-block"></div>
     <div class="row">
@@ -155,8 +100,69 @@
         <%= image_tag 'project-logos/ZAP.png', width: 48, height: 48,
                       alt: 'OWASP ZAP', title: 'OWASP ZAP' %></a>
       </div>
-    </div>
-    </div>
+    </div><%# end of logo row %>
+    </div><%# end of special column %>
+  </div><%# end of row with main text %>
+<div class="row"><%# begin row with sharing URLs %>
+  <div class="col-xs-12">
+      <p class="no-padding best-practices-main-text">
+        <%= t('static_pages.home.share_header_html') %>
+        <%
+          # See https://jonsuh.com/blog/social-share-links/#use-share-urls
+          # Make URLs for Twitter Reddit Facebook LinkedIn Google+
+          twitter_url = 'https://twitter.com/intent/tweet/?' +
+            {
+              text: t('static_pages.home.check_us_out'),
+              url: request.original_url
+            }.to_param.html_safe
+          reddit_url =
+            'https://www.reddit.com/submit/?' +
+            { url: request.original_url }.to_param.html_safe
+          facebook_url =
+            'https://www.facebook.com/sharer/sharer.php?' +
+            { u: request.original_url }.to_param.html_safe
+          linkedin_url =
+            'https://www.linkedin.com/shareArticle?' +
+            {
+              mini: true,
+              url: request.original_url,
+              title: t('static_pages.home.check_us_out'),
+              source: request.original_url,
+              summary: t('static_pages.home.check_us_out')
+            }.to_param.html_safe
+          googleplus_url =
+            'https://plus.google.com/share?' +
+            { url: request.original_url }.to_param.html_safe
+          mailto_url =
+            'mailto:?' +
+            {
+              subject: t('static_pages.home.check_us_out') + ' ' +
+                       request.original_url,
+              body: t('static_pages.home.check_us_out') + "\n" +
+                       request.original_url
+            }.to_param.html_safe
+        %>
+
+        <a href="<%= twitter_url %>" class="btn btn-primary btn-lg btn-main-margin"
+        target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.twitter') %></a>
+
+        <a href="<%= reddit_url %>" class="btn btn-primary btn-lg btn-main-margin"
+        target="_blank"><i class="fa fa-reddit-alien" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.reddit') %></a>
+
+        <a href="<%= facebook_url %>" class="btn btn-primary btn-lg btn-main-margin"
+        target="_blank"><i class="fa fa-facebook" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.facebook') %></a>
+
+        <a href="<%= linkedin_url %>" class="btn btn-primary btn-lg btn-main-margin"
+        target="_blank"><i class="fa fa-linkedin" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.linkedin') %></a>
+
+        <a href="<%= googleplus_url %>" class="btn btn-primary btn-lg btn-main-margin"
+        target="_blank"><i class="fa fa-google-plus" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.googleplus') %></a>
+
+        <a href="<%= mailto_url %>" class="btn btn-primary btn-lg btn-main-margin"
+        target="_blank"><i class="fa fa-envelope" aria-hidden="true"></i>&nbsp;<%= t('static_pages.home.email') %></a>
+
+
   </div>
+</div><%# end of "share this" row %>
   <br>
 <% end %>


### PR DESCRIPTION
It's conventional to have share links at the top or bottom of
the page, so they're easier to find - force them to be at the bottom.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>