### PR TITLE
Add server-side check of project deletion_rationale, fixes #1022

### DIFF
--- a/app/views/projects/delete_form.html.erb
+++ b/app/views/projects/delete_form.html.erb
@@ -15,13 +15,17 @@
     <%= bootstrap_form_for @project, url: project_path(@project) do |f| %>
       <input type="hidden" name="_method" value="delete">
       <%= t('projects.delete_form.info_html', project_name: @project.name) %>
-      <%# TODO: Create textarea for rationale, pass along to delete, which
-          would pass it on to the emailer. %>
+      <%# We check the deletion_rationale on the server.
+          HTML textarea doesn't support pattern=, and minlength= support is
+          spotty. Server-side checking makes the deletion_rationale
+          checks non-bypassable (it's not a security property, but it's
+          nice to be sure), and it also makes it easier to
+          have different rules for admins vs. others. %>
       <textarea name="deletion_rationale"
           placeholder="<%= t('projects.delete_form.rationale_placeholder') %>"
           autofocus="true" cols=70 rows=10
           lang="en" spellcheck="true"
-          required="true"></textarea>
+          required="required"></textarea>
       <%= f.submit t('projects.delete_form.delete_action') %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -395,9 +395,11 @@ en:
         why you are permanently deleting it.
       rationale_placeholder: >-
         (Required) Please explain why you are permanently deleting
-        this project badge entry
-        (and, if applicable, what you wish we did instead)
+        this project badge entry, and if applicable,
+        what you wish we did instead (20+ characters, 15+ non-whitespace)
       delete_action: PERMANENTLY DELETE this project badge entry!
+      too_short: Must have at least 20 characters.
+      more_non_whitespace: Must have at least 15 non-whitespace characters.
     edit:
       edit_status: Edit Project Badge Status
       repo_url_limits: You may only change your repo_url from


### PR DESCRIPTION
Perform a server-side check of the deletion_rationale for projects,
making the check non-bypassable.  This isn't necessary for security,
but it ensures we get *some* text from the user. Hopefully the text is
useful, and in any case this provides a stronger defense against
accidental deletion.  This commit also adds some tests to ensure it works.

The proposed rule is "at least 20 characters and at least 15
non-whitespace characters".  That will at least prevent someone
accidentally providing a bunch of returns.  If people really insist
on giving us garbage (e.g., a bunch of "a"s) we don't
want them involved anyway.

The check isn't require for admins, who presumably know what they're
doing (and can fix it if they make an error).  That way, if an admin
has to delete a bunch of garbage projects, it's not *too* hard to do it.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>