### PR TITLE
Precompute HTML for icons

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,28 +5,4 @@
 # SPDX-License-Identifier: MIT
 
 module ApplicationHelper
-  # Unfortunately, rubocop doesn't realize that concatenating
-  # constants we define is safe.
-  # rubocop: disable Rails/OutputSafety
-  FA_HTML_SAFE = 'fa'.html_safe
-  # rubocop: enable Rails/OutputSafety
-
-  # Returns the tag for a given icon as a SafeBuffer.
-  # In font-awesome 5, the category "fab" is used for brands,
-  # while "fas" is used for general (solid) icons.
-  # Currently we use an icon file; in the future we
-  # might use a reference to an SVG or SVG sprite.
-  def my_icon_tag(icon, category = FA_HTML_SAFE)
-    # Unfortunately, rubocop doesn't realize that concatenating
-    # constants we define is safe.
-    # rubocop: disable Rails/OutputSafety
-    res = ''.html_safe
-    res.safe_concat('<i class="')
-    res += category
-    res.safe_concat(' ')
-    res += icon
-    res.safe_concat('" aria-hidden="true"></i>&nbsp;')
-    # rubocop: enable Rails/OutputSafety
-    res
-  end
 end

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Copyright 2015-2017, the Linux Foundation, IDA, and the
+# CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+# This precomputes the text for each icon as safe_html.
+# This is a singleton class.  It's complicated enough that
+# it's useful to put in its own class.
+
+class Icon
+  class << self
+    ICONS_TO_GENERATE = %i[
+      fa-address-card
+      fa-edit
+      fa-github
+      fa-list
+      fa-plus
+      fa-sign-in
+      fa-sign-out
+      fa-times-circle
+      fa-user
+      fa-user-plus
+    ].freeze
+
+    # Return the SafeBuffer text that represents icon "key".
+    def [](key)
+      # Use fetch, not @icon_data[key], so we discover missing keys
+      @icon_data.fetch(key)
+    end
+
+    # Useful for debugging
+    def keys
+      @icon_data.keys
+    end
+
+    def initialize_class
+      @icon_data = {}
+      ICONS_TO_GENERATE.each do |name|
+        @icon_data[name] = my_icon_tag(name.to_s)
+      end
+      # Should we freeze it?
+      nil
+    end
+
+    private
+
+    # Unfortunately, rubocop doesn't realize that concatenating
+    # constants we define is safe.
+    # rubocop: disable Rails/OutputSafety
+    FA_HTML_SAFE = 'fa'.html_safe
+    # rubocop: enable Rails/OutputSafety
+
+    # Returns the tag for a given icon as a SafeBuffer.
+    # In font-awesome 5, the category "fab" is used for brands,
+    # while "fas" is used for general (solid) icons.
+    # Currently we use an icon file; in the future we
+    # might use a reference to an SVG or SVG sprite.
+    def my_icon_tag(icon, category = FA_HTML_SAFE)
+      # Unfortunately, rubocop doesn't realize that concatenating
+      # constants we define is safe.
+      # rubocop: disable Rails/OutputSafety
+      res = ''.html_safe
+      res.safe_concat('<i class="')
+      res += category
+      res.safe_concat(' ')
+      res += icon
+      res.safe_concat('" aria-hidden="true"></i>&nbsp;')
+      # rubocop: enable Rails/OutputSafety
+      res.freeze
+    end
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -22,15 +22,15 @@
       <ul class='nav navbar-nav navbar-right'>
         <li><%= yield :insert_progress_bar %></li>
         <%= yield :nav_extras %>
-        <li><%= link_to my_icon_tag('fa-list') + t(:projects, scope: :layouts), projects_path %></li>
+        <li><%= link_to Icon[:'fa-list'] + t(:projects, scope: :layouts), projects_path %></li>
 
         <% if logged_in? %>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%=
-              my_icon_tag('fa-user')
+              Icon[:'fa-user']
             %><%= t(:account, scope: :layouts) %><b class="caret"></b></a>
             <ul class="dropdown-menu reverse-dropdown">
-              <li><%= link_to my_icon_tag('fa-address-card') + t(:profile, scope: :layouts), current_user %></li>
+              <li><%= link_to Icon[:'fa-address-card'] + t(:profile, scope: :layouts), current_user %></li>
               <% if current_user.provider == 'local' %>
                 <li><%= link_to t(:settings, scope: :layouts), edit_user_path(current_user) %></li>
               <% end %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -11,7 +11,7 @@
 <% content_for :nav_extras do %>
   <li>
     <% if logged_in? %>
-      <%= link_to my_icon_tag('fa-plus') + t('.add_link'), new_project_path %>
+      <%= link_to Icon[:'fa-plus'] + t('.add_link'), new_project_path %>
     <% end %>
   </li>
 <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for :nav_extras do %>
     <% if can_edit? %>
-      <li><%= link_to my_icon_tag('fa-edit') + t('.edit'), edit_project_path(@project, criteria_level: @criteria_level) %></li>
+      <li><%= link_to Icon[:'fa-edit'] + t('.edit'), edit_project_path(@project, criteria_level: @criteria_level) %></li>
     <% end %>
     <% if can_control? %>
-      <li><%= link_to my_icon_tag('fa-times-circle') + t('.delete'), project_path(@project) + '/delete_form' %></li>
+      <li><%= link_to Icon[:'fa-times-circle'] + t('.delete'), project_path(@project) + '/delete_form' %></li>
     <% end %>
 <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,7 +9,7 @@
          <%= avatar_for @user %>
          <%= @user.name || @user.nickname %>
          <% if current_user && (@user == current_user || current_user.admin?) %>
-           <%= link_to my_icon_tag('fa-edit') + t('.edit_user'),
+           <%= link_to Icon[:'fa-edit'] + t('.edit_user'),
                  edit_user_path(@user),
                  class: 'btn btn-primary', rel: 'nofollow' %>
          <% end %>
@@ -50,7 +50,7 @@
       | <a href="mailto:<%= CGI::escape(@user.email).html_safe %>"><%=
         t('.send_email_to') + @user.email.to_s %></a>
     <% end %>
-    | <%= link_to my_icon_tag('fa-times-circle') + t('.delete_link_name'),
+    | <%= link_to Icon[:'fa-times-circle'] + t('.delete_link_name'),
                   @user, method: :delete,
                   data: { confirm: t('.confirm_delete') },
                   rel: 'nofollow' %>

--- a/config/initializers/icon.rb
+++ b/config/initializers/icon.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Precalculate HTML for icons
+Icon.initialize_class

--- a/test/models/icon_test.rb
+++ b/test/models/icon_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Copyright 2015-2017, the Linux Foundation, IDA, and the
+# CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+require 'test_helper'
+
+class IconTest < ActiveSupport::TestCase
+  test 'Icons exist' do
+    assert Icon.keys.length >= 10
+  end
+
+  test 'fa-edit icon exists and will not be escaped' do
+    result = Icon[:'fa-edit']
+    assert result.present?
+    assert result.length > 10
+    # rubocop: disable Rails/OutputSafety
+    assert_equal result, ''.html_safe + result
+    # rubocop: enable Rails/OutputSafety
+  end
+end


### PR DESCRIPTION
This creates an "Icon" class to precompute and provide
HTML for icons.  Icons are used in all HTML output, so
it makes sense to precompute it for performance.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>