### PR TITLE
Minor code cleanup of /project_stats chart code

### DIFF
--- a/app/helpers/project_stats_helper.rb
+++ b/app/helpers/project_stats_helper.rb
@@ -5,4 +5,40 @@
 # SPDX-License-Identifier: MIT
 
 module ProjectStatsHelper
+  DATE_CHART_OPTIONS = {
+    scales:
+      {
+        xAxes:
+        [
+          {
+            type: 'time',
+            unit: 'day',
+            unitStepSize: 1,
+            ticks: { minRotation: 20 },
+            time: { displayFormats: { 'day': 'YYYY-MM-DD' } }
+          }
+        ]
+      }
+  }.freeze
+
+  # Create line chart of daily stats from ProjectStat
+  # for the provided list of fields
+  # rubocop: disable Metrics/MethodLength
+  def create_line_chart(fields)
+    dataset = []
+    fields.each do |field|
+      # Add "field" to dataset
+      active_dataset =
+        ProjectStat.all.reduce({}) do |h, e|
+          h.merge(e.created_at => e[field])
+        end
+      dataset << {
+        name: t('.' + field),
+        data: active_dataset
+      }
+    end
+    # Done transforming data; return display.
+    line_chart dataset, library: DATE_CHART_OPTIONS, defer: true
+  end
+  # rubocop: enable Metrics/MethodLength
 end

--- a/app/views/project_stats/index.html.erb
+++ b/app/views/project_stats/index.html.erb
@@ -19,28 +19,14 @@
 
 <h2><%= t '.all_projects' %></h2>
 
-<%
-  date_chart_options = {
-    scales: {
-      xAxes: [{
-        type: 'time',
-        unit: 'day',
-        unitStepSize: 1,
-        ticks: { minRotation: 20 },
-        time: {
-          displayFormats: {
-             'day': 'YYYY-MM-DD'
-          } } }]}
-  }
-%>
-
 <%=
   # Show a chart with just total # projects.
   # This gets its own chart because its scale hides everything else.
   series_dataset = ProjectStat.all.reduce({}) do |h,e|
     h.merge(e.created_at => e.percent_ge_0)
   end
-  line_chart series_dataset, library: date_chart_options, defer: true
+  line_chart series_dataset,
+    library: ProjectStatsHelper::DATE_CHART_OPTIONS, defer: true
 %>
 
 <br><br><br>
@@ -59,7 +45,8 @@
     {name: '>=' + minimum.to_s + '%', data: series_dataset}
   end
   # Done transforming data; display it.
-  line_chart dataset, library: date_chart_options, defer: true
+  line_chart dataset,
+    library: ProjectStatsHelper::DATE_CHART_OPTIONS, defer: true
 %>
 
 <br><br><br>
@@ -92,7 +79,8 @@
   dataset << {name: t('.active_edited_in_progress'),
               data: active_edited_in_progress_dataset}
   # Done transforming data; display it.
-  line_chart dataset, library: date_chart_options, defer: true
+  line_chart dataset,
+    library: ProjectStatsHelper::DATE_CHART_OPTIONS, defer: true
 %>
 
 <% end # cache %>
@@ -140,7 +128,7 @@
   end
   line_chart dataset, colors: ['green', 'darkgreen', 'blue', 'darkblue',
                                'red', 'purple'],
-    library: date_chart_options, defer: true
+    library: ProjectStatsHelper::DATE_CHART_OPTIONS, defer: true
 %>
 
 <br>
@@ -166,23 +154,9 @@
     {name: t('.reactivated_projects'),
      data: reactivated_dataset}
   line_chart dataset, colors: ['green', 'blue'],
-    library: date_chart_options, defer: true
+    library: ProjectStatsHelper::DATE_CHART_OPTIONS, defer: true
 %>
 <br><br><br>
-<%
-  date_chart_options = {
-    scales: {
-      xAxes: [{
-        type: 'time',
-        unit: 'day',
-        unitStepSize: 1,
-        ticks: { minRotation: 20 },
-        time: {
-          displayFormats: {
-             'day': 'YYYY-MM-DD'
-          } } }]}
-  }
-%>
 
 <h2><%= t '.projects_silver' %></h2>
 <%=
