### PR TITLE
Update from jquery 1.* to jquery 3.*; fixes #1012

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,7 +18,7 @@
 // (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery3
 //  No longer used: = require jquery.turbolinks
 //= require jquery_ujs
 //= require bootstrap


### PR DESCRIPTION
Update jquery from its current unsupported 1.* branch
to the current 3.* branch.

We use the gem 'jquery-rails' to bring in the JavaScript library jquery,
and keep us up-to-date. However, jquery-rails does not update between
major branches of jquery. The jquery version brought in is determined by
"app/assets/javascripts/application.js", and it previously said:

~~~~
//= require jquery
~~~~

This means we're bringing in the no-longer supported 1.* branch, not the
current 3.* branch.  The jquery 3 branch was released on June 9, 2016,
so jquery 3 has had time for people to get ready for it.

This commit changes the require statement from "jquery" to "jquery3",
which is how you request the newer 3.* branch. This does create
incompatibilities with extremely old web browsers.
However, the jquery 3.* branch is designed to support the
following web browsers, and that seems to be "good enough"
for most users of this application:

* Internet Explorer: 9+
* Chrome, Edge, Firefox, Safari: Current and Current - 1
* Opera: Current
* Safari Mobile iOS: 7+
* Android 4.0+

Jquery 3.* has a number of interface changes, but as far as I can
tell we aren't affected by any of them.  We've generally tried to
follow the jquery documentation recommendations, and by doing so
I think we've avoided many of the potential breaking problems.

My thanks to Guy Podjarny from Snyk for alerting us to our use of
jquery 1.*, and recommending that we switch to the 3.* supported
branch instead.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>