### PR TITLE
Enable users to delete their account and show email (GDPR)

### DIFF
--- a/app/views/projects/_table.html.erb
+++ b/app/views/projects/_table.html.erb
@@ -36,7 +36,8 @@
           <% end %>
         </td>
         <td class='license'><%= project.license %></td>
-        <td><%= link_to project.user_display_name, project.user %></td>
+        <td><%= link_to project.user_display_name, project.user,
+                        rel: 'nofollow' %></td>
         <td><%= project.achieved_passing_at&.
                   to_formatted_s(:db) %></td>
         <td><%= project.badge_percentage_0 %>%</td>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -23,7 +23,8 @@
 <div class="row">
 <div class="col-md-12">
 <strong><%= t '.owned_by' %></strong>
-<%= link_to @project.user_display_name, user_path(@project.user) %>.<br>
+<%= link_to @project.user_display_name, user_path(@project.user),
+            rel: 'nofollow' %>.<br>
 <%= t '.created_at_html', when: @project.created_at %>
 <%= t '.updated_at_html', when: @project.updated_at %>
 <% if ! @project.lost_passing_at.nil? %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,8 +9,11 @@
          <%= avatar_for @user %>
          <%= @user.name || @user.nickname %>
          <% if current_user && (@user == current_user || current_user.admin?) %>
-           <%= link_to t('.edit_user'),
-                       edit_user_path(@user), class: 'btn btn-primary' %>
+           <%= link_to t('.edit_user'), edit_user_path(@user),
+                       class: 'btn btn-primary', rel: 'nofollow' %>
+           <%= link_to t('.delete_link_name'), @user, method: :delete,
+                       data: { confirm: t('.confirm_delete') },
+                       rel: 'nofollow' %>
          <% end %>
        </h3>
      </section>
@@ -44,14 +47,13 @@
    <a href="https://github.com/<%= @user.nickname %>"><%=
    t ('.see_external') %></a>
   <% end %>
-  <% if current_user&.admin? %>
-    <%= t '.as_admin' %>
+  <% if current_user && (@user == current_user || current_user.admin?) %>
     <% if @user.email? %>
       <a href="mailto:<%= CGI::escape(@user.email).html_safe %>"><%=
         t('.send_email_to') + @user.email.to_s %></a> |
     <% end %>
-    <%= link_to t('.delete_link_name'), @user, method: :delete,
-                data: { confirm: t('.confirm_delete') } %>
+  <% end %>
+  <% if current_user&.admin? %>
     <% if @user.admin? %>
       <p><%= t '.is_admin' %></p>
     <% end %>

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
-# Only show specific approved user attributes
-# json.merge! @user.attributes
+# Show specific approved user attributes.
+# We use JSON to help implement the EU General Data Protection Regulation
+# (GDPR) "Data portability" requirements; JSON is a standard format.
+# We do not use "json.merge! @user.attributes" because there are many
+# irrelevant fields, and we especially want to restrict access to some.
 json.call(
   @user, :id, :name, :nickname, :uid, :provider, :created_at, :updated_at
 )
-# ONLY show email to admins
-json.email user.email if current_user&.admin?
+# current user or admin can see more
+# Do NOT cache this server-side, since this includes the email address
+if @user == current_user || current_user&.admin?
+  json.preferred_locale @user.preferred_locale
+  json.email @user.email
+end
+# We currently don't show @projects, @projects_additional_rights, or
+# @edit_projects. That might change in the future.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,6 +249,8 @@ en:
       delete_link_name: delete
       confirm_delete: Are you sure you want to delete this user?
     destroy:
+      cannot_delete_user_with_projects: Cannot delete a user who owns projects.
+      # The following line is no longer used.
       cannot_delete_self: Cannot delete self.
       user_deleted: User deleted.
     redirect_existing: That user already exists. Did you mean


### PR DESCRIPTION
Change how we handle users so that users can delete their own accounts
and show their own email addresses.  The purpose of these changes is
(in part) to comply with the EU General Data Protection Regulation (GDPR)
as we understand it.

This commit enables users to delete their own user accounts to support the
EU 'right of erasure'.  The application requires that every project
entry have an 'owner', so we only allow user account deletion if
a user owns no project entries.  Since users can always delete project
entries if they own them, users can always delete their accounts without
any action from an administrator.

This commit also enables users to show their own email address (in both
the HTML and JSON format).  This supports the GDPR "right of access"
where users must be able to see the personal data we record about them.
With this change, we believe users can view all the personal data we
store about them.  (We intentionally don't store much, but what we
have we show).  This does mean that if users display a screenshot
of their page to others, it will reveal their email address to others
(a problem our previous version didn't have), but we need to comply
with GDPR and this seemed like the most obvious solution.

The JSON format for user data supports the GDPR "data portability"
requirements, since JSON is a widely-used standard format.

JSON stands for "JavaScript Object Notation (JSON)" and is defined in
"The JavaScript Object Notation (JSON) Data Interchange Format"
by T. Bray, Ed., Internet Engineering Task Force (IETF)
Request for Comments (RFC) 8259, December 2017,
<https://tools.ietf.org/html/rfc8259>
It is also defined by
Ecma International's "The JSON Data Interchange Format",
Standard ECMA-404,
<http://www.ecma-international.org/publications/standards/Ecma-404.htm>.

A number of additional tests have been added and honed.
When we limited user account deletion and email display to trusted admins,
then there were fewer cases to check.  Now that normal users can display
their own data, but normal users are not supposed to be able to see some
data about other users, we have more test cases to check on.

As hardening measures, we intentionally set the user account
pages to "noindex", and caching is also disabled on the user page.
Hyperlinks to the user from a project or project index
are marked as "nofollow".
This will reduce the set of crawled user data
available via other sources, and also reduce the impact via caches,
if there is a serious defect elsewhere in the code.
It's best to not have a problem, but it's also wise to
take reasonable prudent measures to reduce the impact of a problem,
just in case.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>