### PR TITLE
Warn users if they are on a development site; Fixes #962

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -7,7 +7,7 @@
 # rubocop:disable Metrics/ModuleLength
 module SessionsHelper
   SESSION_TTL = 48.hours # Automatically log off session if inactive this long
-
+  PRODUCTION_HOSTNAME = 'bestpractices.coreinfrastructure.org'
   require 'uri'
 
   def remove_locale_query(url_query)
@@ -118,6 +118,12 @@ module SessionsHelper
     false
   end
   # rubocop:enable Metrics/CyclomaticComplexity
+
+  def in_development?
+    hostname = ENV['PUBLIC_HOSTNAME']
+    return true if hostname.nil?
+    hostname != PRODUCTION_HOSTNAME
+  end
 
   # Redirects to stored location (or to the default)
   def redirect_back_or(default)

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,5 +1,11 @@
 <% if logged_in? %>
   <div class="row">
+    <% if in_development? %>
+    <div class="alert alert-danger alert-dismissable text-center">
+      <a href="#" class="close" data-dismiss="alert" aria-label="<%= t('projects.misc.close') %>">&times;</a>
+      <%= t('projects.misc.in_development_warning_html') %>
+    </div>
+    <% end %>
     <div class="col-md-2 col-sm-3">
       <div class="main-badge-ques"></div>
     </div>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -12,6 +12,12 @@
 %>
 <% if logged_in? %>
   <div class='row'>
+    <% if in_development? %>
+      <div class="alert alert-danger alert-dismissable text-center">
+        <a href="#" class="close" data-dismiss="alert" aria-label="<%= t('projects.misc.close') %>">&times;</a>
+        <%= t('projects.misc.in_development_warning_html') %>
+      </div>
+    <% end %>
   <div class="col-md-12">
   <br>
   <h2 class='center'><%= t('.new_badge') %></h2>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -8,6 +8,12 @@
 <% end %>
 
 <div class="row">
+  <% if in_development? %>
+  <div class="alert alert-danger alert-dismissable text-center">
+    <a href="#" class="close" data-dismiss="alert" aria-label="<%= t('projects.misc.close') %>">&times;</a>
+    <%= t('projects.misc.in_development_warning_html') %>
+  </div>
+  <% end %>
   <div class="col-md-2 col-sm-3">
     <div class="main-badge-ques"></div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -637,6 +637,10 @@ en:
         found.'
       justification_required_warning: 'Warning: Requires lengthier
         justification.'
+      in_development_warning_html: >-
+        <strong>Warning!</strong> This is not the production system;
+        this is a test tier.
+      close: Close
     delete:
       done: Project was successfully deleted.
   report_mailer:

--- a/test/features/login_test.rb
+++ b/test/features/login_test.rb
@@ -63,6 +63,7 @@ class LoginTest < CapybaraFeatureTest
     assert_equal projects_path, current_path
 
     visit edit_project_path(@project, locale: nil)
+    assert has_content? 'This is not the production system'
     assert has_content? 'We have updated our requirements for the criterion ' \
                         '<a href="#static_analysis">static_analysis</a>. ' \
                         'Please add a justification for '\

--- a/test/integration/project_get_test.rb
+++ b/test/integration/project_get_test.rb
@@ -63,6 +63,8 @@ class ProjectGetTest < ActionDispatch::IntegrationTest
       '1; mode=block',
       @response.headers['X-XSS-Protection']
     )
+    # Check warning on development system
+    assert_match 'This is not the production system', response.body
   end
   # rubocop:enable Metrics/BlockLength
 end

--- a/test/integration/users_manipulate_project_test.rb
+++ b/test/integration/users_manipulate_project_test.rb
@@ -19,6 +19,7 @@ class UsersManipulateProjectTest < ActionDispatch::IntegrationTest
 
     get '/projects/new'
     assert_response :success
+    assert_match 'This is not the production system', response.body
     assert_template 'projects/new'
 
     repo_url = 'https://github.com/coreinfrastructure/best-practices-badge'


### PR DESCRIPTION
This displays an alert to users if they are not on the production
site.  This helps prevent users from entering information on the
wrong website which could be lost.

Signed-off-by: Jason Dossett <jdossett@utdallas.edu>