### PR TITLE
Add hypertext link for seeing user data in JSON format

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -41,11 +41,11 @@
 
   <br><br>
   <p>
-  <a href="<%= user_path(@user, format: :json) %>"
-     title="<%= t '.in_json_format' %>"><%= t '.json_link' %></a>
   <% if @user.provider == 'github' && @user.nickname? %>
-   | <a href="https://github.com/<%= @user.nickname %>"><%=
-   t ('.see_external') %></a>
+   <a href="https://github.com/<%= @user.nickname %>"><%=
+   t('.see_external') %></a>
+  <% else %>
+   <%= t('.local_account') %>
   <% end %>
   <% if current_user && (@user == current_user || current_user.admin?) %>
     <% if @user.email? %>
@@ -56,6 +56,8 @@
                   @user, method: :delete,
                   data: { confirm: t('.confirm_delete') },
                   rel: 'nofollow' %>
+    | <a href="<%= user_path(@user, format: :json) %>"
+       title="<%= t '.in_json_format' %>"><%= t '.json_link' %></a>
   <% end %>
   <% if current_user&.admin? %>
     <% if @user.admin? %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -39,10 +39,12 @@
     <%= render 'projects/table', projects: @edit_projects %>
   <% end %>
 
+  <br><br>
+  <p>
+  <a href="<%= user_path(@user, format: :json) %>"
+     title="<%= t '.in_json_format' %>"><%= t '.json_link' %></a>
   <% if @user.provider == 'github' && @user.nickname? %>
-   <br><br>
-   <p>
-   <a href="https://github.com/<%= @user.nickname %>"><%=
+   | <a href="https://github.com/<%= @user.nickname %>"><%=
    t ('.see_external') %></a>
   <% end %>
   <% if current_user && (@user == current_user || current_user.admin?) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,7 +263,9 @@ en:
       projects_owned: 'Projects owned:'
       projects_additional_rights: 'Projects with additional rights:'
       other_projects_edit: 'Other editable projects per GitHub:'
-      see_external: See this user's external page.
+      json_link: JSON
+      in_json_format: User data in JSON format (a standard portable format)
+      see_external: User's external page.
       is_admin: This user is a badge application administrator.
       as_admin: 'as an admin, you may also:'
       send_email_to: 'Send email to:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -266,6 +266,7 @@ en:
       json_link: JSON
       in_json_format: User data in JSON format (a standard portable format)
       see_external: User's external page.
+      local_account: Custom (local) account
       is_admin: This user is a badge application administrator.
       as_admin: 'as an admin, you may also:'
       send_email_to: 'Send email to:'


### PR DESCRIPTION
The GDPR requires some sort of "portable format" for user data.
We have elected to provide this data in JSON format.
We've provided this data for some time, but the web page
didn't have a link to the JSON format.  It was *documented* how
to get this data in the API, but that's not the same thing.

This commit adds a hypertext link that makes it easy to see the
user data in JSON format.  Those who are not logged in, or are
logged in as a different non-logged-in user, will only receive the
*public* user data in JSON format.  This is just information such
as the public name, creation datetime, and last change datetime.
Logged-in users who look at their own data, and admins, will also see
in the JSON format the private data (which is currently the user email
address and preferred locale).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>