### PR TITLE
On project create, rm trailing / in URLs

### DIFF
--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -618,5 +618,16 @@ class ProjectsControllerTest < ActionController::TestCase
     result = ProjectsController.send :send_reminders
     assert_equal 1, result.size
   end
+
+  # This is a unit test of a private method in ProjectsController.
+  test 'URL cleaning works' do
+    p = ProjectsController.new
+    # Use "send" to do unit test of private method.
+    assert_equal 'xyz', p.send(:clean_url, 'xyz')
+    assert_equal 'xyz', p.send(:clean_url, 'xyz/')
+    assert_equal 'xyz', p.send(:clean_url, 'xyz//')
+    assert_nil p.send(:clean_url, nil)
+    assert_equal 'x/z', p.send(:clean_url, 'x/z')
+  end
 end
 # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
Remove trailing "/" in URLs when trying to create a project entry.

Most URLs that people submit do not have trailing "/", but
a non-trivial number do have a trailing "/", and this makes it
a little harder to notice duplicates.  Remove the trailing "/"
on initial create.

This doesn't prevent later changes, especially of the homepage_url,
but it reduces the number of initial problems.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>