### PR TITLE
Add link alternate and publisher metadata

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -16,6 +16,7 @@ module SessionsHelper
   end
 
   # Reply with original_url modified so it has locale "locale".
+  # Locale may be nil.
   # Remove any query string or previously-specified locale to do this.
   # At the root, we do *not* include a trailing slash, so we
   # return ".../en", not ".../en/".
@@ -24,12 +25,14 @@ module SessionsHelper
     # Remove locale from query string and main path
     url.query = remove_locale_query(url.query)
     new_path = url.path.gsub(%r{\A\/[a-z]{2}(-[A-Za-z0-9-]+)?(/|\z)}, '')
-    # Force path to begin with '/'
+    # Force path to begin with '/' if it has content
     new_path.prepend('/') if new_path.present? && new_path[0] != '/'
     # Recreate path, but now forcibly include the locale.
     # If at top, no trailing slash, e.g., "/fr".
-    url.path = '/' + locale.to_s
-    url.path << new_path unless new_path.blank? || new_path == '/'
+    # url.path = locale.present? ? '/' + locale.to_s : ''
+    # url.path << new_path unless new_path.blank? || new_path == '/'
+    url.path = (locale ? '/' + locale.to_s : '') +
+               (new_path == '/' ? '' : new_path)
     url.to_s
   end
 

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -17,24 +17,25 @@ module SessionsHelper
 
   # Reply with original_url modified so it has locale "locale".
   # Locale may be nil.
-  # Remove any query string or previously-specified locale to do this.
-  # At the root, we do *not* include a trailing slash, so we
-  # return ".../en", not ".../en/".
+  # The rootmost path always has a trailing slash ("http://a.b.c/").
+  # Otherwise, there is never a trailing slash.
+  # To do this, we remove any locale in the query string and
+  # and previously-specified locale.
+  # rubocop: disable Metrics/AbcSize
   def force_locale_url(original_url, locale)
     url = URI.parse(original_url)
-    # Remove locale from query string and main path
+    # Remove locale from query string and main path.  The removing
+    # substitution will sometimes remove too much, so we prepend a '/'
+    # if that happens.
     url.query = remove_locale_query(url.query)
-    new_path = url.path.gsub(%r{\A\/[a-z]{2}(-[A-Za-z0-9-]+)?(/|\z)}, '')
-    # Force path to begin with '/' if it has content
-    new_path.prepend('/') if new_path.present? && new_path[0] != '/'
+    new_path = url.path.gsub(%r{\A\/[a-z]{2}(-[A-Za-z0-9-]+)?(\/|\z)}, '')
+    new_path.prepend('/') if new_path.empty? || new_path[0] != '/'
+    new_path.chomp!('/') if locale || new_path != '/'
     # Recreate path, but now forcibly include the locale.
-    # If at top, no trailing slash, e.g., "/fr".
-    # url.path = locale.present? ? '/' + locale.to_s : ''
-    # url.path << new_path unless new_path.blank? || new_path == '/'
-    url.path = (locale ? '/' + locale.to_s : '') +
-               (new_path == '/' ? '' : new_path)
+    url.path = (locale.present? ? '/' + locale.to_s : '') + new_path
     url.to_s
   end
+  # rubocop: enable Metrics/AbcSize
 
   # Low-level route to set user as being logged in.
   # This doesn't set the last_login_at or forward elsewhere.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= csrf_meta_tags %>
+<%# The following are the same for a given locale, cache for speed -%>
 <% cache locale do # do not cache csrf_meta_tags -%>
   <title>BadgeApp</title>
   <%= favicon_link_tag %>
@@ -20,10 +21,27 @@
     type="font/woff2" crossorigin>
   <link rel="preload" href="<%=
     asset_path('cci-logo-header') %>" as="image" type="image/png">
-  <%= auto_discovery_link_tag :atom, { controller: 'projects', action: 'feed' }, { title: t('feed_title') } %>
+  <%= auto_discovery_link_tag :atom,
+                              { controller: 'projects', action: 'feed' },
+                              { title: t('feed_title') } %>
+  <link rel="publisher" href="https://plus.google.com/+LinuxfoundationOrg" />
+<% end # cache for this locale -%>
+<%# Provide info on all alternate locales for search engines, etc. See: -%>
+<%# https://support.google.com/webmasters/answer/189077?hl=en -%>
+<%# https://searchengineland.com/ -%>
+<%# the-ultimate-guide-to-multilingual-and-multiregional-seo-157838 -%>
+<%# We use original_fullpath so that query strings are included. -%>
+<%# Fullpaths and locales are always distinct, so don't need cache name -%>
+<% cache request.original_fullpath do -%>
+<%   I18n.available_locales.each do |loc| -%>
+       <link rel="alternate" hreflang="<%= loc %>" href="<%=
+             force_locale_url(request.original_url, loc) %>" />
+<%   end # each locale -%>
+       <link rel="alternate" hreflang="x-default" href="<%=
+             force_locale_url(request.original_url, nil) %>" />
+<% end # cache of links to "alternates" for each locale -%>
 </head>
 <body>
-<% end # cache -%>
 <%= render 'layouts/header' -%>
 <% flash.each do |message_type, message| -%>
     <div class="alert alert-<%= message_type %>"><%= message %></div>

