### PR TITLE
Tell system to stop callbacks when they return false

### DIFF
--- a/config/initializers/callback_terminator.rb
+++ b/config/initializers/callback_terminator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Copyright 2015-2017, the Linux Foundation, IDA, and the
+# CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+# Rails 5 changed how callback chains are interpreted. See:
+# https://blog.bigbinary.com/2016/02/13/
+# rails-5-does-not-halt-callback-chain-when-false-is-returned.html
+# For now, restore the old semantics, until we're confident that
+# things work with the new semantics.
+
+ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
Rails 5 changed how callback chains are interpreted. See:
https://blog.bigbinary.com/2016/02/13/
rails-5-does-not-halt-callback-chain-when-false-is-returned.html

This commit restores the old semantics, until we're confident that
things work correctly with the new semantics.  If we need to, we can
change some things, but the point of this commit is to simply ensure
that we're using the *expected* semantics.  We will then walk through
all the actions to make sure that there are no problems.

This commit causes the following *expected* deprecation warning:
DEPRECATION WARNING: ActiveSupport.halt_callback_chains_on_return_false=
is deprecated and will be removed in Rails 5.2. (called from ...)
Once everything has been reviewed, we'll remove the setting
(which will eliminate the deprecation warning).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>