### PR TITLE
Modify project_stats page to use ?type=uncommon

### DIFF
--- a/app/views/project_stats/index.html.erb
+++ b/app/views/project_stats/index.html.erb
@@ -5,15 +5,18 @@
   # It will age out eventually anyway, but this is a large cache entry
   # and we can easily determine what the previous one was. Immediately
   # forcing its deletion provides more cache space for other (useful) things.
+  is_normal = (params[:type] != 'uncommon')
   Rails.cache.delete ActiveSupport::Cache.expand_cache_key(
-    ['project_stats', locale, ProjectStat.all.size-1]
+    ['project_stats', locale, is_normal, ProjectStat.all.size-1]
   )
 
   # Cache the page, it's somewhat expensive to create.
-  cache ['project_stats', locale, ProjectStat.all.size] do
+  cache ['project_stats', locale, is_normal, ProjectStat.all.size] do
 %>
 
 <p id="notice"><%= notice %></p>
+
+<% if is_normal %>
 
 <h1><%= t('.project_stats_header') %></h1>
 
@@ -83,17 +86,7 @@
     library: ProjectStatsHelper::DATE_CHART_OPTIONS, defer: true
 %>
 
-<% end # cache %>
-
-<% if current_user&.admin?
-     # This data isn't sensitive, but it's probably uninteresting to
-     # non-admins, and all these charts take time to create.  Therefore,
-     # only show these to admins.  Non-admins can still get the data via JSON.
-     # We *separately* cache this from the non-admin charts to increase
-     # the likelihood for using at least one cache.
-     cache ['project_stats_admin', locale, ProjectStat.all.size] do -%>
-
-<br><br><br>
+<% else # show "non-normal" displays (less commonly used) %>
 
 <h2><%= t '.daily_activity' %></h2>
 <%=
@@ -250,14 +243,14 @@
   )
 %>
 
+<%   end # uncommon %>
+<% end # cache %>
+
+<% if current_user&.admin? %>
 <%# This links to admin-only information: %>
 <p>
 <%= t '.admin_html' %>
-
-<%
-  end # cache (of admin)
-end # if current_user&.admin?
-%>
+<% end # admin-specific info %>
 
 <br>
 <br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -328,7 +328,9 @@ en:
         receiving reminder
       admin_html: >-
         As an admin, you may also see the <a href="/en/reminders">detailed
-        information about reminders</a>.
+        information about reminders</a> and
+        <a href="/en/project_stats?type=uncommon">graphs of less commonly-used
+        statistics</a>.
       raw_data: 'You can also see the raw data:'
       json_format: JSON format
       csv_format: downloadable CSV format

--- a/test/controllers/project_stats_controller_test.rb
+++ b/test/controllers/project_stats_controller_test.rb
@@ -26,6 +26,11 @@ class ProjectStatsControllerTest < ActionController::TestCase
     assert_response :success
     assert_not_nil assigns(:project_stats)
     assert @response.body.include?('All projects')
+    assert @response.body.include?('As an admin, you may also see')
+  end
+
+  test 'should get less-common stats on request' do
+    get :index, params: { locale: :en, type: 'uncommon' }
     assert @response.body.include?('Percentage of projects earning badges')
   end
 


### PR DESCRIPTION
This reduces delay and memory use, and fixes a bug.

Currently, when the project_stats page is shown, it's
supposed to show more graphs to admins.  This leads to a
rediculous amount of delay and memory use when the admin displays
the project_stats page, as well as some errors in display.

This commit instead shows the simple project_stats page in the
normal case, and shows *only* the less-common graphs if you include
"?type=uncommon" ("show the uncommon graphs").  This means that
you only see a particular set of graphs for any particular request.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>