### PR TITLE
Use more font awesome and tweak signup text

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,4 +5,17 @@
 # SPDX-License-Identifier: MIT
 
 module ApplicationHelper
+  # Returns the tag for a given icon.
+  # In font-awesome 5, the category "fab" is used for brands,
+  # while "fas" is used for general (solid) icons.
+  # Currently we use an icon file; in the future we
+  # might use a reference to an SVG or SVG sprite.
+  def my_icon_tag(icon, category = 'fa')
+    # Unfortunately, rubocop doesn't realize that constants are safe,
+    # so we have to disable the OutputSafety check here.
+    # rubocop: disable Rails/OutputSafety
+    ('<i class="'.html_safe + category + ' '.html_safe + icon +
+      '" aria-hidden="true"></i>&nbsp;'.html_safe)
+    # rubocop: enable Rails/OutputSafety
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,17 +5,28 @@
 # SPDX-License-Identifier: MIT
 
 module ApplicationHelper
-  # Returns the tag for a given icon.
+  # Unfortunately, rubocop doesn't realize that concatenating
+  # constants we define is safe.
+  # rubocop: disable Rails/OutputSafety
+  FA_HTML_SAFE = 'fa'.html_safe
+  # rubocop: enable Rails/OutputSafety
+
+  # Returns the tag for a given icon as a SafeBuffer.
   # In font-awesome 5, the category "fab" is used for brands,
   # while "fas" is used for general (solid) icons.
   # Currently we use an icon file; in the future we
   # might use a reference to an SVG or SVG sprite.
-  def my_icon_tag(icon, category = 'fa')
-    # Unfortunately, rubocop doesn't realize that constants are safe,
-    # so we have to disable the OutputSafety check here.
+  def my_icon_tag(icon, category = FA_HTML_SAFE)
+    # Unfortunately, rubocop doesn't realize that concatenating
+    # constants we define is safe.
     # rubocop: disable Rails/OutputSafety
-    ('<i class="'.html_safe + category + ' '.html_safe + icon +
-      '" aria-hidden="true"></i>&nbsp;'.html_safe)
+    res = ''.html_safe
+    res.safe_concat('<i class="')
+    res += category
+    res.safe_concat(' ')
+    res += icon
+    res.safe_concat('" aria-hidden="true"></i>&nbsp;')
     # rubocop: enable Rails/OutputSafety
+    res
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -20,17 +20,17 @@
       <div class="collapse navbar-collapse" id="collapsingRightNav">
 
       <ul class='nav navbar-nav navbar-right'>
+        <li><%= yield :insert_progress_bar %></li>
         <%= yield :nav_extras %>
-                <li><%= yield :insert_progress_bar %></li>
-        <li><%= link_to t(:projects, scope: :layouts), projects_path %></li>
+        <li><%= link_to '<i class="fa fa-list" aria-hidden="true"></i>&nbsp;'.html_safe + t(:projects, scope: :layouts), projects_path %></li>
+
         <% if logged_in? %>
-          <!--li><%= link_to t(:users, scope: :layouts), users_path %></li-->
           <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-              <%= t(:account, scope: :layouts) %><b class="caret"></b>
-            </a>
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i
+              class="fa fa-user" aria-hidden="true"
+            ></i>&nbsp;<%= t(:account, scope: :layouts) %><b class="caret"></b></a>
             <ul class="dropdown-menu reverse-dropdown">
-              <li><%= link_to t(:profile, scope: :layouts), current_user %></li>
+              <li><%= link_to '<i class="fa fa-address-card" aria-hidden="true"></i>&nbsp;'.html_safe + t(:profile, scope: :layouts), current_user %></li>
               <% if current_user.provider == 'local' %>
                 <li><%= link_to t(:settings, scope: :layouts), edit_user_path(current_user) %></li>
               <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -22,15 +22,15 @@
       <ul class='nav navbar-nav navbar-right'>
         <li><%= yield :insert_progress_bar %></li>
         <%= yield :nav_extras %>
-        <li><%= link_to '<i class="fa fa-list" aria-hidden="true"></i>&nbsp;'.html_safe + t(:projects, scope: :layouts), projects_path %></li>
+        <li><%= link_to my_icon_tag('fa-list') + t(:projects, scope: :layouts), projects_path %></li>
 
         <% if logged_in? %>
           <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i
-              class="fa fa-user" aria-hidden="true"
-            ></i>&nbsp;<%= t(:account, scope: :layouts) %><b class="caret"></b></a>
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%=
+              my_icon_tag('fa-user')
+            %><%= t(:account, scope: :layouts) %><b class="caret"></b></a>
             <ul class="dropdown-menu reverse-dropdown">
-              <li><%= link_to '<i class="fa fa-address-card" aria-hidden="true"></i>&nbsp;'.html_safe + t(:profile, scope: :layouts), current_user %></li>
+              <li><%= link_to my_icon_tag('fa-address-card') + t(:profile, scope: :layouts), current_user %></li>
               <% if current_user.provider == 'local' %>
                 <li><%= link_to t(:settings, scope: :layouts), edit_user_path(current_user) %></li>
               <% end %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -11,7 +11,7 @@
 <% content_for :nav_extras do %>
   <li>
     <% if logged_in? %>
