### PR TITLE
Encrypt email using attr_encrypted and blind_index gems

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 # rubocop:disable all
+# DO NOT PUT REAL SECRETS HERE
 # Development Badge App calls back to http://localhost:3000/auth/github
 export GITHUB_KEY = '17a26e63d809313d64dd'
 export GITHUB_SECRET = 'd7567231bee265358462176dca802e30479992f7'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,9 @@
 source 'https://rubygems.org'
 ruby File.open('.ruby-version', 'rb') { |f| f.read.chomp }
 
+gem 'attr_encrypted', '3.1.0' # Encrypt email addresses
 gem 'bcrypt', '3.1.12' # Security - for salted hashed interated passwords
+gem 'blind_index', '0.2.0' # Index encrypted email addresses
 gem 'bootstrap-sass', '3.3.7'
 gem 'bootstrap-social-rails', '4.12.0'
 gem 'bootstrap-will_paginate', '1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,11 +45,15 @@ GEM
       io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.4.0)
+    attr_encrypted (3.1.0)
+      encryptor (~> 3.0.0)
     autoprefixer-rails (8.5.0)
       execjs
     awesome_print (1.8.0)
     bcrypt (3.1.12)
     bindex (0.5.0)
+    blind_index (0.2.0)
+      activesupport (>= 4.2)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
     bootstrap-sass (3.3.7)
@@ -109,6 +113,7 @@ GEM
     dotenv-rails (2.4.0)
       dotenv (= 2.4.0)
       railties (>= 3.2, < 6.0)
+    encryptor (3.0.0)
     erubi (1.7.1)
     erubis (2.7.0)
     eslintrb (2.1.0)
@@ -424,8 +429,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  attr_encrypted (= 3.1.0)
   awesome_print (= 1.8.0)
   bcrypt (= 3.1.12)
+  blind_index (= 0.2.0)
   bootsnap (= 1.3.0)
   bootstrap-sass (= 3.3.7)
   bootstrap-social-rails (= 4.12.0)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -25,12 +25,24 @@ class UserMailer < ApplicationMailer
     end
   end
 
+  # Compute an array of valid destination email addresses, given an
+  # "email" value and a change_list for email.
+  # We'll try to add whatever valid email addresses we can find.
+  def find_destinations(email, changes)
+    destination = []
+    destination << email if email&.include?('@')
+    changes&.each do |entry|
+      destination << entry if entry&.include?('@')
+    end
+    destination
+  end
+
   def user_update(user, changes)
     @user = user
     @changes = changes
-    # If email changed, send to *both* email addresses (that way, if user
+    # If email changed, send to *all* email addresses (that way, if user
     # didn't approve this, the user will at least *see* the email change).
-    destination = changes['email'] ? changes['email'] : user.email
+    destination = find_destinations(user&.email, changes['email'])
     I18n.with_locale(user.preferred_locale.to_sym) do
       mail(
         to: destination,

--- a/app/views/projects/reminders_summary.html.erb
+++ b/app/views/projects/reminders_summary.html.erb
@@ -42,7 +42,8 @@ Here are the next projects scheduled for inactive reminders:
         <td><%= project.updated_at %></td>
         <td><%= project.last_reminder_at %></td>
         <td><%= project.badge_percentage_0 %>%</td>
-        <td><a href="mailto:<%= project.user_email %>"><%= project.user_email %></a></td>
+        <%# Email must be specially retrieved to decrypt it. %>
+        <td><%= User.find_by(id: project.user_id).email %></a></td>
         <td><%= 'OLD' if project.updated_at < 180.days.ago %></td>
       </tr>
     <% end %>
@@ -76,7 +77,7 @@ Here are the projects that have recently received reminders:
         <td><%= project.updated_at %></td>
         <td><%= project.last_reminder_at %></td>
         <td><%= project.badge_percentage_0 %>%</td>
-        <td><a href="mailto:<%= project.user_email %>"><%= project.user_email %></a></td>
+        <td><%= User(id: project.user_id).email %></a></td>
         <td><%= 'OLD' if project.updated_at < 180.days.ago %></td>
         <td><%= 'YES' if project.last_reminder_at < project.updated_at %></td>
       </tr>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -48,9 +48,14 @@
    <%= t('.local_account') %>
   <% end %>
   <% if current_user && (@user == current_user || current_user.admin?) %>
-    <% if @user.email? %>
-      | <a href="mailto:<%= CGI::escape(@user.email).html_safe %>"><%=
-        t('.send_email_to') + @user.email.to_s %></a>
+    <% if @user.encrypted_email?
+         begin
+           user_email = @user.email
+         rescue
+           user_email = 'CANNOT_DECRYPT'
+         end %>
+      | <a href="mailto:<%= CGI::escape(user_email).html_safe %>"><%=
+        t('.send_email_to') + user_email.to_s %></a>
     <% end %>
     | <%= link_to Icon[:'fa-times-circle'] + t('.delete_link_name'),
                   @user, method: :delete,

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -8,3 +8,4 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:email]

