### PR TITLE
Add support for /projects/:id/badge.json and include badge_level in JSON

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -66,8 +66,9 @@ class ProjectsController < ApplicationController
   end
 
   BADGE_PROJECT_FIELDS =
-    'id, badge_percentage_0, badge_percentage_1, badge_percentage_2'
+    'id, updated_at, badge_percentage_0, badge_percentage_1, badge_percentage_2'
 
+  # rubocop:disable Metrics/MethodLength
   def badge
     # Don't use "set_project", but instead specifically find the project
     # ourselves.  That way, we can select *only* the fields we need
@@ -77,14 +78,18 @@ class ProjectsController < ApplicationController
     # Note: If the "find" fails this will raise an exception, which
     # will eventually lead (correctly) to a failure report.
     @project = Project.select(BADGE_PROJECT_FIELDS).find(params[:id])
-    set_surrogate_key_header @project.record_key + '/badge'
     respond_to do |format|
       format.svg do
+        set_surrogate_key_header @project.record_key + '/badge'
         send_data Badge[value_for_badge],
                   type: 'image/svg+xml', disposition: 'inline'
       end
+      format.json do
+        format.json { render :badge, status: :ok, location: @project }
+      end
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   # GET /projects/new
   def new

--- a/app/views/projects/_project.json.jbuilder
+++ b/app/views/projects/_project.json.jbuilder
@@ -3,6 +3,7 @@
 # Show project in JSON format.
 # This is a partial so "show" and "index" can share this.
 json.merge! project.attributes
+json.badge_level project.badge_level
 # rubocop:disable Rails/OutputSafety
 json.project_entry_attribution('Please credit '.html_safe +
                                project.user.name +

--- a/app/views/projects/badge.json.jbuilder
+++ b/app/views/projects/badge.json.jbuilder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# JSON data doesn't depend on locale
+json.cache! ['badge-json', @project], expires_in: 10.minutes do
+  json.id @project.id
+  json.updated_at @project.updated_at
+  json.badge_level @project.badge_level
+end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -131,6 +131,7 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_equal 'Pathfinder OS', body['name']
     assert_equal 'Operating system for Pathfinder rover', body['description']
     assert_equal 'https://www.nasa.gov', body['homepage_url']
+    assert_equal 'in_progress', body['badge_level']
   end
 
   test 'should get edit' do
@@ -393,6 +394,14 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_equal contents('badge-silver.svg'), @response.body
   end
 
+  test 'A perfect silver project should have the silver badge in JSON' do
+    get :badge, params: { id: @perfect_silver_project, format: 'json' }
+    assert_response :success
+    json_data = JSON.parse(@response.body)
+    assert_equal 'silver', json_data['badge_level']
+    assert_equal @perfect_silver_project.id, json_data['id'].to_i
+  end
+
   test 'A perfect project should have the gold badge' do
     get :badge, params: { id: @perfect_project, format: 'svg' }
     assert_response :success
@@ -403,6 +412,14 @@ class ProjectsControllerTest < ActionController::TestCase
     get :badge, params: { id: @perfect_unjustified_project, format: 'svg' }
     assert_response :success
     assert_includes @response.body, 'in progress'
+  end
+
+  test 'An in-progress project must reply in_progress in JSON' do
+    get :badge, params: { id: @project, format: 'json' }
+    assert_response :success
+    json_data = JSON.parse(@response.body)
+    assert_equal 'in_progress', json_data['badge_level']
+    assert_equal @project.id, json_data['id'].to_i
   end
 
   test 'An empty project should not have the badge; it should be in progress' do


### PR DESCRIPTION
We already supported /projects/:id/badge and by default that is SVG.
Add support for /projects/:id/badge.json so that external queries
can easily determine the badge level of a project.  The reply
includes "badge_level" which is one of the short badge level names
("in_progress", "passing", "silver", or "gold").

For consistency, also provide badge_level when replying with a full
JSON response for a project (e.g., /projects/:id.json).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>