### PR TITLE
Add a task to allow rekeying of email addresses

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -185,6 +185,26 @@ class User < ApplicationRecord
     reset_sent_at < 2.hours.ago
   end
 
+  # Rekey (change the key of) the email address of the user, given the old key.
+  # Note that this will reset the IV, since we do *NOT* want to reuse IVs.
+  # This does not SAVE the user data - do a save afterwards if you want that!
+  # This will raise an exception if the old key doesn't work.
+  def rekey(old_key)
+    return if encrypted_email_iv.blank? || encrypted_email.blank?
+    old_iv = Base64.decode64(encrypted_email_iv)
+    # Get the old email address; this will raise an exception if the
+    # given key is wrong.
+    old_email_address = User.decrypt_email(
+      encrypted_email, iv: old_iv, key: old_key
+    )
+    # Change to new email address; this creates a new IV, re-encrypts,
+    # and recalculates the blind index using the current blind index key.
+    # This deals with a quirk of attr_encrypted: You have to set the
+    # old encrypted_mail value to nil before you can force a re-encrypt.
+    self.encrypted_email = nil
+    self.email = old_email_address
+  end
+
   GRAVATAR_PREFIX = 'https://secure.gravatar.com/avatar/'
 
   # Return URL for an image suitable for doing a lookup on gravatar

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -6,6 +6,7 @@
 
 require 'test_helper'
 
+# rubocop:disable Metrics/ClassLength
 class UserTest < ActiveSupport::TestCase
   setup do
     @user = User.new(
@@ -84,6 +85,31 @@ class UserTest < ActiveSupport::TestCase
     assert_not @user.valid?
   end
 
+  test 'rekey test' do
+    # This is a somewhat complicated setup to create a user with an old key.
+    # We don't bother setting up an old blind index, because we're going
+    # to just obliterate it anyway.
+    user1 = User.new
+    # Set a different email address to initialize attr_encrypted
+    user1.email = 'wrong_email'
+    # Now insert some encrypted data using an "old" key
+    old_key = ['ea' * 32].pack('H*')
+    old_iv = Base64.decode64(user1.encrypted_email_iv)
+    email_address = 'bogus@stuff.com'
+    user1.encrypted_email = User.encrypt_email(
+      email_address,
+      key: old_key, iv: old_iv
+    )
+    # Setup done, now invoke rekey to test rekeying the record.
+    user1.rekey(old_key)
+    # Check if rekey results are correct
+    assert email_address, user1.email
+    new_blind_index = BlindIndex.generate_bidx( # Recalc so test's less fragile
+      email_address, User.blind_indexes[:email]
+    )
+    assert new_blind_index, user1.encrypted_email_bidx
+  end
+
   test 'associated projects should be destroyed' do
     @user.save!
     @user.projects.create!(
@@ -116,3 +142,4 @@ class UserTest < ActiveSupport::TestCase
     ActiveModel::SecurePassword.min_cost = true
   end
 end
+# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
A critical property of keys and passwords, from a security viewpoint,
that it is *easy* to change them if they are revealed.
That doesn't work if there's no easy way to change them.

Here we provide a mechanism to rekey email addresses, if needed.
Most of the functionality is in the User model, so it's
a little easier to test.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>