### PR TITLE
Add more fields to exported JSON user data

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -150,6 +150,12 @@ class User < ApplicationRecord
     UserMailer.github_welcome(self).deliver_now
   end
 
+  def email_if_decryptable
+    email
+  rescue OpenSSL::Cipher::CipherError
+    'CANNOT_DECRYPT'
+  end
+
   def admin?
     role == 'admin'
   end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -49,11 +49,8 @@
   <% end %>
   <% if current_user && (@user == current_user || current_user.admin?) %>
     <% if @user.encrypted_email?
-         begin
-           user_email = @user.email
-         rescue
-           user_email = 'CANNOT_DECRYPT'
-         end %>
+         user_email = @user.email_if_decryptable
+    %>
       | <a href="mailto:<%= CGI::escape(user_email).html_safe %>"><%=
         t('.send_email_to') + user_email.to_s %></a>
     <% end %>

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -13,6 +13,11 @@ json.call(
 if @user == current_user || current_user&.admin?
   json.preferred_locale @user.preferred_locale
   json.email @user.email
+  json.activated
+  json.activated_at
+  json.reset_sent_at
+  json.last_login_at
+  json.use_gravatar
 end
 # We currently don't show @projects, @projects_additional_rights, or
 # @edit_projects. That might change in the future.

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -8,16 +8,24 @@
 json.call(
   @user, :id, :name, :nickname, :uid, :provider, :created_at, :updated_at
 )
+# This is an array of the project ids this user owns.
+json.projects @user.projects.pluck(:id)
+# Generate { project1.id: ['edit'], project2.id: ['edit'], ...}.
+# We generate this format in case there's more than 1 right in the future.
+# We could use @user.additional_rights.pluck(:id) instead, but we've
+# already calculated it so there's no point in doing it twice.
+json.additional_rights(
+  @projects_additional_rights.pluck(:id).each_with_object({}) do |p, result|
+    result[p] = ['edit']
+  end
+)
+#
 # current user or admin can see more
 # Do NOT cache this server-side, since this includes the email address
 if @user == current_user || current_user&.admin?
   json.preferred_locale @user.preferred_locale
-  json.email @user.email
-  json.activated
-  json.activated_at
-  json.reset_sent_at
-  json.last_login_at
-  json.use_gravatar
+  json.email @user.email_if_decryptable
+  json.call(@user, :activated, :activated_at, :reset_sent_at)
+  json.call(@user, :last_login_at)
+  json.call(@user, :use_gravatar)
 end
-# We currently don't show @projects, @projects_additional_rights, or
-# @edit_projects. That might change in the future.

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -115,4 +115,14 @@ class UserTest < ActiveSupport::TestCase
     assert_match(/\$2a\$/, User.digest('foobar'))
     ActiveModel::SecurePassword.min_cost = true
   end
+
+  test 'Test user.email_if_decryptable when not decryptable' do
+    class StubUser < User
+      def email
+       raise OpenSSL::Cipher::CipherError
+      end
+    end
+    u = StubUser.new
+    assert_equal 'CANNOT_DECRYPT', u.email_if_decryptable
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -119,7 +119,7 @@ class UserTest < ActiveSupport::TestCase
   test 'Test user.email_if_decryptable when not decryptable' do
     class StubUser < User
       def email
-       raise OpenSSL::Cipher::CipherError
+        raise OpenSSL::Cipher::CipherError
       end
     end
     u = StubUser.new


### PR DESCRIPTION
GDPR's "data portability" requirements require that we
provide users our data about them in a portable way.
We provide data in JSON format.  This commit adds a few
much-less useful fields, with the goal of providing
everything we reasonably can.  We don't want to share
digests, since in some circumstances those are like passwords
and they are randomly generated anyway.

That said, we can provide these, so let's do so:

*  json.activated
*  json.activated_at
*  json.reset_sent_at
*  json.last_login_at
*  json.use_gravatar

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>