### PR TITLE
Record last_login_at time in user record

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -29,6 +29,8 @@ module SessionsHelper
   end
   # rubocop:enable Metrics/AbcSize
 
+  # Low-level route to set user as being logged in.
+  # This doesn't set the last_login_at or forward elsewhere.
   def log_in(user)
     session[:user_id] = user.id
     # Switch to user's preferred locale, but only if the current locale is :en

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,11 +75,12 @@ en:
     already_logged_in: You are already logged in.
     incorrect_login_info: Incorrect login information
     invalid_combo: Invalid email/password combination
-    signed_in: Logged in!
+    signed_in: "Logged in! Last login: %{last_login_at}"
     not_activated: >-
       Account not activated. Check your email for the activation
       link.
     signed_out: Logged out!
+    no_login_time: (No previous time recorded.)
   static_pages:
     home:
       badge_program: CII Best Practices Badge Program

--- a/db/migrate/20180218221750_add_login_at_to_user.rb
+++ b/db/migrate/20180218221750_add_login_at_to_user.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddLoginAtToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :last_login_at, :datetime
+    add_index :users, :last_login_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180207050018) do
+ActiveRecord::Schema.define(version: 20180218221750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -396,8 +396,10 @@ ActiveRecord::Schema.define(version: 20180207050018) do
     t.string "reset_digest"
     t.datetime "reset_sent_at"
     t.string "preferred_locale", default: "en"
+    t.datetime "last_login_at"
     t.index ["email"], name: "index_users_on_email"
     t.index ["email"], name: "unique_local_email", unique: true, where: "((provider)::text = 'local'::text)"
+    t.index ["last_login_at"], name: "index_users_on_last_login_at"
     t.index ["uid"], name: "index_users_on_uid"
   end
 


### PR DESCRIPTION
Record the last_login_time in user record when a user logs in.
This makes it easier to see what users are active, and can
help users detect if someone else has been abusing their account.

This will also make it easier to record how many different
users have been logged in over some period of time.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>