### PR TITLE
Add rake task mass_email (e.g., for GDPR compliance)

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -62,4 +62,16 @@ class UserMailer < ApplicationMailer
       )
     end
   end
+
+  def direct_message(user, subject, body)
+    @user = user
+    @subject = subject
+    @body = body
+    I18n.with_locale(user.preferred_locale.to_sym) do
+      mail(
+        to: user.email,
+        subject: subject
+      )
+    end
+  end
 end

--- a/app/views/user_mailer/direct_message.text.erb
+++ b/app/views/user_mailer/direct_message.text.erb
@@ -1,0 +1,2 @@
+<%# We do not try to localize in this case - we assume we're in a hurry. -%>
+<%= raw @body %>

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -657,6 +657,23 @@ desc 'Run monthly tasks (called from "daily")'
 task monthly: %i[environment monthly_announcement fix_use_gravatar] do
 end
 
+# Send a mass email, subject MASS_EMAIL_SUBJECT, body MASS_EMAIL_BODY.
+# If you set MASS_EMAIL_WHERE, only matching records will be emailed.
+# We send *separate* emails for each user, so that users won't be able
+# to learn of each other's email addresses.
+# We do *NOT* try to localize, for speed.
+desc 'Send a mass email (e.g., a required GDPR notification)'
+task :mass_email do
+  subject = ENV['MASS_EMAIL_SUBJECT']
+  body = ENV['MASS_EMAIL_BODY']
+  where_condition = ENV['MASS_EMAIL_WHERE'] || 'true'
+  raise if !subject || !body
+  User.where(where_condition).find_each do |u|
+    UserMailer.direct_message(u, subject, body).deliver_now
+    Rails.logger.info "Mass notification sent to user id #{u.id}"
+  end
+end
+
 # Run this task periodically if we want to test the
 # install-badge-dev-environment script
 desc 'check that install-badge-dev-environment works'

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -33,4 +33,10 @@ class UserMailerTest < ActionMailer::TestCase
     assert_match user.reset_token, mail.parts[0].body.to_s
     assert_match CGI.escape(user.email), mail.body.encoded
   end
+
+  test 'direct_message' do
+    mail = UserMailer.direct_message(User.first, 'Dummy subject', 'Dummy body')
+    assert_equal 'Dummy subject', mail.subject
+    assert_equal [User.first.email], mail.to
+  end
 end


### PR DESCRIPTION
Sometime we may need to contact users QUICKLY.  For example,
the GDPR requires user notification within 72 hours in some cases.

This commit adds a new rake task to do a mass email.
You set the subject, body, and condition via environment variables,
and then trigger the rake task.  This means that you do NOT
need to upload any code changes to send the mass email.

The implementation in this commit focuses on
being the "minimum viable product" that gets the job done.
This is NOT a user-visible function,
and changing it will only affect system administrators,
so changing the interface is no big deal.
We could add other features later, like HTML and internationalization.

This doesn't support HTML emails.  The point is to send a
relatively simple message quickly, so there's no need to complicate
things by including HTML.

This doesn't support internationalization.  In the expected use cases
we won't have time to get many or any translations done, and if we
do have some translations done, we can just include
ALL the available translations in a single body.

We hope that we will never need to use this task, but
it's best to be prepared.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>