### PR TITLE
Disable exec-load to eliminate false puma error; fixes #1026

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec puma -C config/puma.rb
+web: env BUNDLE_DISABLE_EXEC_LOAD=true bundle exec puma -C config/puma.rb


### PR DESCRIPTION
Disable exec-load in Procfile to eliminate a false puma error
at runtime on Heroku.  This is a tiny but non-obvious change, so this
commit message provides lots of detail.

Every day we typically get incorrect error reports of the following form:

> heroku/web.1: Process exited with status 1

This is caused because Heroku cycles the webserver (puma) by sending
SIGTERM, but when puma exits it incorrectly returns an error code of 1
("error occurred"). That is simply wrong; a process that exits because
it was specifically asked to do so (via SIGTERM) has not experienced an
error. Instead, exiting on a request to do so, without any other error,
is correct behavior and should return a status code of 0. However,
because puma incorrectly reports a non-zero error code, lots of other
logs whine about a significant problem (even though no problem has
occurred).

At this time there seems to be some disagreement on whether the problem
is really from puma or bundler.  See puma issue 1438 and
bundler issue 6090 for more.  In a grand sense we don't care,
we just don't want false positives.

One solution (noted in the issues above) would be to make "bundle exec"
use Kernel.exec instead of Kernel.load. This essentially disables a minor
optimization that bundler usually uses. This is slightly slower on startup
(it replaces a whole OS process, instead of just reloading from Ruby),
but we rarely start web processes so it would have practically no effect in
the real world.

Per "bundle config --help", we do this just by setting the environment
variable BUNDLE_DISABLE_EXEC_LOAD. The environment variables take
precedence, and then we don't have to worry about race conditions setting
a global variable if multiple procs start at the same time.

This commit uses the "env" command; technically we probably don't need to,
but this ensures that regardless of shell (or straight invocation of
exec) we get our environment variable set.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>