### PR TITLE
Include times in admin notification, fixes #1035

### DIFF
--- a/app/views/report_mailer/project_status_change.html.erb
+++ b/app/views/report_mailer/project_status_change.html.erb
@@ -7,6 +7,16 @@
       has changed
       from <%= @old_badge_status %>
       to <%= @new_badge_status %>.
+      The project entry was created on <%= @project.created_at %>.
+      <% if @new_badge_status == 'passing' %>
+      Time from project entry creation to passing =
+      <%=
+        distance_of_time_in_words(
+          @project.created_at,
+          @project.achieved_passing_at
+        )
+      %>
+      <% end %>
       See <a href="<%= @project_info_url %>"><%= @project_info_url %></a>
       for more.
     </p>

--- a/app/views/report_mailer/project_status_change.text.erb
+++ b/app/views/report_mailer/project_status_change.text.erb
@@ -7,4 +7,13 @@ on <%= ENV['PUBLIC_HOSTNAME'] %>
 has changed
 from <%= @old_badge_status %>
 to <%= @new_badge_status %>.
+The project entry was created on <%= @project.created_at %>.
+<% if @new_badge_status == 'passing' %>
+Time from project entry creation to passing = <%=
+%>
+  distance_of_time_in_words(
+    @project.created_at,
+    @project.achieved_passing_at
+  )
+<% end %>
 See <%= @project_info_url %> for more.

--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -1,3 +1,6 @@
+# Configuration file for tool rails_best_practices
+# Note: Inside { } you can use "except_methods:" and "ignored_files:" to omit
+# some checks.
 AddModelVirtualAttributeCheck: { }
 AlwaysAddDbIndexCheck: { }
 CheckSaveReturnValueCheck: { }


### PR DESCRIPTION
In the emailed report to admins, report the project entry
created_at time and (where appropriate) the difference
between the created_at time and the achieved_passing_at time.

This will help highlight "unusually speedy" badge achievements,
e.g., so that we can review those more closely.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>