### PR TITLE
Implement BADGEAPP_DENY_LOGIN mode

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,9 +21,13 @@ class SessionsController < ApplicationController
     end
   end
 
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def create
     counter_fixation # Counter session fixation (but save forwarding url)
-    if request.env['omniauth.auth'].present?
+    if Rails.application.config.deny_login
+      flash.now[:danger] = t('sessions.login_disabled')
+      render 'new', status: :forbidden
+    elsif request.env['omniauth.auth'].present?
       omniauth_login
     elsif params[:session][:provider] == 'local'
       local_login
@@ -32,6 +36,7 @@ class SessionsController < ApplicationController
       render 'new'
     end
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def destroy
     log_out if logged_in?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,8 +49,13 @@ class UsersController < ApplicationController
   end
   # rubocop: enable Metrics/AbcSize
 
-  # rubocop: disable Metrics/MethodLength
+  # rubocop: disable Metrics/MethodLength, Metrics/AbcSize
   def create
+    if Rails.application.config.deny_login
+      flash.now[:danger] = t('sessions.login_disabled')
+      render 'new', status: :forbidden
+      return
+    end
     @user = User.find_by(email: user_params[:email])
     if @user
       redirect_existing
@@ -66,7 +71,7 @@ class UsersController < ApplicationController
       end
     end
   end
-  # rubocop: enable Metrics/MethodLength
+  # rubocop: enable Metrics/MethodLength, Metrics/AbcSize
 
   def edit
     @user = User.find(params[:id])

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -51,7 +51,10 @@ module SessionsHelper
   end
 
   # Returns the user corresponding to the remember token cookie
+  # rubocop:disable Metrics/MethodLength
   def current_user
+    return if Rails.application.config.deny_login
+    # Extra parens used here to indicate safe assignment in condition
     if (user_id = session[:user_id])
       @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])
@@ -64,6 +67,7 @@ module SessionsHelper
       end
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   # Returns true if the user is logged in, false otherwise.
   def logged_in?

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,6 +1,18 @@
 <br>
 <h1 class='center'><%= t('sessions.login_header') %></h1>
 
+<% if Rails.application.config.deny_login %>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <div class="center-block">
+       <%= t('sessions.login_disabled') %>
+    </div>
+  </div>
+</div>
+
+<% else %>
+
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
    <div class="center-block">
@@ -48,3 +60,4 @@
     <br>
   </div>
 </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,6 +2,18 @@
  <br>
  <h1 class="center"><%= t '.signup_header' %></h1>
 
+<% if Rails.application.config.deny_login %>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <div class="center-block">
+       <%= t('sessions.login_disabled') %>
+    </div>
+  </div>
+</div>
+
+<% else %>
+
  <br>
  <div class="row">
    <div class="col-md-6 col-md-offset-3">
@@ -34,3 +46,4 @@
  </div>
 
 </div>
+<% end %>

--- a/config/initializers/deny_login.rb
+++ b/config/initializers/deny_login.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Copyright 2015-2017, the Linux Foundation, IDA, and the
+# CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+# If environment variable BADGEAPP_DENY_LOGIN has a non-blank value
+# ("true" is recommended), then no on can log in or do things logged-in
+# users can do (such as edit anything).
+Rails.application.config.deny_login = ENV['BADGEAPP_DENY_LOGIN'].present?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,7 @@ en:
     login_custom: Log in using custom account
     no_custom: No custom account? Sign up now!
     already_logged_in: You are already logged in.
+    login_disabled: All logins temporarily disabled
     incorrect_login_info: Incorrect login information
     invalid_combo: Invalid email/password combination
     signed_in: "Logged in! Last login: %{last_login_at}"

--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -83,6 +83,25 @@ The application is configured by various environment variables:
   Used by aes-256-gcm (256-bit AES in GCM mode).
 * EMAIL_BLIND_INDEX_KEY: Key for blind index created for email
   (used by PBKDF2-HMAC-SHA256).  Must be 64 hex digits (==32 bytes==256 bits).
