### PR TITLE
In CircleCI run "gem install bundler"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,11 @@
+dependencies:
+  pre:
+    # Fix this CircleCI warning:
+    # "Warning: the running version of Bundler (1.14.6) is older
+    # than the version that created the lockfile (1.16.0).
+    # We suggest you upgrade to the latest version of Bundler by
+    # running `gem install bundler`."
+    - gem install bundler --no-document
 test:
   pre:
     - "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"


### PR DESCRIPTION
Install *current* version of bundler early in CircleCI.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>