--- a/db/migrate/20180525145445_add_encrypted_email_to_users.rb
+++ b/db/migrate/20180525145445_add_encrypted_email_to_users.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class AddEncryptedEmailToUsers < ActiveRecord::Migration[5.1]
+  def change
+    # Hold onto the old data for a bit, because it's precious.
+    # Once we're confident things are okay, we'll delete this field
+    # in a separate operation.
+    rename_column :users, :email, :unencrypted_email
+
+    # Add columns to encrypt email addresses
+    add_column :users, :encrypted_email, :string
+    add_column :users, :encrypted_email_iv, :string
+
+    # Add columns for blind indexes of email addresses
+    add_column :users, :encrypted_email_bidx, :string
+    add_index :users, :encrypted_email_bidx
+    # The following replaces the old 'unique_local_email_hash'.
+    # For *local* accounts we must have *unique* email addresses - enforce
+    # this in the database system itself, to prevent race conditions.
+    add_index :users, :encrypted_email_bidx,
+              name: 'encrypted_email_local_unique_bidx',
+              unique: true,
+              where: "provider = 'local'"
+    # This is reversible, in the sense that we don't need to do anything
+    # special to undo it.
+    reversible do |dir|
+      dir.up do
+        # It would be *MUCH* faster to tell the database to
+        # directly calculate the new columns, like this:
+        # execute <<-SQL
+        # UPDATE users SET encrypted_email = ..., ... ;
+        # SQL
+        # However, that would require us to send the secret keys to the
+        # database, where they could be logged or recorded.  We expressly
+        # want to *never* send the database our secret keys.
+        # So we'll do a (slow) Ruby loop instead.
+        # This loop only happens once, during the migration, so it's
+        # not a big deal that it's slow, and find_each helps.
+        # Migrations on PostgreSQL happen within a transaction, so this
+        # is a one-time atomic operation.
+        User.reset_column_information # Ensure column info is current
+        User.find_each do |user|
+          next if user.unencrypted_email.blank? # skip if nothing to encrypt
+          user.name = '-' unless user.name? # Won't save if blank
+          user.email = user.unencrypted_email # encrypt & index the email
+          user.save!
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180218221750) do
+ActiveRecord::Schema.define(version: 20180525145445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -382,7 +382,7 @@ ActiveRecord::Schema.define(version: 20180218221750) do
     t.string "uid"
     t.string "name"
     t.string "nickname"
-    t.citext "email"
+    t.citext "unencrypted_email"
     t.string "password_digest"
     t.string "secret_token"
     t.string "validation_code"
@@ -397,10 +397,15 @@ ActiveRecord::Schema.define(version: 20180218221750) do
     t.datetime "reset_sent_at"
     t.string "preferred_locale", default: "en"
     t.datetime "last_login_at"
-    t.index ["email"], name: "index_users_on_email"
-    t.index ["email"], name: "unique_local_email", unique: true, where: "((provider)::text = 'local'::text)"
+    t.string "encrypted_email"
+    t.string "encrypted_email_iv"
+    t.string "encrypted_email_bidx"
+    t.index ["encrypted_email_bidx"], name: "encrypted_email_local_unique_bidx", unique: true, where: "((provider)::text = 'local'::text)"
+    t.index ["encrypted_email_bidx"], name: "index_users_on_encrypted_email_bidx"
     t.index ["last_login_at"], name: "index_users_on_last_login_at"
     t.index ["uid"], name: "index_users_on_uid"
+    t.index ["unencrypted_email"], name: "index_users_on_unencrypted_email"
+    t.index ["unencrypted_email"], name: "unique_local_email", unique: true, where: "((provider)::text = 'local'::text)"
   end
 
   create_table "versions", id: :serial, force: :cascade do |t|

--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -78,6 +78,16 @@ The application is configured by various environment variables:
   "production" or "fake_production". Plausible values are
   "debug", "info", and "warn". Default is "info". See:
   <http://guides.rubyonrails.org/debugging_rails_applications.html>
+* EMAIL_ENCRYPTION_KEY: Key to decrypt email addresses.
+  Hexadecimal string, must be 64 hex digits (==32 bytes==256 bits).
+  Used by aes-256-gcm (256-bit AES in GCM mode).
+* EMAIL_BLIND_INDEX_KEY: Key for blind index created for email
+  (used by PBKDF2-HMAC-SHA256).  Must be 64 hex digits (==32 bytes==256 bits).
+
+You can make cryptographically random values (such as keys)
+using "rails secret".  E.g., to create 64 random hexadecimal digits, use:
+
+>    rails secret | head -c64 ; echo
 
 This can be set on Heroku.  For example, to change the maximum number
 of email reminders to inactive projects on production-bestpractices:

--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -87,7 +87,7 @@ The application is configured by various environment variables:
 You can make cryptographically random values (such as keys)
 using "rails secret".  E.g., to create 64 random hexadecimal digits, use:
 
->    rails secret | head -c64 ; echo
+> rails secret | head -c64 ; echo
 
 This can be set on Heroku.  For example, to change the maximum number
 of email reminders to inactive projects on production-bestpractices:

--- a/doc/security.md
+++ b/doc/security.md
@@ -117,9 +117,9 @@ how we implement these requirements):
       so we don't need to keep those confidential.
     - Non-public data is kept confidential.
       User passwords and user email addresses are non-public data.
