### PR TITLE
Fix URL in email ("." should be "/").  Fixes #1096

### DIFF
--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -35,7 +35,7 @@ class ReportMailer < ApplicationMailer
     @project = project
     @old_badge_status = old_badge_status
     @new_badge_status = new_badge_status
-    @project_info_url = projects_url(@project, locale: nil)
+    @project_info_url = project_url(@project, locale: nil)
     @report_destination = REPORT_EMAIL_DESTINATION
     set_headers
     I18n.with_locale(I18n.default_locale) do
@@ -66,7 +66,7 @@ class ReportMailer < ApplicationMailer
     return unless user.email?
     return unless user.email.include?('@')
     @project_info_url =
-      projects_url(@project, locale: user.preferred_locale.to_sym)
+      project_url(@project, locale: user.preferred_locale.to_sym)
     @email_destination = user.email
     @new_level = new_badge_level
     @old_level = old_badge_level
@@ -94,7 +94,7 @@ class ReportMailer < ApplicationMailer
     return unless user.email?
     return unless user.email.include?('@')
     @project_info_url =
-      projects_url(@project, locale: user.preferred_locale.to_sym)
+      project_url(@project, locale: user.preferred_locale.to_sym)
     @email_destination = user.email
     set_headers
     I18n.with_locale(user.preferred_locale.to_sym) do
@@ -154,7 +154,7 @@ class ReportMailer < ApplicationMailer
     return unless user.email?
     return unless user.email.include?('@')
     @project_info_url =
-      projects_url(@project, locale: user.preferred_locale.to_sym)
+      project_url(@project, locale: user.preferred_locale.to_sym)
     @email_destination = user.email
     set_headers
     I18n.with_locale(user.preferred_locale.to_sym) do


### PR DESCRIPTION
Fix the URL in some emails ("." should be "/").
The problem is that we used the wrong helper; we used
"projects_url" (plural name) when we should have used
"project_url" (singular name).  We're referring to a
singular project, so we must use the singular helper.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>