### PR TITLE
Eliminate ActiveSupport.halt_callback_chains_on_return_false = true

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,8 @@ class ApplicationController < ActionController::Base
   after_action :persist_session_timestamp
 
   # If locale is not provided in the URL, redirect to best option.
+  # Special URLs which do not have locales, such as "/robots.txt",
+  # must "skip_before_action :redir_missing_locale".
   before_action :redir_missing_locale
 
   # Set the locale, based on best available information.
@@ -139,7 +141,7 @@ class ApplicationController < ActionController::Base
   # Set the locale, based on best available information.
   # See <http://guides.rubyonrails.org/i18n.html>.
   def set_locale_to_best_available
-    best_locale = params[:locale]
+    best_locale = params[:locale] # Locale in URL always takes precedent
     best_locale = find_best_locale if best_locale.blank?
 
     # Assigning a value to I18n.locale *looks* like a

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -6,8 +6,8 @@
 
 class PasswordResetsController < ApplicationController
   before_action :obtain_user, only: %i[edit update]
-  before_action :valid_user, only: %i[edit update]
-  before_action :check_expiration, only: %i[edit update]
+  before_action :require_valid_user, only: %i[edit update]
+  before_action :require_unexpired_reset, only: %i[edit update]
 
   def new; end
 
@@ -59,7 +59,7 @@ class PasswordResetsController < ApplicationController
   end
 
   # Confirms a valid user.
-  def valid_user
+  def require_valid_user
     unless @user&.activated? &&
            @user&.authenticated?(:reset, params[:id])
       redirect_to root_url
@@ -67,7 +67,7 @@ class PasswordResetsController < ApplicationController
   end
 
   # Checks expiration of reset token.
-  def check_expiration
+  def require_unexpired_reset
     return unless @user.password_reset_expired?
 
     flash[:danger] = t('password_resets.reset_expired')

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -16,10 +16,10 @@ class ProjectsController < ApplicationController
 
   before_action :set_project,
                 only: %i[edit update delete_form destroy show show_json]
-  before_action :logged_in?, only: :create
+  before_action :require_logged_in, only: :create
   before_action :can_edit_else_redirect, only: %i[edit update]
   before_action :can_control_else_redirect, only: %i[destroy delete_form]
-  before_action :adequate_deletion_rationale, only: :destroy
+  before_action :require_adequate_deletion_rationale, only: :destroy
   before_action :set_criteria_level, only: %i[show edit update]
 
   # Cache with Fastly CDN.  We can't use this header, because logged-in
@@ -335,7 +335,7 @@ class ProjectsController < ApplicationController
     redirect_to root_path
   end
 
-  def adequate_deletion_rationale
+  def require_adequate_deletion_rationale
     return true if current_user&.admin?
 
     deletion_rationale = params[:deletion_rationale]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
   # and other additional filters scheduled to run after it are cancelled.
   # See: http://guides.rubyonrails.org/action_controller_overview.html
   # Require being logged in for "index" to slightly discourage enumeration
-  before_action :logged_in_user, only: %i[edit update destroy index]
+  before_action :redir_unless_logged_in, only: %i[edit update destroy index]
   before_action :redir_unless_current_user_can_edit,
                 only: %i[edit update destroy]
   before_action :enable_maximum_privacy_headers
@@ -145,7 +145,7 @@ class UsersController < ApplicationController
     # private data.  However, we also want to be prepared so that
     # if there *is* a breach, we reduce its impact.
     # These lines instruct others to disable indexing and caching of
-    # user data, so that if private data is inadvertantly reviewed,
+    # user data, so that if private data is inadvertantly released,
     # it is much less likely to be easily available to others via
     # web-crawled data (such as from search engines) or via caches.
     # The goal is to make it harder for adversaries to get leaked data.
@@ -167,7 +167,7 @@ class UsersController < ApplicationController
   end
 
   # Confirms a logged-in user.
-  def logged_in_user
+  def redir_unless_logged_in
     return if logged_in?
 
     flash[:danger] = t('users.please_log_in')

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -70,6 +70,10 @@ module SessionsHelper
     !current_user.nil?
   end
 
+  def require_logged_in
+    throw(:abort) unless logged_in?
+  end
+
   def current_user_is_admin?
     logged_in? && current_user.admin?
   end

--- a/config/initializers/callback_terminator.rb
+++ b/config/initializers/callback_terminator.rb
@@ -7,7 +7,12 @@
 # Rails 5 changed how callback chains are interpreted. See:
 # https://blog.bigbinary.com/2016/02/13/
 # rails-5-does-not-halt-callback-chain-when-false-is-returned.html
-# For now, restore the old semantics, until we're confident that
-# things work with the new semantics.
+# In short, returning false DOES NOT stop the chain any more.
+# Rendering or redirecting still halts the chain (in development, this
+# produces a "Filter chain halted as .... rendered or redirected" message).
+# If you want to halt the chain, but do not render or redirect,
+# use this to halt the chain: throw(:abort)
 
-ActiveSupport.halt_callback_chains_on_return_false = true
+# Set the following to true to restore the old semantics,
+# but this is not supported in Rails 5.2+:
+# ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
Rails 5 changed how callback chains are interpreted. See:
https://blog.bigbinary.com/2016/02/13/
rails-5-does-not-halt-callback-chain-when-false-is-returned.html
In short, returning false DOES NOT stop the chain any more.
Rendering or redirecting still halts the chain (in development, this
produces a "Filter chain halted as .... rendered or redirected" message).
If you want to halt the chain, but do not render or redirect,
you can use this to halt the chain: throw(:abort)

This changes the code to throw an exception instead of just returning false,
and also renames several chain entries to make it clear that they
do NOT simply return a true/false value.
Thankfully, in almost all cases we were already invoking
render or redirect_to when we wanted to stop the chain.
Our negative testing also gives us confidence that the semantic change,
and this new code, isn't leading to a vulnerability.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>