### PR TITLE
Change justification comment mark from '#' to '//' fixes #1009

### DIFF
--- a/app/assets/javascripts/project-form.js
+++ b/app/assets/javascripts/project-form.js
@@ -88,7 +88,7 @@ function getColor(value) {
 function containsURL(justification) {
   // string.startsWith('#') was causing a test failure on circleCI.
   // We are not sure why, but regex works fine so let's use that.
-  var possibleComment = /^\s*#/.exec(justification);
+  var possibleComment = /^\/\/ /.exec(justification);
   if (!justification || (!!possibleComment && possibleComment.index === 0)) {
     return false;
   } else {
@@ -109,7 +109,7 @@ function criterionStatus(criterion) {
 function justificationGood(justification) {
   // string.startsWith('#') was causing a test failure on circleCI.
   // We are not sure why, but regex works fine so let's use that.
-  var possibleComment = /^\s*#/.exec(justification);
+  var possibleComment = /^\/\/ /.exec(justification);
   if (!justification || (!!possibleComment && possibleComment.index === 0)) {
     return false;
   } else {

--- a/app/lib/floss_license_detective.rb
+++ b/app/lib/floss_license_detective.rb
@@ -130,7 +130,7 @@ class FlossLicenseDetective < Detective
       { floss_license_osi_status:
           {
             value: 'Unmet', confidence: 1,
-            explanation: '# Did not find license in the OSI list.'
+            explanation: '// Did not find license in the OSI list.'
           } }
     else
       # We currently don't handle (...), so don't even guess.

--- a/app/lib/hardened_sites_detective.rb
+++ b/app/lib/hardened_sites_detective.rb
@@ -25,13 +25,13 @@ class HardenedSitesDetective < Detective
   UNMET_MISSING =
     {
       value: 'Unmet', confidence: 5,
-      explanation: '# One or more of the required security hardening headers '\
+      explanation: '// One or more of the required security hardening headers '\
         'is missing.'
     }.freeze
   UNMET_NOSNIFF =
     {
       value: 'Unmet', confidence: 5,
-      explanation: '# X-Content-Type-Options was not set to "nosniff".'
+      explanation: '// X-Content-Type-Options was not set to "nosniff".'
     }.freeze
 
   INPUTS = %i[repo_url homepage_url].freeze

--- a/app/lib/project_sites_https_detective.rb
+++ b/app/lib/project_sites_https_detective.rb
@@ -24,7 +24,7 @@ class ProjectSitesHttpsDetective < Detective
       @results[:sites_https_status] =
         {
           value: 'Unmet', confidence: 5,
-          explanation: '# Given an http: URL.'
+          explanation: '// Given an http: URL.'
         }
     elsif homepage_url.blank? && repo_url.blank?
       # Do nothing.  Shouldn't happen.

--- a/app/lib/repo_files_examine_detective.rb
+++ b/app/lib/repo_files_examine_detective.rb
@@ -32,7 +32,7 @@ class RepoFilesExamineDetective < Detective
   def unmet_result(result_description)
     {
       value: 'Unmet', confidence: 1,
-      explanation: "# No #{result_description} file found."
+      explanation: "// No #{result_description} file found."
     }
   end
 

--- a/app/lib/subdir_file_contents_detective.rb
+++ b/app/lib/subdir_file_contents_detective.rb
@@ -20,14 +20,14 @@ class SubdirFileContentsDetective < Detective
   def unmet_result(result_description)
     {
       value: 'Unmet', confidence: 1,
-      explanation: "# No #{result_description} file(s) found."
+      explanation: "// No #{result_description} file(s) found."
     }
   end
 
   def unmet_result_folder(result_description)
     {
       value: 'Unmet', confidence: 3,
-      explanation: "# No appropriate folder found for #{result_description}."
+      explanation: "// No appropriate folder found for #{result_description}."
     }
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -221,7 +221,7 @@ class Project < ApplicationRecord
   # which *are* traversed by BadgeApp and thus need to be much more strict.
   #
   def contains_url?(text)
-    return false if !text || text.start_with?('#')
+    return false if !text || text.start_with?('// ')
     text =~ %r{https?://[^ ]{5}}
   end
 
@@ -484,7 +484,7 @@ class Project < ApplicationRecord
   end
 
   def justification_good?(justification)
-    return false if justification.nil? || justification.start_with?('#')
+    return false if justification.nil? || justification.start_with?('// ')
     justification.length >= MIN_SHOULD_LENGTH
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -477,7 +477,7 @@ en:
           them considered at least).
           If you want to enter justification text as a generic comment,
           instead of being a rationale that the situation is acceptable,
-          start the text with '#'.
+          start the text block with '//' followed by a space.
           Feedback is welcome via the
           <a href="https://github.com/coreinfrastructure/best-practices-badge">GitHub
           site as issues or pull requests</a> There is also a

--- a/db/migrate/20180124232626_revise_comment_marker.rb
+++ b/db/migrate/20180124232626_revise_comment_marker.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+class ReviseCommentMarker < ActiveRecord::Migration[5.1]
+  # These are the fields for justification.  They're known at this
+  # point, so we'll just list them.
+  # Omitted (not actually database columns):
+  # - require_2FA_justification
+  # - secure_2FA_justification
+  JUSTIFICATION_FIELDS = %w[
+    homepage_url_justification
+    sites_https_justification
+    description_good_justification
+    interact_justification
+    contribution_justification
+    contribution_requirements_justification
+    license_location_justification
+    floss_license_justification
+    floss_license_osi_justification
+    documentation_basics_justification
+    documentation_interface_justification
+    repo_public_justification
+    repo_track_justification
+    repo_interim_justification
+    repo_distributed_justification
+    version_unique_justification
+    version_semver_justification
+    version_tags_justification
+    release_notes_justification
+    release_notes_vulns_justification
+    report_url_justification
+    report_tracker_justification
+    report_process_justification
+    report_responses_justification
+    enhancement_responses_justification
+    report_archive_justification
+    vulnerability_report_process_justification
+    vulnerability_report_private_justification
+    vulnerability_report_response_justification
+    build_justification
+    build_common_tools_justification
+    build_floss_tools_justification
+    test_justification
+    test_invocation_justification
+    test_most_justification
+    test_policy_justification
+    tests_are_added_justification
+    tests_documented_added_justification
+    warnings_justification
+    warnings_fixed_justification
+    warnings_strict_justification
+    know_secure_design_justification
+    know_common_errors_justification
+    crypto_published_justification
+    crypto_call_justification
+    crypto_floss_justification
+    crypto_keylength_justification
+    crypto_working_justification
+    crypto_pfs_justification
+    crypto_password_storage_justification
+    crypto_random_justification
+    delivery_mitm_justification
+    delivery_unsigned_justification
+    vulnerabilities_fixed_60_days_justification
+    vulnerabilities_critical_fixed_justification
+    static_analysis_justification
+    static_analysis_common_vulnerabilities_justification
+    static_analysis_fixed_justification
+    static_analysis_often_justification
+    dynamic_analysis_justification
+    dynamic_analysis_unsafe_justification
+    dynamic_analysis_enable_assertions_justification
+    dynamic_analysis_fixed_justification
+    crypto_weaknesses_justification
+    test_continuous_integration_justification
+    discussion_justification
+    no_leaked_credentials_justification
+    english_justification
+    hardening_justification
+    crypto_used_network_justification
+    crypto_tls12_justification
+    crypto_certificate_verification_justification
+    crypto_verification_private_justification
+    hardened_site_justification
+    installation_common_justification
+    build_reproducible_justification
+    dco_justification
+    governance_justification
+    code_of_conduct_justification
+    roles_responsibilities_justification
+    access_continuity_justification
+    bus_factor_justification
+    documentation_roadmap_justification
+    documentation_architecture_justification
+    documentation_security_justification
+    documentation_quick_start_justification
+    documentation_current_justification
+    documentation_achievements_justification
+    accessibility_best_practices_justification
+    internationalization_justification
+    sites_password_security_justification
+    maintenance_or_update_justification
+    vulnerability_report_credit_justification
+    vulnerability_response_process_justification
+    coding_standards_justification
+    coding_standards_enforced_justification
+    build_standard_variables_justification
+    build_preserve_debug_justification
+    build_non_recursive_justification
+    build_repeatable_justification
+    installation_standard_variables_justification
+    installation_development_quick_justification
+    external_dependencies_justification
+    dependency_monitoring_justification
+    updateable_reused_components_justification
+    interfaces_current_justification
+    automated_integration_testing_justification
+    regression_tests_added50_justification
+    test_statement_coverage80_justification
+    test_policy_mandated_justification
+    implement_secure_design_justification
+    input_validation_justification
+    crypto_algorithm_agility_justification
+    crypto_credential_agility_justification
+    signed_releases_justification
+    version_tags_signed_justification
+    contributors_unassociated_justification
+    copyright_per_file_justification
+    license_per_file_justification
+    small_tasks_justification
+    code_review_standards_justification
+    two_person_review_justification
+    test_statement_coverage90_justification
+    test_branch_coverage80_justification
+    security_review_justification
+    assurance_case_justification
+    achieve_passing_justification
+    achieve_silver_justification
+  ].freeze
+
+  def sql_change_marker(field, old, new)
+    # Return SQL to change comment marker from "old" to "new" for "field".
+    # Presumes old and new are NOT special in SIMILAR TO.
+    old_len = old.length + 1
+    # Empty here document returns a string
+    <<-SQL
+      UPDATE projects
+      SET #{field} =
+          CONCAT('#{new} ', RIGHT(LTRIM(#{field}), -#{old_len}))
+      WHERE #{field} similar to ' *#{old} %';
+      SELECT id,#{field} FROM projects;
+    SQL
+  end
+
+  def change
+    JUSTIFICATION_FIELDS.each do |field|
+      reversible do |dir|
+        dir.up do
+          execute sql_change_marker(field, '#', '//')
+        end
+        dir.down do
+          execute sql_change_marker(field, '//', '#')
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170626143755) do
+ActiveRecord::Schema.define(version: 20180124232626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -229,7 +229,7 @@ class ProjectTest < ActiveSupport::TestCase
     )
     assert !@unjustified_project.send(
       :justification_good?,
-      '# This is a comment.'
+      '// This is a comment.'
     )
     assert !@unjustified_project.send(:justification_good?, 'bah.')
     assert !@unjustified_project.send(:justification_good?, '')

--- a/test/unit/lib/subdir_file_contents_detective_test.rb
+++ b/test/unit/lib/subdir_file_contents_detective_test.rb
@@ -52,7 +52,7 @@ class SubdirFileContentsDetectiveTest < ActiveSupport::TestCase
       dbs = results[:documentation_basics_status]
       assert dbs.key?(:explanation)
       assert_equal(
-        '# No documentation basics file(s) found.',
+        '// No documentation basics file(s) found.',
         dbs[:explanation]
       )
       assert dbs.key?(:value)


### PR DESCRIPTION
Up to now, if a justification textbox begins with "#", optionally
preceded by spaces, it is considered a "justification comment"
(and is not considered a justification for purposes of an Unmet SHOULD
or where a justification is otherwise required). That made sense because
in many programming languages, "#" introduces a comment that ends at
the end of the line.

In retrospect, that was a mistake, because "#" also has a meaning in
markdown - the beginning of a header. This means that justification
comments look really wonky when viewed (though they look fine while
they're being edited).

We need to change things somehow. The simplest approach, taken here,
is to switch to leading "//" (possibly preceded by spaces) as the
marker for a justification comment. This is a comment marker in many
programming languages, including JavaScript, Java, C#, C++, and C.
Since many OSS project leaders/participants will know at least one of
these programming languages, it should be relatively clear
what's indicated. The sequence "//" is extremely unlikely to be
used accidentally, has no markdown meaning, and is easy to type, too.

Unlike the previous implementation, the text must start with
exactly "//" (even leading spaces disable it).
This is simpler and faster.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>