### PR TITLE
Clarify: must EDIT project entries to change reminder status

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -384,6 +384,10 @@ en:
       may_select_html: >-
         You may select from one of your GitHub repos <em>OR</em>
         provide information about some other project.
+        If your project hasn't earned a passing badge and
+        you haven't made any edits for at least 30 days,
+        we'll send you a reminder email
+        (you can disable reminders at any time if you want to).
       new_badge_or: OR
       select_one_github: Select one of your GitHub repos
       submit_github: Submit GitHub Repository

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -679,7 +679,8 @@ en:
         unknown_placeholder: Please explain
       disabled_reminders: >-
         (Advanced) Disable inactivity reminder (we recommend you
-        leave this unchecked)
+        leave this unchecked; note that project entries
+        must be edited to change whether or not reminders are sent)
       general_comments:
         description: 'Other general comments about the project:'
         placeholder: Additional Comments (in markdown)
@@ -757,8 +758,9 @@ en:
       reminder about every 30-60 days.
       You can disable these inactivity reminder messages at any time;
       just edit your badge entry at
-      <a href="%{project_info_url}">%{project_info_url}</a>
+      <a href="%{project_info_url}#project_disabled_reminders">%{project_info_url}#project_disabled_reminders</a>
       to turn on "disable inactivity reminder".
+      Remember to <i>edit</i> the project entry if you want to change the value.
       If your project has earned a passing badge, or its
       badge entry has been edited within 30 days,
       then no inactivity reminder will be sent.
@@ -787,8 +789,10 @@ en:
       reminder about every 30-60 days.
       You can disable these inactivity reminder messages at any time;
       just edit your badge entry at
-      %{project_info_url}
+      %{project_info_url}#project_disabled_reminders
       to turn on "disable inactivity reminder".
+      Be sure to edit the project entry if you want to change whether
+      or not you receive inactivity reminders!
       If your project has earned a passing badge, or its
       badge entry has been edited within 30 days,
       then no inactivity reminder will be sent.
@@ -832,8 +836,10 @@ en:
       We don't send reminders if you continue to update your badge entry,
       and we only send reminders approximately every 30-60 days.  However,
       if you want to disable these reminder messages, edit your badge entry at
-      <a href="%{project_info_url}">%{project_info_url}</a>
+      <a href="%{project_info_url}#project_disabled_reminders">%{project_info_url}#project_disabled_reminders</a>
       to turn on "disable inactivity reminder".
+      Be sure to edit the project entry, don't just display it, if you
+      want to change whether or not you'll receive an inactivity reminder.
       We hope you'll instead keep working at it
       and eventually earn the badge.
       </p>
@@ -869,8 +875,10 @@ en:
       We don't send reminders if you continue to update your badge entry,
       and we only send reminders approximately every 30-60 days.  However,
       if you want to disable these reminder messages, edit your badge entry at
-      %{project_info_url}
+      %{project_info_url}#project_disabled_reminders
       to turn on "disable inactivity reminder".
+      Be sure to edit the project entry, don't just display it, if you
+      want to change whether or not you'll receive an inactivity reminder.
       We hope you'll instead keep working at it
       and eventually earn the badge.
 


### PR DESCRIPTION
We've received some emails that suggest that people are trying
to change the reminder status, but don't realize that they're
only in *show* mode and not *edit* mode.  Show and edit look
similar, but checkboxes in particular look nearly identical,
and that appears to be leading to the problem.

This commit addresses the problem by changing the text to try
to make it ABUNDANTLY clear that you have to EDIT the project
entry to change this value (just like any other value).

In the long term, we want to make it possible to link
*directly* to the edit mode for this value, to simplify this
further.  However, that requires non-trivial code changes,
and we would STILL want it to be clear to users anyway.
So let's make the situation clear with text right now,
because we *CAN* do that right now, without having to wait
for code changes.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>