--- a/config/initializers/canonical_trailing_slash.rb
+++ b/config/initializers/canonical_trailing_slash.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Copyright 2015-2017, the Linux Foundation, IDA, and the
+# CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+# Redirect to canonical URL as needed, using some of our Rack middleware.
+# See: "Avoiding SEO Duplicate Content Issues with Ruby and
+# Rack Middleware" by Brent Ertz, 7/24/2012, https://quickleft.com/
+# blog/avoiding-seo-duplicate-content-issues-with-ruby-and-rack-middleware/
+
+module Rack
+  # If we get a URL with a trailing slash other than "/", redirect to
+  # a page without the trailing slash so that we have a single
+  # canonical URL format.
+  class CanonicalizeTrailingSlash
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      request = Rack::Request.new env
+      if %r{^/(.*)/$}.match?(request.path_info)
+        # Clean up URL and redirect a different URL
+        url = request.base_url + request.path.chomp('/') +
+              (request.query_string.empty? ? '' : '?' + request.query_string)
+        [301, { 'Location' => url, 'Content-Type' => 'text/html' }, []]
+      else
+        # Nothing to do, continue chain.
+        @app.call env
+      end
+    end
+  end
+end
+
+Rails.application.config.middleware.insert_before(
+  0,
+  Rack::CanonicalizeTrailingSlash
+)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   # The "robots.txt" file is always at the root of the
   # document tree, and locale is irrelevant to it. Handle it specially.
   get '/robots.txt' => 'static_pages#robots',
-      defaults: { format: 'text' }
+      defaults: { format: 'text' }, as: :robots
 
   # The /projects/NUMBER/badge image route needs speed and never depends
   # on the locale. Perhaps most importantly, badge images need to have

--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -422,6 +422,17 @@ You can access 'I18n.locale' to see the current locale's value
 (this is a thread-local query, so this works fine when multiple
 threads are active).
 
+### Canonical URLs
+
+We try to always refer to canonical URL forms.
+In some cases that can help search engine rankings, and in any case
+it's easier to understand.
+Rails' built-in "path" and "url" helpers add a trailing slash
+if it is at the root without locale (e.g., "https://x.com/"),
+but otherwise they do not add a trailing slash.
+We accept a locale setting in the query string, but we prefer to generate
+locales in the path (e.g., "https://x.com/en", not "https://x.com?locale=en").
+
 ## App authentication via GitHub
 
 The BadgeApp needs to authenticate itself through OAuth2 on

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -82,4 +82,12 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
     get criteria_path(locale: :'zh-CN')
     assert_response :success
   end
+
+  test 'should redirect criteria with trailing slash' do
+    get '/en/criteria/'
+    follow_redirect!
+    assert_response :success
+    # Notice that the trailing slash is now gone
+    assert_equal '/en/criteria', @request.fullpath
+  end
 end

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -19,7 +19,8 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
     # target=... better not end immediately, we need rel="noopener"
     refute_includes @response.body, 'target=[^ >]+>'
     # Ensure locale cross-references are present, and that
-    # the home page URL doesn't have a trailing slash.
+    # the home page URL doesn't have a trailing slash UNLESS there's no locale.
+    # If there's no locale, include a '/' to be consistent with root_path.
     #
     # There's a weird test environment artifact I haven't been
     # able to track down.  The view response sometimes has an original url of
@@ -47,7 +48,7 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
     end
     assert_match \
       %r{<link\ rel="alternate"\ hreflang="x-default"
-       \ href="https?://[a-z0-9.:]+"\ />}x,
+       \ href="https?://[a-z0-9.:]+/"\ />}x,
       @response.body
   end
 

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -6,6 +6,7 @@
 
 require 'test_helper'
 
+# rubocop: disable Metrics/BlockLength
 class SessionsHelperTest < ActionView::TestCase
   setup do
     @user = users(:test_user)
@@ -25,6 +26,10 @@ class SessionsHelperTest < ActionView::TestCase
 
   # Unit test.  There are tricky cases, so try various forms
   test 'check force_locale_url' do
+    assert_equal 'https://a.b.c/',
+                 force_locale_url('https://a.b.c/', nil)
+    assert_equal 'https://a.b.c/',
+                 force_locale_url('https://a.b.c', nil)
     assert_equal 'https://a.b.c/fr', force_locale_url('https://a.b.c/', :fr)
     assert_equal 'https://a.b.c/fr', force_locale_url('https://a.b.c', :fr)
     assert_equal 'https://a.b.c/en',
@@ -50,3 +55,4 @@ class SessionsHelperTest < ActionView::TestCase
                  )
   end
 end
+# rubocop: enable Metrics/BlockLength


### PR DESCRIPTION
This adds link rel="alternate" metadata to make it much
easier to find the alternate locales for various pages.
It includes an "x-default" locale, which eases
automatically finding the "no locale" URL.

It also adds link rel="publisher" so that it's clear
who the publisher is.

This should help search engines find (and understand) the site.
That's especially important now that the site is automatically
redirecting based on locale.

For more information, see:
https://support.google.com/webmasters/answer/189077?hl=en
https://searchengineland.com/
the-ultimate-guide-to-multilingual-and-multiregional-seo-157838

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>