### PR TITLE
Move criteria to right of status chooser when there's room (fixes #862)

### DIFF
--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -138,7 +138,8 @@ label.required:after {
 }
 
 .criteria-radio {
-  padding-top: 5px;
+  // padding-top: 5px;
+  margin-top: -10px; // Compensate to ensure RHS text isn't too low
   padding-left: 20px;
 }
 

--- a/app/views/projects/_status_chooser.html.erb
+++ b/app/views/projects/_status_chooser.html.erb
@@ -15,7 +15,7 @@
     <% is_crypto = criterion.to_s.match(/^crypto_/)
        crypto_class = is_crypto ? ' criterion-is-crypto' : '' %>
 
-    <div class="col-md-3 col-sm-3 col-xs-4 criteria-radio<%= crypto_class %>">
+    <div class="col-md-3 col-sm-4 col-xs-4 criteria-radio<%= crypto_class %>">
       <div class="status-chooser">
       <%= f.form_group status_symbol do %>
         <%#
@@ -74,7 +74,7 @@
     </div>
   </div>
 <% end # cache 'buttons' %>
-  <div class='col-md-12 col-sm-12 col-xs-12 criteria-desc'>
+  <div class='col-md-9 col-sm-8 col-xs-12 criteria-desc'>
     <% cache ['desc', criterion.to_s, criteria_level, locale ] do
        # Here we provide the description, details, and markings like
        # "met_url_required?".  We cache this separately.
@@ -99,6 +99,10 @@
                        details: criterion.details.html_safe})
           end %>
     <% end # cache 'desc' %>
+
+    </div><%# end of existing column %>
+    <div class="col-xs-12"><%# new section for justification and rule %>
+
     <% justification_symbol = (criterion.to_s + '_justification').to_sym
        if (is_disabled)
          project_criterion_justification = project[justification_symbol]


### PR DESCRIPTION
When there's enough width, move the criteria text to the right of
the chooser.  The justification text continues to be below the
chooser, to maximize the amount of space available for long answers.

We originally moved the criteria text to a new line because the Russian text
was too long in the original format.  That solved one problem,
but created a new one.

As @KitsuneRal noted, "I have to say though that criteria take a lot
of vertical screen estate now that the radio group is displayed in
a separate div from the text and both are float: left. And since the
current representation doesn't map to the conventional "question-response"
arrangement, I already caught myself once mistakenly associating the radio
group with a criteria above, not below - though the (barely visible on
poorer monitors) separator line tries to mitigate that."

Now that the criteria text and the responses are on the same line
(on larger monitors), this confusion should disappear.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>