### PR TITLE
Modify robots.txt to disallow /users (fixes #1027)

### DIFF
--- a/app/views/static_pages/robots.text.erb
+++ b/app/views/static_pages/robots.text.erb
@@ -1,5 +1,13 @@
 User-Agent: *
 <% if ENV['PUBLIC_HOSTNAME'] == 'bestpractices.coreinfrastructure.org' %>
+<%# Tell crawlers to skip user data, to help privacy. %>
+Disallow: /users
+Disallow: /en/users
+Disallow: /fr/users
+Disallow: /ja/users
+Disallow: /ru/users
+Disallow: /zh-CN/users
+Disallow: /de/users
 Allow: /
 <% else %>
 Disallow: /

--- a/app/views/static_pages/robots.text.erb
+++ b/app/views/static_pages/robots.text.erb
@@ -1,6 +1,13 @@
-User-Agent: *
 <% if ENV['PUBLIC_HOSTNAME'] == 'bestpractices.coreinfrastructure.org' %>
-<%# Tell crawlers to skip user data, to help privacy. %>
+# This is the real production system for the CII Best Practices badge.
+
+User-Agent: *
+#
+# Tell crawlers to skip public user data, to help maintain user privacy.
+# With these instructions, if users delete their accounts,
+# the user data will rapidly disappear elsewhere as well.
+# We don't use wildcards here, because some crawlers don't support wildcards;
+# instead we list every supported locale.
 Disallow: /users
 Disallow: /en/users
 Disallow: /fr/users
@@ -8,7 +15,19 @@ Disallow: /ja/users
 Disallow: /ru/users
 Disallow: /zh-CN/users
 Disallow: /de/users
+#
+# Don't crawl project *.json files; the normal HTML files are usually
+# what people want and it takes time to crawl these JSON files.
+# We have to use wildcards for these, and these are merely an optimization
+# for us, not a way to help protect user privacy.
+Disallow: /projects.json$
+Disallow: /projects/*.json$
+Disallow: /*/projects/*.json$
+#
+# In most cases we *do* want this site to be crawled:
 Allow: /
 <% else %>
+# This is not the real production system, do not crawl this data at all.
+User-Agent: *
 Disallow: /
 <% end %>

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -17,6 +17,9 @@
 # :de, :"en-au-ocker", :"en-NZ", :"zh-TW", :"pt-BR", :nep, :uk, :ro, :da,
 # :hu, :cs]
 
+# NOTICE: If you add a locale, also modify robots.txt to prevent crawling of
+# user accounts in that locale. See: app/views/static_pages/robots.text.erb
+
 I18n.available_locales = %i[en zh-CN fr de ja ru]
 
 # If we don't have text, fall back to English.  That obviously isn't

--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -503,6 +503,9 @@ To add a new locale, modify the file "config/initializers/i18n.rb"
 and edit the assignment of "I18n.available_locales" to add
 the new locale.  The system will now permit users to request it.
 
+Also modify robots.txt to prevent crawling of
+user accounts in that locale. See: "app/views/static_pages/robots.text.erb".
+
 Next, create a stub locale file in the "config/locales" directory
 named LOCALE.yml.  A decent way to start is:
 

--- a/test/features/robots_contents_test.rb
+++ b/test/features/robots_contents_test.rb
@@ -19,7 +19,15 @@ class RobotsProductionTest < CapybaraFeatureTest
     visit '/robots.txt'
     assert has_content? 'User-Agent: *'
     assert has_content? 'Allow: /'
-    refute has_content? 'Disallow: /'
+    assert has_content? 'Disallow: /users'
+    # Directly check for locales used by EU countries, ensure they're there
+    assert has_content? 'Disallow: /en/users'
+    assert has_content? 'Disallow: /fr/users'
+    assert has_content? 'Disallow: /de/users'
+    # Loop through all locales (make sure we didn't miss one)
+    I18n.available_locales.each do |loc|
+      assert has_content? "Disallow: /#{loc}/users"
+    end
   end
 end
 


### PR DESCRIPTION
This modifies the BadgeApp's "robots.txt" to disallow crawling
(and thus indexing) of anything in /users, including /LOCALE/users.

The GDPR is obviously very sensitive about user data, and we display
some user data. If another site crawls/scrapes/spiders the data (say for a
web search), then I think it's primarily the problem of the other site to
ensure that the data disappears in a reasonable period of time.

That said, we can make it much less likely that user data will show up
in spidered data at all, by expressly telling spiders to not look at
those pages. Then, if a user account is deleted, that user data will
disappear much more quickly. In addition, if we make a mistake and
accidentally provide private data (primarily the email address), it won't
be indexed in other places in most cases - reducing the damage caused
if we make a mistake. Disallowing in robots.txt removes the user pages
from search results, but I think it's unlikely people would normally
want to see our user pages as search results, and in a separate pull
request I propose setting those pages to "noindex" anyway (which also
removes them from search results). Using robots.txt will also counter
the web crawling of user pages that, while not a big deal, causes us
to do some work that is unlikely to help anyone.

See the robotstxt.org specification <http://www.robotstxt.org/orig.html>
and the Google robots.txt specification at
<https://developers.google.com/search/reference/robots_txt>.
The latter describes how Google does things and adds more capabilities,
in particular, Google has "Allow", and if there's a conflict, the longest
(most specific rule) wins.  So for example, "/users" is longer than "/"
so something matching "/users" would be disallowed.
We shouldn't specify "/users/" since both /users and /users/ map to
"index" (and we need the rules to cover both, so just using "/users"
is simpler). There are no resources starting with "/users" that aren't
user-related, so it's simplest to just disallow "/users" (and so on).

This change takes many steps to ensure that adding a locale
won't suddenly allow crawling a page.
This change modifies our instructions to ourselves on how to create
locales, AND creates a cross-reference comment at the very line you
have to change to add a locale.   In addition, the automated tests
specifically check to ensure that we disallow every locale, and those
are run before any deployment.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>