-      We *do* consider them higher-value assets and protect specially:
+      We *do* consider them higher-value assets and protect them specially:
         - User passwords are only stored on the server as
-          iterated salted hashes (using bcrypt).
+          iterated per-user salted hashes (using bcrypt).
         - Users may choose to "remember me" to automatically re-login on
           that specific browser if they use a local account.
           This is implemented using a
@@ -145,6 +145,24 @@ how we implement these requirements):
           Most of the rest of this document describes the
           measures we take to prevent turning unintentional mistakes
           into exposures of this data.
+        - We encrypt email addresses, to provide protection for data at rest,
+          and never provide the keys to the database system
+          (so someone who can only see what the database handles, or can
+          get a copy of it, will not see sensitive data including
+          raw passwords and unencrypted email addresses).
+          As discussed further in the section on "Encrypted email addresses",
+          we encrypt the email addresses using AES with 256-bit keys in
+          GCM mode ('aes-256-gcm').  We also hash the email addresses, so they
+          can be indexed, using the hashed key algorithm PBKDF2-HMAC-SHA256.
+          These are strong, well-tested algorithms.
+        - For each user account we store some other data.
+          Some we present to the public, such as creation and edit times.
+          We do not present the preferred locale to the public, under the
+          theory that we don't know of a reason someone else would
+          have a legitimate reason to know that.
+          However, this is not sensitive data and it is certainly
+          not identifying information, so we would not consider it a breach
+          if someone else got the "preferred locale" information.
         - HTTPS is used to encrypt all communications between users
           and the application; this protects the confidentiality of
           all data in motion.
@@ -1169,11 +1187,25 @@ even if an attacker can view the data within the database, that attacker
 will not receive sensitive information.
 Passwords are specially encrypted as passwords (per above),
 email addresses are encrypted (as described here), and almost all other