+* BADGEAPP_DENY_LOGIN: If a non-blank value is set ("true" is recommended),
+  then no on can log in, no one can create a new account (sign up),
+  and no one can do anything that requires being logged (users are always
+  treated as if they are not logged in).
+  This essentially prevents ANY changes by users (daily statistics
+  creates are unaffected).
+  From a security POV this is enforced by SessionsController#create (login),
+  UsersController#create (create new user/sign up), and
+  SessionsHelper#current_user (determine who current logged-in user is).
+  Some views disable the login and sign-in display, so that it's more
+  obvious to user what is going on.
+  This may be a useful mode to enable if there is a serious exploitable
+  security vulnerability, that can only be exploited by users who are
+  logged in or can appear to log in.  Unlike *completely* disabling the
+  site, this mode allows people to see current information
+  (such as badge status, project data, and public user data).
+  Note that application admins cannot log in, or use their privileges,
+  when this mode is enabled.  Only hosting site admins can turn this mode
+  on or off (since they're the only ones who can set environment variables).
 
 You can make cryptographically random values (such as keys)
 using "rails secret".  E.g., to create 64 random hexadecimal digits, use:

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -22,4 +22,28 @@ class SessionsControllerTest < ActionController::TestCase
     assert_not flash.empty?
     assert_redirected_to root_url
   end
+
+  test 'login via session controller' do
+    post :create, params: {
+      session: {
+        provider: 'local', email: 'test@example.org', password: 'password'
+      }
+    }
+    assert flash && flash[:success]
+    assert flash[:success].include?('Logged in!')
+  end
+
+  test 'login via session controller fails if' do
+    old_deny = Rails.application.config.deny_login
+    Rails.application.config.deny_login = true # Not thread-safe
+    post :create, params: {
+      session: {
+        provider: 'local', email: 'test@example.org', password: 'password'
+      }
+    }
+    assert flash && flash[:danger]
+    assert flash[:danger].include?('logins temporarily disabled')
+    assert '403', response.code
+    Rails.application.config.deny_login = old_deny
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -155,6 +155,29 @@ class UsersControllerTest < ActionController::TestCase
     assert_redirected_to login_url
   end
 
+  test 'can create local user' do
+    VCR.use_cassette('can_create_local_user') do
+      patch :create, params: {
+        user: { name: 'Not here', email: 'nonsense@example.org' }, locale: :en
+      }
+    end
+    assert '302', response.code
+  end
+
+  test 'cannot create local user if login disabled' do
+    deny_login_old = Rails.application.config.deny_login
+    Rails.application.config.deny_login = true
+
+    VCR.use_cassette('cannot_create_local_user_if_login_disabled') do
+      patch :create, params: {
+        user: { name: 'Not here', email: 'nonsense@example.org' }, locale: :en
+      }
+    end
+    assert '403', response.code
+
+    Rails.application.config.deny_login = deny_login_old
+  end
+
   test 'should redirect update when not logged in' do
     patch :update, params: {
       id: @user, user: { name: @user.name, email: @user.email }, locale: :en

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -24,6 +24,18 @@ class SessionsHelperTest < ActionView::TestCase
     assert_nil current_user
   end
 
+  test 'current_user returns nil when deny_login' do
+    # First, log in as user
+    log_in_as(@user)
+    assert current_user == @user
+    # Previous login irrelevant once deny_login is true
+    deny_login_old = Rails.application.config.deny_login
+    Rails.application.config.deny_login = true
+    assert current_user.nil?
+    # Restore normal setting
+    Rails.application.config.deny_login = deny_login_old
+  end
+
   # Unit test.  There are tricky cases, so try various forms
   test 'check force_locale_url' do
     assert_equal 'https://a.b.c/',


### PR DESCRIPTION
Implement the BADGEAPP_DENY_LOGIN mode.

If a non-blank value is set ("true" is recommended)
on the environmental variable BADGEAPP_DENY_LOGIN,
then no on can log in, no one can create a new account (sign up),
and no one can do anything that requires being logged (users are always
treated as if they are not logged in).
This essentially prevents ANY changes by users (daily statistics
creates are unaffected).

From a security POV this is enforced by SessionsController#create (login),
UsersController#create (create new user/sign up), and
SessionsHelper#current_user (determine who current logged-in user is).
Some views disable the login and sign-in display, so that it's more
obvious to user what is going on.

This may be a useful mode to enable if there is a serious exploitable
security vulnerability, that can only be exploited by users who are
logged in or can appear to log in.  Unlike *completely* disabling the
site, this mode allows people to see current information
(such as badge status, project data, and public user data).
Note that application admins cannot log in, or use their privileges,
when this mode is enabled.  Only hosting site admins can turn this mode
on or off (since they're the only ones who can set environment variables).

Before this commit, we could *completely* disable all access to the site
if there is a security issue, but that is not desirable.  In some
cases this mode is a reasonable alternative.  However, we have to
implement this mode *ahead* of time if we want to be able to use it
in the future.

There's not a lot of *main* code - a lot of the code here is to
implement tests of it.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>