### PR TITLE
Require rationale to delete project and report it

### DIFF
--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -164,11 +164,13 @@ class ReportMailer < ApplicationMailer
   end
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
-  # Report if a project is deleted
-  def report_project_deleted(project, user)
+  # Report if a project is deleted.  "deletion_rationale" is untrusted
+  # data from a user.
+  def report_project_deleted(project, user, deletion_rationale)
     @report_destination = REPORT_EMAIL_DESTINATION
     @project = project
     @user = user
+    @deletion_rationale = deletion_rationale
     set_headers
     I18n.with_locale(@user.preferred_locale.to_sym) do
       mail(

--- a/app/views/projects/delete_form.html.erb
+++ b/app/views/projects/delete_form.html.erb
@@ -1,0 +1,28 @@
+<%# TODO: nav_extras? %>
+
+<div class="row">
+  <% if in_development? %>
+  <div class="alert alert-danger alert-dismissable text-center">
+    <a href="#" class="close" data-dismiss="alert" aria-label="<%= t('projects.misc.close') %>">&times;</a>
+    <%= t('projects.misc.in_development_warning_html') %>
+  </div>
+  <% end %>
+  <div class="col-md-2 col-sm-3">
+    <div class="main-badge-ques"></div>
+  </div>
+  <div class="col-md-7 col-sm-6">
+    <h1 class="m-t-0 h2"><%=@project.try(:name).presence || '(Name Unknown)' %></h2>
+    <%= bootstrap_form_for @project, url: project_path(@project) do |f| %>
+      <input type="hidden" name="_method" value="delete">
+      <%= t('projects.delete_form.info_html', project_name: @project.name) %>
+      <%# TODO: Create textarea for rationale, pass along to delete, which
+          would pass it on to the emailer. %>
+      <textarea name="deletion_rationale"
+          placeholder="<%= t('projects.delete_form.rationale_placeholder') %>"
+          autofocus="true" cols=70 rows=10
+          lang="en" spellcheck="true"
+          required="true"></textarea>
+      <%= f.submit t('projects.delete_form.delete_action') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -3,7 +3,7 @@
       <li><%= link_to t('.edit'), edit_project_path(@project, criteria_level: @criteria_level) %></li>
     <% end %>
     <% if can_control? %>
-      <li><%= link_to t('.delete'), { action: :destroy, id: @project.id }, method: :delete, data: { confirm: t('.confirm_delete', project_id: @project.id) } %></li>
+      <li><%= link_to t('.delete'), project_path(@project) + '/delete_form' %></li>
     <% end %>
 <% end %>
 

--- a/app/views/report_mailer/report_project_deleted.text.erb
+++ b/app/views/report_mailer/report_project_deleted.text.erb
@@ -10,6 +10,9 @@ It was created at <%= @project.created_at %>, and was
 
 This action was carried out by user <%= @user.id %> named <%= @user.name %>.
 
+The deletion rationale provided was:
+<%= @deletion_rationale %>
+
 The project's JSON record at deletion was:
 
 <%= JSON.pretty_generate(@project.as_json) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -373,6 +373,28 @@ en:
       sign_in_first: Please sign in to add a project!
       original_repos: "=> Original GitHub Repos"
       fork_repos: "=> Forked GitHub Repos"
+    delete_form:
+      info_html: >-
+        <b>Warning</b> - you are about to <b>permanently</b>
+        delete this badge entry for %{project_name}.
+        We recommend that you do <b>not</b> delete this badge entry,
+        instead, complete the badge requirements later.
+        If you think some criteria don't make any sense, cannot figure out
+        how to meet some criteria, or have other questions, please contact us.
+        You don't need to complete the badge all at once; most projects
+        get the badge by meeting missing criteria over time.
+        Also, note that not all criteria must be met to get a badge
+        (some criteria are SHOULD be met or are SUGGESTED).
+        If you don't want badge reminders emailed to use,
+        edit the project entry and turn off email reminders.
+        However, if you are <i>certain</i> that you want to delete this
+        badge entry, please explain why you are deleting this badge entry
+        below.
+      rationale_placeholder: >-
+        (Required) Please explain why you are deleting
+        this project badge entry
+        (and, if applicable, what you wish we did instead)
+      delete_action: Permanently delete this project badge entry!
     edit:
       edit_status: Edit Project Badge Status
       repo_url_limits: You may only change your repo_url from

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -375,26 +375,27 @@ en:
       fork_repos: "=> Forked GitHub Repos"
     delete_form:
       info_html: >-
-        <b>Warning</b> - you are about to <b>permanently</b>
-        delete this badge entry for %{project_name}.
-        We recommend that you do <b>not</b> delete this badge entry,
-        instead, complete the badge requirements later.
+        <b>Warning</b> - you are about to <b>permanently delete</b>
+        the badge entry for %{project_name}.
+        This <b>cannot</b> be easily undone, so
+        we recommend that you do <b>not</b> delete this badge entry.
+        You don't need to complete badge criteria all at once;
+        most projects get the badge by identifying and meeting
+        missing criteria over time.
         If you think some criteria don't make any sense, cannot figure out
         how to meet some criteria, or have other questions, please contact us.
-        You don't need to complete the badge all at once; most projects
-        get the badge by meeting missing criteria over time.
-        Also, note that not all criteria must be met to get a badge
-        (some criteria are SHOULD be met or are SUGGESTED).
-        If you don't want badge reminders emailed to use,
-        edit the project entry and turn off email reminders.
-        However, if you are <i>certain</i> that you want to delete this
-        badge entry, please explain why you are deleting this badge entry
-        below.
+        Note that not all criteria must be met to get a badge
+        (some criteria SHOULD be met or are simply SUGGESTED).
+        If you don't want reminders emailed to you,
+        simply edit the project entry and turn off email reminders instead.
+        However, if you are <i>certain</i> that you want to
+        <i>permanently delete</i> this badge entry, please explain below
+        why you are permanently deleting it.
       rationale_placeholder: >-
-        (Required) Please explain why you are deleting
+        (Required) Please explain why you are permanently deleting
         this project badge entry
         (and, if applicable, what you wish we did instead)
-      delete_action: Permanently delete this project badge entry!
+      delete_action: PERMANENTLY DELETE this project badge entry!
     edit:
       edit_status: Edit Project Badge Status
       repo_url_limits: You may only change your repo_url from

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
     resources :projects do
       member do
         get 'badge', defaults: { format: 'svg' }
+        get 'delete_form' => 'projects#delete_form'
         get '' => 'projects#show_json',
             constraints: ->(req) { req.format == :json }
         get ':criteria_level(.:format)' => 'projects#show',

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -438,6 +438,13 @@ class ProjectsControllerTest < ActionController::TestCase
     #        @perfect_passing_project.lost_passing_at
   end
 
+  test 'Can display delete form' do
+    log_in_as(@project.user)
+    get :delete_form, params: { id: @project }
+    assert_response :success
+    assert_includes @response.body, 'Warning'
+  end
+
   test 'should destroy own project' do
     log_in_as(@project.user)
     num = ActionMailer::Base.deliveries.size


### PR DESCRIPTION
Currently people sometimes delete project badge entries and
we have no idea why.  Also, although we required confirmation
before deletion, it was still very easy for people to
accidentally delete project entries.

This commit changes the "delete" UI link to instead present
a special form (delete_form),
where we "require" a deletion rationale.
That deletion rationale is included in the email to admins
that occurs when a project is deleted.  This makes it
much less likely that a deletion will happen by accident,
and the rationale may help us better understand why some
people delete project entries.

We only use HTML to "require" the deletion rationale, and don't
bother to check that on the server, since failing to provide
this information isn't a security issue.  We just would like to know.

This uses a separate "delete_form" name and method,
not "delete", since Rails handles "delete" specially.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>