-data is considered public.
-We try to not reveal a user's preferred locale on general principle
-(who needs to know?), but that is not
-personally-identifying information and we would not consider it a
-security violation if that information were leaked.
+data is considered public or at least not sensitive.
+
+We work hard to comply with various privacy-related regulations,
+including the European General Data Protection Regulation (GDPR).
+We do not believe that encrypting email addresses is strictly
+required by the GDPR; we just need to prefer releasing private information.
+Still, we want to not just meet requirements, we want to exceed them.
+Encrypting email addresses makes it even harder for attackers to get this
+information, because it's encrypted at rest and not available by extracting
+data from the database system.
+
+First, it is useful to note why we encrypt just email addresses
+(and passwords), and not all data.
+Most obviously, almost all data we manage is public anyway.
+In addition,
+the easy ways to encrypt data aren't available to us. Transparent Data
+Encryption (TDE) is not a capability of PostgreSQL. Whole-database
+encryption can be done with other tricks but it is extremely expensive
+on Heroku.
 
 We encrypt emails using the Rails-specific approach outlined in
 ["Securing User Emails in Rails" by Andrew Kane (May 14, 2018)](https://shorts.dokkuapp.com/securing-user-emails-in-rails/).
@@ -1182,10 +1214,21 @@ gem 'blind_index' to index encrypted email addresses.
 This approach builds on standard general-purpose approaches for
 encrypting data and indexing the data, e.g., see
 ["How to Search on Securely Encrypted Database Fields" by By Scott Arciszewski](https://www.sitepoint.com/how-to-search-on-securely-encrypted-database-fields/).
+The important aspect here is that we encrypt the data (so it cannot be
+revealed by those without the encryption key),
+and we also create cryptographic keyed hashes of the data (so
+we can search on the data if we have the hash key).
+The latter value is called a "blind index".
 
 We encrypt the email addresses using AES with 256-bit keys in
 GCM mode ('aes-256-gcm').  We also hash the email addresses, so they
 can be indexed, using the hashed key algorithm PBKDF2-HMAC-SHA256.
+The hashes are of email addresses after they've been downcased;
+that supports case-insensitive searching for email addresses.
+
+Implementation note: the indexes created by blind_index always
+end in a newline.  That doesn't matter for security, but it can cause
+debugging problems if you weren't expecting that.
 
 Note that 'attr_encrypted' depends on the gem 'encryptor'.
 Encryptor version 2.0.0 had a

--- a/doc/security.md
+++ b/doc/security.md
@@ -1160,6 +1160,46 @@ these attempt to thwart or slow attack even if the system has a vulnerability.
     of emails we will send out each time; this keeps us from looking like
     a spammer.
 
+#### Encrypted email addresses
+
+We encrypt email addresses within the database, and never
+send the descryption or index keys to the database.
+This provides protection of this data at rest, and also means that
+even if an attacker can view the data within the database, that attacker
+will not receive sensitive information.
+Passwords are specially encrypted as passwords (per above),
+email addresses are encrypted (as described here), and almost all other
+data is considered public.
+We try to not reveal a user's preferred locale on general principle
+(who needs to know?), but that is not
+personally-identifying information and we would not consider it a
+security violation if that information were leaked.
+
+We encrypt emails using the Rails-specific approach outlined in
+["Securing User Emails in Rails" by Andrew Kane (May 14, 2018)](https://shorts.dokkuapp.com/securing-user-emails-in-rails/).
+We use the gem 'attr_encrypted' to encrypt email addresses, and
+gem 'blind_index' to index encrypted email addresses.
+This approach builds on standard general-purpose approaches for
+encrypting data and indexing the data, e.g., see
+["How to Search on Securely Encrypted Database Fields" by By Scott Arciszewski](https://www.sitepoint.com/how-to-search-on-securely-encrypted-database-fields/).
+
+We encrypt the email addresses using AES with 256-bit keys in
+GCM mode ('aes-256-gcm').  We also hash the email addresses, so they
+can be indexed, using the hashed key algorithm PBKDF2-HMAC-SHA256.
+
+Note that 'attr_encrypted' depends on the gem 'encryptor'.
+Encryptor version 2.0.0 had a
+[major security bug when using AES-*-GCM algorithms](https://github.com/attr-encrypted/encryptor/pull/22).
+We do not use that version, but instead use
+a newer version that does not have that vulnerability.
+Some old documentation recommends using
+'attr_encryptor' instead because of this vulnerability, but the
+vulnerability has since been fixed and
+'attr_encryptor' is no longer maintained.
+Vulnerabilities are never a great sign, but we do take it as a good sign
+that the developers of encryptor were willing to make a breaking change
+to fix a security vulnerabilities.
+
 ### Making adjustments
 
 We want to counter all common vulnerabilities, not just those

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,6 +1,10 @@
 # Read about fixtures at:
 # http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 #
+# We vary the user email address domains (some have .com, some have .org)
+# on the general principle that we should vary test values;
+# they don't have any particular meaning.
+#
 # We encrypt user email addresses. For test purposes, we used a fixed
 # encryption IV (don't do this with real data), and provide precomputed
 # values for "encrypted_email" and "encrypted_email_bidx".  There's
@@ -17,6 +21,28 @@
 # x = User.new; x.email = 'test@example.org'; x.compute_email_bidx
 # This assumes that you're using the usual (default) test keys.
 #
+# Here it is all together:
+# puts('  encrypted_email_iv: "G4fbeClWL3aFMY9I"')
+# puts('  encrypted_email: ' + User.encrypt_email(current_email,
+#      iv: Base64.decode64('G4fbeClWL3aFMY9I')).inspect)
+# puts('  encrypted_email_bidx: ' + BlindIndex.generate_bidx(
+#       current_email, User.blind_indexes[:email]).inspect)
+#
+# Here are some additional encryptions if you need them:
+# current_email = 'mark@example.org'
+# encrypted_email_iv: "G4fbeClWL3aFMY9I"
+# encrypted_email: "0LWldZP1iahMHmhaQwjU9g27hpaNo56iCfMNh+ZsERg=\n"
+# encrypted_email_bidx: "C/0XJyW8Xitx19MPv1j8B65iNOaykMLZnMZ/TctNp3U=\n"
+#
+# current_email = 'forgetful@example.org'
+# encrypted_email_iv: "G4fbeClWL3aFMY9I"
+# encrypted_email: "27ulebbkl7xNLmFHDArW/ZzHIFjaYveE2hxJl2Kxdk2/rm4xXw==\n"
+# encrypted_email_bidx: "0SHo5Lc+XTrcY6HvouDwAIvEdy+8odILw9DP3MGXMfM=\n"
+#
+# current_email = 'admin@example.org'
+# encrypted_email: "3LC6d73QlLFAA3RTCEnJ455qaUF28kYI7ZOGoIDUhkzm\n"
+# encrypted_email_iv: "G4fbeClWL3aFMY9I"
+# encrypted_email_bidx: "yspd41bZJvT9bn0MQXU2l2dnhpZTIKpf0u46w6+qf1U=\n"
 
 # current_email = 'test@example.org'
 test_user:
@@ -30,36 +56,36 @@ test_user:
   activated: true
   activated_at: <%= Time.zone.now %>
 
-# current_email = 'melissa@example.org'
+# current_email = 'melissa@example.com'
 test_user_melissa:
   name: Melissa Lewis
-  encrypted_email: "0LG7d6DjkIlEFmVSHQvDv5abKJMMkBPFsdaOpyO/5Av6b1M=\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  encrypted_email_bidx: "YHiTbwhse+wm3w96DeNAXuKEeyt3dzlGV7BSjLjfUtg=\n"
+  encrypted_email: "0LG7d6DjkIlEFmVSHQvDv5qGImt+oNOl9LLibPvLAwHeWmo=\n"
+  encrypted_email_bidx: "ip6E/EM+EYkbzsRm6ZTprRg4PTsN/T5xY9E80U3Hlfo=\n"
   password_digest: <%= User.digest('password1') %>
   provider: local
   preferred_locale: en
   activated: true
   activated_at: <%= Time.zone.now %>
 
-# current_email = 'mark@example.org'
+# current_email = 'mark@example.com'
 test_user_mark:
   name: Mark Watney
-  encrypted_email: "0LWldZP1iahMHmhaQwjU9g27hpaNo56iCfMNh+ZsERg=\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  encrypted_email_bidx: "C/0XJyW8Xitx19MPv1j8B65iNOaykMLZnMZ/TctNp3U=\n"
+  encrypted_email: "0LWldZP1iahMHmhaQwTJ/JxzMJME5stBTXCm7WcmYyg=\n"
+  encrypted_email_bidx: "aZpkg4oEr8KjacLrZINGN1JRGD1caIWoWUTM57KOePk=\n"
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
   activated: true
   activated_at: <%= Time.zone.now %>
 
-# current_email = 'forgetful@example.org'
+# current_email = 'forgetful@example.com'
 test_user_not_active:
   name: Forgetful
-  encrypted_email: "27ulebbkl7xNLmFHDArW/ZzHIFjaYveE2hxJl2Kxdk2/rm4xXw==\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  encrypted_email_bidx: "0SHo5Lc+XTrcY6HvouDwAIvEdy+8odILw9DP3MGXMfM=\n"
+  encrypted_email: "27ulebbkl7xNLmFHDArW/ZzHLEXQQHbOqCyJ9yfVGoZn2ok7ew==\n"
+  encrypted_email_bidx: "nRtJqO5uutJ7Z/HcjLHM/jt3cA++pN1t85URKscQfsQ=\n"
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
@@ -68,8 +94,8 @@ test_user_not_active:
 # current_email = 'CaseSensitive@example.org'
 test_user_cs:
   name: Case Sensitive
-  encrypted_email: "/rWke4D1n7pIGm1JCCfD6ZiEP0bY51bxymIp4AvOLZGyoX8ln1EALDc=\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
+  encrypted_email: "/rWke4D1n7pIGm1JCCfD6ZiEP0bY51bxymIp4AvOLZGyoX8ln1EALDc=\n"
   encrypted_email_bidx: "+rRkCLpeIVcfwtPu+Jy6YyXtksI/w3frgdSu8J4kR2M=\n"
   password_digest: <%= User.digest('password') %>
   provider: local
@@ -77,12 +103,12 @@ test_user_cs:
   activated: true
   activated_at: <%= Time.zone.now %>
 
-# current_email = 'admin@example.org'
+# current_email = 'admin@example.com'
 admin_user:
   name: Admin
-  encrypted_email: "3LC6d73QlLFAA3RTCEnJ455qaUF28kYI7ZOGoIDUhkzm\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  encrypted_email_bidx: "yspd41bZJvT9bn0MQXU2l2dnhpZTIKpf0u46w6+qf1U=\n"
+  encrypted_email: "3LC6d73QlLFAA3RTCEnF/pQPuTWBDzfZWpDX1TJ+bsBO\n"
+  encrypted_email_bidx: "PH39U8dihphvLTlLEwJWXdy2OLz477WOn/DNsZaHqfE=\n"
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
@@ -90,13 +116,13 @@ admin_user:
   activated_at: <%= Time.zone.now %>
   role: admin
 
-# current_email = 'github-user@example.org'
+# current_email = 'github-user@example.com'
 github_user:
   name: GitHub The User
   nickname: github-user
-  encrypted_email: "2r2jdqby3LxSC3Z/CB/H/ImFKgTSu16xi1y/444M1k6yTn4sKLLl\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  encrypted_email_bidx: "8Eqc0l8ZjhA2Z6w/SIuZyWhZesmYiKZXgnTqqaKhWew=\n"
+  encrypted_email: "2r2jdqby3LxSC3Z/CB/H/ImFKgTeplS8IDY+qfw8Fi73KhLn8MYC\n"
+  encrypted_email_bidx: "Vyiu7EdbDXioCgMAVIWqLHyBH148S9JcSspSWq6nPN8=\n"
   password_digest: <%= User.digest('password') %>
   provider: github
   preferred_locale: en

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,7 +3,12 @@
 #
 # We vary the user email address domains (some have .com, some have .org)
 # on the general principle that we should vary test values;
-# they don't have any particular meaning.
+# they don't have any particular meaning.  Make sure they match the tests!
+#
+# WARNING: The encrypted_email_bidx *MUST* end in newline, because that
+# is the format created (and required) by the gem blind_index.
+# The encrypted_email also ends in newline, but that's just because the
+# gem attr_encrypted does that (it's not actually required).
 #
 # We encrypt user email addresses. For test purposes, we used a fixed
 # encryption IV (don't do this with real data), and provide precomputed

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,7 +2,10 @@
 
 test_user:
   name: Test
-  email: test@example.org
+  encrypted_email: <%= User.encrypt_email('test@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email_iv: "G4fbeClWL3aFMY9I"
+  # Need to compute_email_bidx - this is ugly but works
+  encrypted_email_bidx: <%= x = User.new; x.email = 'test@example.org'; x.compute_email_bidx %>
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
@@ -11,7 +14,9 @@ test_user:
 
 test_user_melissa:
   name: Melissa Lewis
-  email: melissa@example.com
+  encrypted_email: <%= User.encrypt_email('melissa@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email_iv: "G4fbeClWL3aFMY9I"
+  encrypted_email_bidx: <%= x = User.new; x.email = 'melissa@example.org'; x.compute_email_bidx %>
   password_digest: <%= User.digest('password1') %>
   provider: local
   preferred_locale: en
@@ -20,7 +25,9 @@ test_user_melissa:
 
 test_user_mark:
   name: Mark Watney
-  email: mark@example.com
+  encrypted_email: <%= User.encrypt_email('mark@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email_iv: "G4fbeClWL3aFMY9I"
+  encrypted_email_bidx: <%= x = User.new; x.email = 'mark@example.org'; x.compute_email_bidx %>
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
@@ -29,7 +36,9 @@ test_user_mark:
 
 test_user_not_active:
   name: Forgetful
-  email: forgetful@example.com
+  encrypted_email: <%= User.encrypt_email('forgetful@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email_iv: "G4fbeClWL3aFMY9I"
+  encrypted_email_bidx: <%= x = User.new; x.email = 'forgetful@example.org'; x.compute_email_bidx %>
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
@@ -37,7 +46,9 @@ test_user_not_active:
 
 test_user_cs:
   name: Case Sensitive
-  email: CaseSensitive@example.org
+  encrypted_email: <%= User.encrypt_email('CaseSensitive@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email_iv: "G4fbeClWL3aFMY9I"
+  encrypted_email_bidx: <%= x = User.new; x.email = 'CaseSensitive@example.org'; x.compute_email_bidx %>
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
@@ -46,7 +57,9 @@ test_user_cs:
 
 admin_user:
   name: Admin
-  email: admin@example.com
+  encrypted_email: <%= User.encrypt_email('admin@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email_iv: "G4fbeClWL3aFMY9I"
+  encrypted_email_bidx: <%= x = User.new; x.email = 'admin@example.org'; x.compute_email_bidx %>
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
@@ -57,7 +70,9 @@ admin_user:
 github_user:
   name: GitHub The User
   nickname: github-user
-  email: github-user@example.com
+  encrypted_email: <%= User.encrypt_email('github-user@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email_iv: "G4fbeClWL3aFMY9I"
+  encrypted_email_bidx: <%= x = User.new; x.email = 'github-user@example.org'; x.compute_email_bidx %>
   password_digest: <%= User.digest('password') %>
   provider: github
   preferred_locale: en
@@ -66,7 +81,9 @@ github_user:
 
 fr_user:
   name: French Test
-  email: fr-test@example.org
+  encrypted_email: <%= User.encrypt_email('fr-test@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email_iv: "G4fbeClWL3aFMY9I"
+  encrypted_email_bidx: <%= x = User.new; x.email = 'fr-test@example.org'; x.compute_email_bidx %>
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: fr

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,65 +1,88 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# Read about fixtures at:
+# http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+#
+# We encrypt user email addresses. For test purposes, we used a fixed
+# encryption IV (don't do this with real data), and provide precomputed
+# values for "encrypted_email" and "encrypted_email_bidx".  There's
+# lot of infrastructure that has to work to compute these values, and they
+# take time to compute, so providing precomputed values makes sense.
+# To find values for new email addresses, run "rails console" and then:
+# encrypted_email_iv: "G4fbeClWL3aFMY9I"
+# encrypted_email:
+#   User.encrypt_email('test@example.org',
+#                       iv: Base64.decode64('G4fbeClWL3aFMY9I'))
+# encrypted_email_bidx:
+#   BlindIndex.generate_bidx("test@example.org", User.blind_indexes[:email])
+# An alternative approach is to create a stub user:
+# x = User.new; x.email = 'test@example.org'; x.compute_email_bidx
+# This assumes that you're using the usual (default) test keys.
+#
 
+# current_email = 'test@example.org'
 test_user:
   name: Test
-  encrypted_email: <%= User.encrypt_email('test@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  # Need to compute_email_bidx - this is ugly but works
-  encrypted_email_bidx: <%= x = User.new; x.email = 'test@example.org'; x.compute_email_bidx %>
+  encrypted_email: "ybGkapP1iahMHmhaQwjU9qTfGB7w/KCFTiUGkIVZZ08=\n"
+  encrypted_email_bidx: "hEghi+qNCA63qDAuTIq8jBWtOweoQ33EstwMnvM3/gk=\n"
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
   activated: true
   activated_at: <%= Time.zone.now %>
 
+# current_email = 'melissa@example.org'
 test_user_melissa:
   name: Melissa Lewis
-  encrypted_email: <%= User.encrypt_email('melissa@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email: "0LG7d6DjkIlEFmVSHQvDv5abKJMMkBPFsdaOpyO/5Av6b1M=\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  encrypted_email_bidx: <%= x = User.new; x.email = 'melissa@example.org'; x.compute_email_bidx %>
+  encrypted_email_bidx: "YHiTbwhse+wm3w96DeNAXuKEeyt3dzlGV7BSjLjfUtg=\n"
   password_digest: <%= User.digest('password1') %>
   provider: local
   preferred_locale: en
   activated: true
   activated_at: <%= Time.zone.now %>
 
+# current_email = 'mark@example.org'
 test_user_mark:
   name: Mark Watney
-  encrypted_email: <%= User.encrypt_email('mark@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email: "0LWldZP1iahMHmhaQwjU9g27hpaNo56iCfMNh+ZsERg=\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  encrypted_email_bidx: <%= x = User.new; x.email = 'mark@example.org'; x.compute_email_bidx %>
+  encrypted_email_bidx: "C/0XJyW8Xitx19MPv1j8B65iNOaykMLZnMZ/TctNp3U=\n"
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
   activated: true
   activated_at: <%= Time.zone.now %>
 
+# current_email = 'forgetful@example.org'
 test_user_not_active:
   name: Forgetful
-  encrypted_email: <%= User.encrypt_email('forgetful@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email: "27ulebbkl7xNLmFHDArW/ZzHIFjaYveE2hxJl2Kxdk2/rm4xXw==\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  encrypted_email_bidx: <%= x = User.new; x.email = 'forgetful@example.org'; x.compute_email_bidx %>
+  encrypted_email_bidx: "0SHo5Lc+XTrcY6HvouDwAIvEdy+8odILw9DP3MGXMfM=\n"
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
   activated: false
 
+# current_email = 'CaseSensitive@example.org'
 test_user_cs:
   name: Case Sensitive
-  encrypted_email: <%= User.encrypt_email('CaseSensitive@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email: "/rWke4D1n7pIGm1JCCfD6ZiEP0bY51bxymIp4AvOLZGyoX8ln1EALDc=\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  encrypted_email_bidx: <%= x = User.new; x.email = 'CaseSensitive@example.org'; x.compute_email_bidx %>
+  encrypted_email_bidx: "+rRkCLpeIVcfwtPu+Jy6YyXtksI/w3frgdSu8J4kR2M=\n"
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
   activated: true
   activated_at: <%= Time.zone.now %>
 
+# current_email = 'admin@example.org'
 admin_user:
   name: Admin
-  encrypted_email: <%= User.encrypt_email('admin@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email: "3LC6d73QlLFAA3RTCEnJ455qaUF28kYI7ZOGoIDUhkzm\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  encrypted_email_bidx: <%= x = User.new; x.email = 'admin@example.org'; x.compute_email_bidx %>
+  encrypted_email_bidx: "yspd41bZJvT9bn0MQXU2l2dnhpZTIKpf0u46w6+qf1U=\n"
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: en
@@ -67,23 +90,25 @@ admin_user:
   activated_at: <%= Time.zone.now %>
   role: admin
 
+# current_email = 'github-user@example.org'
 github_user:
   name: GitHub The User
   nickname: github-user
-  encrypted_email: <%= User.encrypt_email('github-user@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email: "2r2jdqby3LxSC3Z/CB/H/ImFKgTSu16xi1y/444M1k6yTn4sKLLl\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  encrypted_email_bidx: <%= x = User.new; x.email = 'github-user@example.org'; x.compute_email_bidx %>
+  encrypted_email_bidx: "8Eqc0l8ZjhA2Z6w/SIuZyWhZesmYiKZXgnTqqaKhWew=\n"
   password_digest: <%= User.digest('password') %>
   provider: github
   preferred_locale: en
   activated: true
   activated_at: <%= Time.zone.now %>
 
+# current_email = 'fr-test@example.org'
 fr_user:
   name: French Test
-  encrypted_email: <%= User.encrypt_email('fr-test@example.org', iv: Base64.decode64('G4fbeClWL3aFMY9I')) %>
+  encrypted_email: "26b6arbjhYlEFmVSHQvDv5abKOzHp6ZN4HPtuqnxJkbq84I=\n"
   encrypted_email_iv: "G4fbeClWL3aFMY9I"
-  encrypted_email_bidx: <%= x = User.new; x.email = 'fr-test@example.org'; x.compute_email_bidx %>
+  encrypted_email_bidx: "7e3Bzzf0T1HnQKICsDEqJGosonRFiZZNtN445wgNDYU=\n"
   password_digest: <%= User.digest('password') %>
   provider: local
   preferred_locale: fr


### PR DESCRIPTION
This commit encrypts email using two gems,
attr_encrypted and blind_index, that are designed
specifically for this purpose.

At this point many tests don't pass for unknown reasons.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>