### PR TITLE
Internationalize (i18n) the "not found" (404) page. Fixes #1111

### DIFF
--- a/app/views/static_pages/error_404.html
+++ b/app/views/static_pages/error_404.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<!-- This is intentionally short to minimize bandwidth use during attack. -->
-<html>
-  <title>Error 404: Page Not Found</title>
-  <h1>Error 404: Page Not Found</h1>
-  <p>
-  <a href="/">Please go to the front page</a>.
-</html>

--- a/app/views/static_pages/error_404.html.erb
+++ b/app/views/static_pages/error_404.html.erb
@@ -1,0 +1,29 @@
+<% cache locale do -%>
+<!DOCTYPE html>
+<%# This is intentionally short and does *NOT* use the standard layout,
+    to minimize CPU and bandwidth use during an attack.
+    An attacker may create a rediculous number of requests that lead to a 404.
+    By optimizing this for speed, we have a better chance of keeping
+    up and can recover more quickly.  Instead of giving lots of info,
+    we simply explain that there is no page and give a link to the home page.
+    We *do* use the locale, since we want humans to be able to use
+    understand this information if there's a human reader.
+    We intentionally do *not* parrot back the bad URL. The user can
+    already see the URL (using the browser), and returning a known-bad URL
+    creates an opportunity for a XSS attack that we don't need to provide.
+    Users will never see this page during normal use. -%>
+<html>
+  <head>
+    <title><%= t '.heading' %></title>
+  </head>
+  <body>
+    <h1><%= t '.heading' %></h1>
+    <p>
+    <%= t '.no_such_page' %>
+    </p>
+    <p>
+    <a href="/<%= locale %>"><%= t '.please_home' %></a>
+    </p>
+  </body>
+</html>
+<% end # cache %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,10 @@ en:
     signed_out: Logged out!
     no_login_time: (No previous time recorded.)
   static_pages:
+    error_404:
+      heading: "Error 404: Page Not Found"
+      no_such_page: Sorry, no such page exists.
+      please_home: Please go to the home page.
     home:
       badge_program: CII Best Practices Badge Program
       get_your_badge: Get Your Badge Now!


### PR DESCRIPTION
Internationalize (i18n) the "not found" (404) page.
This is intentionally short and does *NOT* use the standard layout,
to minimize CPU and bandwidth use during an attack.
It's cached per locale, speeding later replies for a given locale.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>