### PR TITLE
DO NOT MERGE: Enable git login when the email keys aren't available

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -54,11 +54,7 @@ class SessionsController < ApplicationController
 
     # Record last_login_at time
     user.last_login_at = Time.now.utc
-    begin
-      user.save!
-    rescue OpenSSL::Cipher::CipherError # Keep running if we can't decrypt
-      logger.info("CipherError while saving user id #{user.id}")
-    end
+    user.save_skip_decryption_errors!
   end
   # rubocop: enable Metrics/MethodLength
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -42,7 +42,6 @@ class SessionsController < ApplicationController
   private
 
   # Perform tasks for a user who just successfully logged in.
-  # rubocop: disable Metrics/MethodLength
   def successful_login(user)
     log_in user
     redirect_back_or root_url
@@ -56,7 +55,6 @@ class SessionsController < ApplicationController
     user.last_login_at = Time.now.utc
     user.save_skip_decryption_errors!
   end
-  # rubocop: enable Metrics/MethodLength
 
   # We want to save the forwarding url of a session but
   # still need to counter session fixation,  this does it

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -42,6 +42,7 @@ class SessionsController < ApplicationController
   private
 
   # Perform tasks for a user who just successfully logged in.
+  # rubocop: disable Metrics/MethodLength
   def successful_login(user)
     log_in user
     redirect_back_or root_url
@@ -53,8 +54,13 @@ class SessionsController < ApplicationController
 
     # Record last_login_at time
     user.last_login_at = Time.now.utc
-    user.save!
+    begin
+      user.save!
+    rescue OpenSSL::Cipher::CipherError # Keep running if we can't decrypt
+      logger.info("CipherError while saving user id #{user.id}")
+    end
   end
+  # rubocop: enable Metrics/MethodLength
 
   # We want to save the forwarding url of a session but
   # still need to counter session fixation,  this does it

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -229,11 +229,9 @@ class User < ApplicationRecord
   # We do this so we can have functionality (though reduced) without
   # the email keys.
   def save_skip_decryption_errors!
-    begin
-      save!
-    rescue OpenSSL::Cipher::CipherError
-      logger.info("CipherError while saving user id #{id}")
-    end
+    save!
+  rescue OpenSSL::Cipher::CipherError
+    logger.info("CipherError while saving user id #{id}")
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -225,6 +225,17 @@ class User < ApplicationRecord
     response.code == 200
   end
 
+  # Save, but skip errors caused by decryption key failures.
+  # We do this so we can have functionality (though reduced) without
+  # the email keys.
+  def save_skip_decryption_errors!
+    begin
+      save!
+    rescue OpenSSL::Cipher::CipherError
+      logger.info("CipherError while saving user id #{id}")
+    end
+  end
+
   private
 
   # Creates and assigns the activation token and digest.


### PR DESCRIPTION
Enable git login when the email keys aren't available.

This makes it easier to test the system without making
the email keys available.  That's a good thing, because
the more activities that don't require the keys, the
easier it is to protect those keys.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>