### PR TITLE
Run fix_use_gravatar 1/month

### DIFF
--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -654,7 +654,7 @@ end
 # rubocop:enable Style/Send
 
 desc 'Run monthly tasks (called from "daily")'
-task monthly: %i[environment monthly_announcement] do
+task monthly: %i[environment monthly_announcement fix_use_gravatar] do
 end
 
 # Run this task periodically if we want to test the


### PR DESCRIPTION
Run fix_use_gravatar 1/month, so that if users remove or add
a gravatar, but don't tell us, we'll eventually figure it out.

Heroku scheduler's built-in capability only lets us
schedule things hourly or daily, so we can't set it up directly
in the Heroku scheduler.  But that's not a problem, because
we already have a mechanism built on that to run monthly...
so let's just use that.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>