### PR TITLE
Change "content_for" to "provide"

### DIFF
--- a/app/views/projects/_form_0.html.erb
+++ b/app/views/projects/_form_0.html.erb
@@ -2,7 +2,7 @@
     That allows us to fill in and then end the current column & row,
     followed by starting and finishing another full row. %>
 <% badge_hostname = (ENV['PUBLIC_HOSTNAME'] || 'localhost') %>
-<% content_for :insert_progress_bar do %>
+<% provide :insert_progress_bar do %>
   <div id="progress-mobile" class="progress">
     <div id="badge-progress"
          class="progress-bar progress-bar-success badge-progress"

--- a/app/views/projects/_form_1.html.erb
+++ b/app/views/projects/_form_1.html.erb
@@ -3,7 +3,7 @@
     followed by starting and finishing another full row. %>
 <% badge_hostname = (ENV['PUBLIC_HOSTNAME'] || 'localhost') %>
 <%# TODO: Use badge_percentage_1 %>
-<% content_for :insert_progress_bar do %>
+<% provide :insert_progress_bar do %>
   <div id="progress-mobile" class="progress">
     <div id="badge-progress"
          class="progress-bar progress-bar-success badge-progress"

--- a/app/views/projects/_form_2.html.erb
+++ b/app/views/projects/_form_2.html.erb
@@ -3,7 +3,7 @@
     followed by starting and finishing another full row. %>
 <% badge_hostname = (ENV['PUBLIC_HOSTNAME'] || 'localhost') %>
 <%# TODO: Use badge_percentage_1 %>
-<% content_for :insert_progress_bar do %>
+<% provide :insert_progress_bar do %>
   <div id="progress-mobile" class="progress">
     <div id="badge-progress"
          class="progress-bar progress-bar-success badge-progress"

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -8,7 +8,7 @@
     [t('.in_progress_variable', percent: 90), 90]
   ]
 %>
-<% content_for :nav_extras do %>
+<% provide :nav_extras do %>
   <li>
     <% if logged_in? %>
       <%= link_to Icon[:'fa-plus'] + t('.add_link'), new_project_path %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :nav_extras do %>
+<% provide :nav_extras do %>
     <% if can_edit? %>
       <li><%= link_to Icon[:'fa-edit'] + t('.edit'), edit_project_path(@project, criteria_level: @criteria_level), rel: 'nofollow' %></li>
     <% end %>


### PR DESCRIPTION
Change from "content_for" to "provide", as it can be slightly faster
and more importantly enables potential future uses of streaming.

We use "content_for" in various views, but we *never* use its
ability to concatenate values.  Since we don't use that feature,
switch them all to "provide" instead, which can do the same thing
but doesn't have to search the whole template for values.
This is especially important if we ever use streaming in the future
for these cases.  Perhaps more importantly, we tend to create new things
based on existing constructs; if we use "provide" where practical,
future things will be more easily switched to streaming.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>