### PR TITLE
Mildly optimize views/layouts

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,3 +1,4 @@
+<% cache locale do -%>
 <footer class="footer">
   <div class="container">
     <div class="row">
@@ -16,3 +17,4 @@
    </div>
   </div>
 </footer>
+<% end -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= csrf_meta_tags %>
-<% cache locale do # do not cache csrf_meta_tags %>
+<% cache locale do # do not cache csrf_meta_tags -%>
   <title>BadgeApp</title>
   <%= favicon_link_tag %>
   <%= stylesheet_link_tag    'application', media: 'all' %>
@@ -23,17 +23,17 @@
   <%= auto_discovery_link_tag :atom, { controller: 'projects', action: 'feed' }, { title: t('feed_title') } %>
 </head>
 <body>
-<% end # cache %>
-  <%= render 'layouts/header' %>
-  <% flash.each do |message_type, message| %>
+<% end # cache -%>
+<%= render 'layouts/header' -%>
+<% flash.each do |message_type, message| -%>
     <div class="alert alert-<%= message_type %>"><%= message %></div>
-  <% end %>
+<% end -%>
 
   <div class="container container_margins">
-  <%= yield %>
+  <%= yield -%>
   </div>
 
-  <%= render 'layouts/footer' %>
-  <%= debug(params) if Rails.env.development? %>
+<%= render 'layouts/footer' -%>
+<%= debug(params) if Rails.env.development? -%>
 </body>
 </html>


### PR DESCRIPTION
Make a few small improvements for performance:
Add a locale-sensitive cache for the footer, and use "-%>"
in various places so that newslines aren't being included
(in some cases this eliminates a separate newline concatenation;
every separate concatenation request hurts performance).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>