### PR TITLE
Preload font awesome fonts

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,8 @@
   <%= stylesheet_link_tag    'application', media: 'all' %>
   <%= javascript_include_tag 'application', defer: true %>
   <link rel="preload" href="<%=
-    font_path('fontawesome-webfont.woff2') %>" as="font">
+    font_path('fontawesome-webfont.woff2') %>" as="font"
+    type="font/woff2" crossorigin>
   <%= auto_discovery_link_tag :atom, { controller: 'projects', action: 'feed' }, { title: t('feed_title') } %>
 </head>
 <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,9 @@
   <link rel="preload" href="<%=
     font_path('fontawesome-webfont.woff2') %>" as="font"
     type="font/woff2" crossorigin>
+  <link rel="preload" href="<%=
+    asset_path('cci-logo-header') %>" as="image"
+    type="image/png">
   <%= auto_discovery_link_tag :atom, { controller: 'projects', action: 'feed' }, { title: t('feed_title') } %>
 </head>
 <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,8 @@
   <%= favicon_link_tag %>
   <%= stylesheet_link_tag    'application', media: 'all' %>
   <%= javascript_include_tag 'application', defer: true %>
+  <link rel="preload" href="<%=
+    font_path('fontawesome-webfont.woff2') %>" as="font">
   <%= auto_discovery_link_tag :atom, { controller: 'projects', action: 'feed' }, { title: t('feed_title') } %>
 </head>
 <body>


### PR DESCRIPTION
Speed up first-time display by hinting to the web brower
to download the font awesome fonts.  The browser will eventually
figure that out, but only after it parses the CSS and more of the HTML.
Include the hint in the HTML head, so that the browser can
initiate the request sooner.

This doesn't matter after the first-time display, because the
fonts will almost certainly be cached, but this is an easy
optimization for first-time display.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>