### PR TITLE
Enable git login when the email keys aren't available (simpler way)

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -51,9 +51,13 @@ class SessionsController < ApplicationController
     last_login = t('sessions.no_login_time') if last_login.blank?
     flash[:success] = t('sessions.signed_in', last_login_at: last_login)
 
-    # Record last_login_at time
-    user.last_login_at = Time.now.utc
-    user.save!
+    # Record last_login_at time.  We use update_columns because
+    # it works even if we don't have the correct email decryption keys,
+    # and so it won't change updated_at (so updated_at becomes more useful).
+    # We don't need the model validations, we're just setting a timestamp.
+    # rubocop: disable Rails/SkipsModelValidations
+    user.update_columns(last_login_at: Time.now.utc)
+    # rubocop: enable Rails/SkipsModelValidations
   end
 
   # We want to save the forwarding url of a session but


### PR DESCRIPTION
Enable git login when the email keys aren't available.

This makes it easier to test the system without making
the email keys available. That's a good thing, because
the more activities that don't require the keys, the
easier it is to protect those keys.

I had previously done this by rescuing the exception
raised if OpenSSL can't decrypt things, and then I had
to test that case, etc.

This commit instead does something much simpler:
instead of save!, just use update_columns.
Then there's no need to decrypt anything, so there's no error
to be triggered in the first place.  It also means that
we don't change the updated_at value of users merely when
they log in, which seems like a more appropriate use of
updated_at.  Now update_at is still changed when user-visible
data changes (such as the email address or locale preference),
but not for something as ephermeral as the last login time
(which is stored as a separate value anyway).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>