### PR TITLE
Link to Prometheus on startpage is wrong

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -54,7 +54,7 @@
       <a href="<%= projects_dir %>/42" class="earner-logo">
         <%= image_tag 'project-logos/GitLab.png', width: 39, height: 48,
                       alt: 'GitLab', title: 'GitLab' %></a>
-      <a href="<%= projects_dir %>/i486" class="earner-logo">
+      <a href="<%= projects_dir %>/486" class="earner-logo">
         <%= image_tag 'project-logos/Prometheus.png', width: 41, height: 48,
                       alt: 'Prometheus', title: 'Prometheus' %></a>
       <a href="<%= projects_dir %>/112" class="earner-logo">


### PR DESCRIPTION
The link in the graphic "some badge earners" for Prometheus links to https://bestpractices.coreinfrastructure.org/en/projects/i486 instead of https://bestpractices.coreinfrastructure.org/en/projects/486 (i486 instead of 486).