### PR TITLE
Require user email uniqueness ONLY on local accounts

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,8 +44,17 @@ class User < ApplicationRecord
   )
 
   validates :name, presence: true, length: { maximum: 50 }
-  validates :email, presence: true, length: { maximum: 255 },
-                    uniqueness: { case_sensitive: false }, email: true
+
+  validates :email, presence: true, length: { maximum: 255 }, email: true
+
+  # We check uniqueness of local account email addresses *both* here in
+  # the model *and* also directly in the database (via unique_local_email).
+  # The uniqueness check here in the model provides better error messages
+  # and works regardless of the underlying RDBMS.  The RDBMS-level index
+  # check, however, is immune to races where supported (PostgreSQL does),
+  # because the RDBMS is the final arbiter).
+  validates :email, uniqueness: { scope: :provider }, case_sensitive: false,
+                    if: ->(u) { u.provider == 'local' }
 
   # Validate passwords; this is obviously security-related.
   # We directly control validations instead of using the default

--- a/test/features/login_test.rb
+++ b/test/features/login_test.rb
@@ -126,6 +126,21 @@ class LoginTest < CapybaraFeatureTest
   end
   # rubocop:enable Metrics/BlockLength
 
+  scenario 'Can Login custom where GitHub account has same email', js: false do
+    # Make GitHub account have same email address as custom account
+    @github_user = users(:github_user)
+    @github_user.email = @user.email
+    @github_user.save!
+    # Now have custom account log in.
+    visit projects_path(locale: :en)
+    click_on 'Login'
+    fill_in 'Email', with: @user.email
+    fill_in 'Password', with: 'password'
+    click_button 'Log in using custom account'
+    assert has_content? 'Logged in!'
+    assert_equal projects_path(locale: :en), current_path
+  end
+
   # Test if we switch to user's preferred locale on login.
   # Here we test on a path that isn't the root.
   scenario 'Can Login in fr locale to /projects', js: true do


### PR DESCRIPTION
We previously checked email uniqueness in the user model, and
unintentionally required that the email be globally unique.

This commit instead requires case-insensitive uniqueness *only*
for local accounts, completely ignoring GitHub users (who are
handled differently).  In particular, we had a user who had
both her local account and GitHub account tied to the same
user email address; that should have worked, but didn't because
of the overly-restrictive check.

Note that this commit includes a regression test, one that did
*not* pass before but passes now.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>