@@ -200,7 +174,8 @@
     {name: '>=' + minimum.to_s + '%', data: series_dataset}
   end
   # Done transforming data; display it.
-  line_chart dataset, library: date_chart_options, defer: true
+  line_chart dataset,
+    library: ProjectStatsHelper::DATE_CHART_OPTIONS, defer: true
 %>
 
 <br><br><br>
@@ -217,7 +192,8 @@
     {name: '>=' + minimum.to_s + '%', data: series_dataset}
   end
   # Done transforming data; display it.
-  line_chart dataset, library: date_chart_options, defer: true
+  line_chart dataset,
+    library: ProjectStatsHelper::DATE_CHART_OPTIONS, defer: true
 %>
 
 <br><br><br>
@@ -232,7 +208,8 @@
     {name: t("projects.form_early.level.#{level}"), data: series_dataset}
   end
   # Done transforming data; display it.
-  line_chart dataset, library: date_chart_options, defer: true
+  line_chart dataset,
+    library: ProjectStatsHelper::DATE_CHART_OPTIONS, defer: true
 %>
 
 <br><br><br>
@@ -248,34 +225,29 @@
     {name: t("projects.form_early.level.#{level}"), data: series_dataset}
   end
   # Done transforming data; display it.
-  line_chart dataset, library: date_chart_options, defer: true
+  line_chart dataset,
+    library: ProjectStatsHelper::DATE_CHART_OPTIONS, defer: true
 %>
 
 <br><br><br>
 
 <h2><%= t '.user_statistics' %></h2>
 <%=
-  dataset = []
-  ["users",
-  "github_users",
-  "local_users",
-  "users_created_since_yesterday",
-  "users_updated_since_yesterday",
-  "users_with_projects",
-  "users_without_projects",
-  "users_with_multiple_projects",
-  "users_with_passing_projects",
-  "users_with_silver_projects",
-  "users_with_gold_projects"].each do |field|
-    # Add "field" to dataset
-    active_dataset = ProjectStat.all.reduce({}) do |h,e|
-      h.merge(e.created_at => e[field])
-    end
-    dataset << {name: t('.' + field),
-                data: active_dataset}
-  end
-  # Done transforming data; display it.
-  line_chart dataset, library: date_chart_options, defer: true
+  create_line_chart(
+    [
+      "users",
+      "github_users",
+      "local_users",
+      "users_created_since_yesterday",
+      "users_updated_since_yesterday",
+      "users_with_projects",
+      "users_without_projects",
+      "users_with_multiple_projects",
+      "users_with_passing_projects",
+      "users_with_silver_projects",
+      "users_with_gold_projects"
+    ]
+  )
 %>
 
 <%# This links to admin-only information: %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -315,6 +315,7 @@ en:
       raw_data: 'You can also see the raw data:'
       json_format: JSON format
       csv_format: downloadable CSV format
+      user_statistics: User statistics
       users: Users
       github_users: GitHub Users
       local_users: Custom (Local) Users

--- a/test/controllers/project_stats_controller_test.rb
+++ b/test/controllers/project_stats_controller_test.rb
@@ -15,6 +15,18 @@ class ProjectStatsControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     assert_not_nil assigns(:project_stats)
+    assert @response.body.include?('All projects')
+    # This isn't normally shown:
+    refute @response.body.include?('Percentage of projects earning badges')
+  end
+
+  test 'should get index as admin' do
+    log_in_as(users(:admin_user))
+    get :index
+    assert_response :success
+    assert_not_nil assigns(:project_stats)
+    assert @response.body.include?('All projects')
+    assert @response.body.include?('Percentage of projects earning badges')
   end
 
   test 'should get index, CSV format' do


### PR DESCRIPTION
Clean up code to simplify slightly.
This also adds some tests, as the process of cleaning up the
code revealed that the tests needed to be improved.
This commit adds a test for the "as admin" case of seeing
project stats, and adds simple checks of the contents of the response.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>