### PR TITLE
Allow "new project" for GitHub user with no repos, fixes #1020

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -14,6 +14,7 @@ module ProjectsHelper
     no_intra_emphasis: true, autolink: true,
     space_after_headers: true, fenced_code_blocks: true
   )
+  NO_REPOS = [[], []].freeze # No forks and no originals
 
   def github_select
     # List original then forked Github projects, with headers
@@ -23,7 +24,7 @@ module ProjectsHelper
   end
 
   def fork_and_original
-    repo_data.partition { |repo| repo[1] } # partition on fork
+    repo_data.blank? ? NO_REPOS : repo_data.partition { |repo| repo[1] }
   end
 
   def original_header(original_repos)


### PR DESCRIPTION
If a GitHub user with no repos tries to create a new project entry,
they currently fail out because we don't handle the empty case cleanly.

This fixes the code so the empty case works correctly.

Thanks to nancylizi <https://github.com/nancylizi> for reporting this.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>