-      <%= link_to t('.add_link'), new_project_path %>
+      <%= link_to '<i class="fa fa-plus" aria-hidden="true"></i>&nbsp;'.html_safe + t('.add_link'), new_project_path %>
     <% end %>
   </li>
 <% end %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -11,7 +11,7 @@
 <% content_for :nav_extras do %>
   <li>
     <% if logged_in? %>
-      <%= link_to '<i class="fa fa-plus" aria-hidden="true"></i>&nbsp;'.html_safe + t('.add_link'), new_project_path %>
+      <%= link_to my_icon_tag('fa-plus') + t('.add_link'), new_project_path %>
     <% end %>
   </li>
 <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for :nav_extras do %>
     <% if can_edit? %>
-      <li><%= link_to t('.edit'), edit_project_path(@project, criteria_level: @criteria_level) %></li>
+      <li><%= link_to '<i class="fa fa-edit" aria-hidden="true"></i>&nbsp;'.html_safe + t('.edit'), edit_project_path(@project, criteria_level: @criteria_level) %></li>
     <% end %>
     <% if can_control? %>
-      <li><%= link_to t('.delete'), project_path(@project) + '/delete_form' %></li>
+      <li><%= link_to '<i class="fa fa-times-circle" aria-hidden="true"></i>&nbsp;'.html_safe + t('.delete'), project_path(@project) + '/delete_form' %></li>
     <% end %>
 <% end %>
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for :nav_extras do %>
     <% if can_edit? %>
-      <li><%= link_to '<i class="fa fa-edit" aria-hidden="true"></i>&nbsp;'.html_safe + t('.edit'), edit_project_path(@project, criteria_level: @criteria_level) %></li>
+      <li><%= link_to my_icon_tag('fa-edit') + t('.edit'), edit_project_path(@project, criteria_level: @criteria_level) %></li>
     <% end %>
     <% if can_control? %>
-      <li><%= link_to '<i class="fa fa-times-circle" aria-hidden="true"></i>&nbsp;'.html_safe + t('.delete'), project_path(@project) + '/delete_form' %></li>
+      <li><%= link_to my_icon_tag('fa-times-circle') + t('.delete'), project_path(@project) + '/delete_form' %></li>
     <% end %>
 <% end %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -4,10 +4,13 @@
 
  <br>
  <div class="row">
-   <div class="col-md-6 col-md-offset-3"><%= link_to t('.intro_github'), login_path %> <%= t '.intro_html' %></div>
+   <div class="col-md-6 col-md-offset-3">
+     <%= link_to t('.intro_github'), login_path %>
+     <br><br>
+     <%= t '.intro_html' %>
+     <br><br>
+   </div>
  </div>
- <br><br>
-
 
  <div class="row">
    <div class="col-md-6 col-md-offset-3">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,8 +9,9 @@
          <%= avatar_for @user %>
          <%= @user.name || @user.nickname %>
          <% if current_user && (@user == current_user || current_user.admin?) %>
-           <%= link_to '<i class="fa fa-edit" aria-hidden="true"></i>&nbsp;'.html_safe + t('.edit_user'), edit_user_path(@user),
-                       class: 'btn btn-primary', rel: 'nofollow' %>
+           <%= link_to my_icon_tag('fa-edit') + t('.edit_user'),
+                 edit_user_path(@user),
+                 class: 'btn btn-primary', rel: 'nofollow' %>
          <% end %>
        </h3>
      </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,7 +9,7 @@
          <%= avatar_for @user %>
          <%= @user.name || @user.nickname %>
          <% if current_user && (@user == current_user || current_user.admin?) %>
-           <%= link_to t('.edit_user'), edit_user_path(@user),
+           <%= link_to '<i class="fa fa-edit" aria-hidden="true"></i>&nbsp;'.html_safe + t('.edit_user'), edit_user_path(@user),
                        class: 'btn btn-primary', rel: 'nofollow' %>
          <% end %>
        </h3>
@@ -46,10 +46,10 @@
   <% end %>
   <% if current_user && (@user == current_user || current_user.admin?) %>
     <% if @user.email? %>
-      <a href="mailto:<%= CGI::escape(@user.email).html_safe %>"><%=
-        t('.send_email_to') + @user.email.to_s %></a> |
+      | <a href="mailto:<%= CGI::escape(@user.email).html_safe %>"><%=
+        t('.send_email_to') + @user.email.to_s %></a>
     <% end %>
-    <%= link_to t('.delete_link_name'), @user, method: :delete,
+    | <%= link_to '<i class="fa fa-times-circle" aria-hidden="true"></i>&nbsp;'.html_safe + t('.delete_link_name'), @user, method: :delete,
                   data: { confirm: t('.confirm_delete') },
                   rel: 'nofollow' %>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -50,7 +50,8 @@
       | <a href="mailto:<%= CGI::escape(@user.email).html_safe %>"><%=
         t('.send_email_to') + @user.email.to_s %></a>
     <% end %>
-    | <%= link_to '<i class="fa fa-times-circle" aria-hidden="true"></i>&nbsp;'.html_safe + t('.delete_link_name'), @user, method: :delete,
+    | <%= link_to my_icon_tag('fa-times-circle') + t('.delete_link_name'),
+                  @user, method: :delete,
                   data: { confirm: t('.confirm_delete') },
                   rel: 'nofollow' %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,8 +220,9 @@ en:
   users:
     new:
       signup_header: Sign up
-      intro_github: If you have GitHub account, you can just use
-        that to log in instead (this automatically does a sign up).
+      intro_github: If you have a GitHub account, you can just use
+        it to log in instead
+        (a first-time GitHub login will automatically sign you up).
       intro_html: |-
         If you don't want to log in with a GitHub account, you can
         sign up here instead (this creates a custom account using

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,11 +25,11 @@ en:
     profile: Profile
     settings: Settings
     choose_locale: Choose locale
-    logout_html: <span class="glyphicon glyphicon-log-out"></span>
+    logout_html: <i class="fa fa-sign-out" aria-hidden="true"></i>
       Logout
-    signup_html: <span class="glyphicon glyphicon-user"></span>
+    signup_html: <i class="fa fa-user-plus" aria-hidden="true"></i>
       Sign Up
-    login_html: <span class="glyphicon glyphicon-log-in"></span>
+    login_html: <i class="fa fa-sign-in" aria-hidden="true"></i>
       Login
     footer_text_html: >-
       <small> <strong>Need help? Have a question? See a problem?
@@ -61,7 +61,7 @@ en:
   sessions:
     login_header: Log in
     login_with_github_html: <span class="fa fa-github"></span>
-      Log in with GitHub
+      Log in with GitHub (automatically signs up if necessary)
     or: or
     email: Email
     password: Password
@@ -221,10 +221,12 @@ en:
     new:
       signup_header: Sign up
       intro_github: If you have GitHub account, you can just use
-        that to log in.
+        that to log in (this automatically does a sign up).
       intro_html: |-
         If you don't want to log in with a GitHub account, you can
-        sign up here instead. <br><br> If you didn't receive your activation link,
+        sign up here instead (this creates a custom account using
+        your email address). <br><br> If you didn't receive
+        your activation link,
         please sign up again and we will send you a new one.
       name: Name
       email: Email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,8 +54,8 @@ en:
     password_empty: Password can't be empty
     password_reset: Password has been reset
     instructions_sent: Email sent with password reset instructions
-    cant_reset_nonlocal: Sorry, can't reset the password for a
-      non-local user
+    cant_reset_nonlocal: Sorry, can only reset the password for a custom
+      (local) user
     reset_expired: Password reset has expired.
     update_password: Update password
   sessions:
@@ -221,7 +221,7 @@ en:
     new:
       signup_header: Sign up
       intro_github: If you have GitHub account, you can just use
-        that to log in (this automatically does a sign up).
+        that to log in instead (this automatically does a sign up).
       intro_html: |-
         If you don't want to log in with a GitHub account, you can
         sign up here instead (this creates a custom account using
@@ -233,7 +233,7 @@ en:
       preferred_locale: Preferred locale
       password: Password
       password_confirmation: Confirm Password
-      create_account: Create my account
+      create_account: Create my custom account
     edit:
       update_user_info: Update User Information
       save_changes: Save changes
@@ -247,8 +247,8 @@ en:
       see_external: See this user's external page.
       is_admin: This user is a badge application administrator.
       as_admin: 'as an admin, you may also:'
-      send_email_to: 'send email to:'
-      delete_link_name: delete
+      send_email_to: 'Send email to:'
+      delete_link_name: Delete user account
       confirm_delete: Are you sure you want to delete this user?
     destroy:
       cannot_delete_user_with_projects: Cannot delete a user who owns projects.

--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -825,6 +825,11 @@ or a local account (so people who don't want to use GitHub don't need to).
 We trust GitHub's answers about whether or not a user is who they say they
 are, and about which GitHub projects they can edit.
 
+Note: In the user interface we use the term "custom account"
+instead of "local account" or "local user account" or "local user";
+they are all the same thing.  These are accounts
+where the user directly logs into the system with a password.
+
 We currently can't be sure if a local user is actually allowed to
 edit a given project, but admins can override any claims if necessary.
 If this becomes a problem, we could make it possible for a


### PR DESCRIPTION
This commit adds icons to all major navigation-level actions,
and switches the ones that existed to all use font awesome.

This improves the look, and is a step towards eliminating
glyphicons and subsetting font awesome (to speed first-time display).

It also tweaks the login and signup text to make it clearer that
logging in via GitHub does an automatic sign-up.

One challenge is that in English "sign in" and "sign up"
are different operations, but they sound similar and are related,
so it's easy for people to be confused.
In addition, because we want users to have *convenient* experience,
users who sign in using GitHub also have an automatic sign up
(if necessary).  We tried to be clear before - hopefully these
changes will make it even clearer.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>