### PR TITLE
Fix rack-attack configuration for our production environment

### DIFF
--- a/app/lib/client_ip.rb
+++ b/app/lib/client_ip.rb
@@ -4,10 +4,6 @@
 # CII Best Practices badge contributors
 # SPDX-License-Identifier: MIT
 
-# The priority is based upon order of creation:
-# first created -> highest priority.
-# See how all your routes lay out with "rake routes".
-
 module ClientIp
   # Compute the correct remote IP address for our environment.
   # We have done tests, and in our current environment this is the

--- a/app/lib/client_ip.rb
+++ b/app/lib/client_ip.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Copyright 2015-2017, the Linux Foundation, IDA, and the
+# CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+# The priority is based upon order of creation:
+# first created -> highest priority.
+# See how all your routes lay out with "rake routes".
+
+module ClientIp
+  # Compute the correct remote IP address for our environment.
+  # We have done tests, and in our current environment this is the
+  # always the next-to-last value of the comma-space-separated value
+  # "HTTP_X_FORWARDED_FOR" (from the HTTP header X-Forwarded-For).
+  # That's because the last value of "HTTP_X_FORWARDED_FOR"
+  # is always our CDN (which intercepts it first), and the previous
+  # value is set by our CDN to whatever IP address the CDN got.
+  # A client can always set X-Forwarded-For and try to spoof something,
+  # but those entries are always earlier in the list
+  # (so we can easily ignore them).
+  # Use correct_remote_ip(req) instead of req.ip.
+  def self.acquire(req)
+    forwarding = req.get_header('HTTP_X_FORWARDED_FOR')
+    if forwarding
+      # Production environment, pick next-to-last value
+      forwarding.split(', ')[-2]
+    else
+      # Test/development environment, do the best you can.
+      req.ip
+    end
+  end
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -25,28 +25,6 @@ class Rack::Attack
     "/#{loc}/users"
   end.append('/users').to_set
 
-  # Compute the correct remote IP address for our environment.
-  # We have done tests, and in our current environment this is the
-  # always the next-to-last value of the comma-space-separated value
-  # "HTTP_X_FORWARDED_FOR" (from the HTTP header X-Forwarded-For).
-  # That's because the last value of "HTTP_X_FORWARDED_FOR"
-  # is always our CDN (which intercepts it first), and the previous
-  # value is set by our CDN to whatever IP address the CDN got.
-  # A client can always set X-Forwarded-For and try to spoof something,
-  # but those entries are always earlier in the list
-  # (so we can easily ignore them).
-  # Use correct_remote_ip(req) instead of req.ip.
-  def correct_remote_ip(req)
-    forwarding = req.get_header('HTTP_X_FORWARDED_FOR')
-    if forwarding
-      # Production environment, pick next-to-last value
-      forwarding.split(', ')[-2]
-    else
-      # Test/development environment, do the best you can.
-      req.ip
-    end
-  end
-
   ### Configure Cache ###
 
   # If you don't want to use Rails.cache (Rack::Attack's default), then

--- a/test/unit/lib/client_ip_test.rb
+++ b/test/unit/lib/client_ip_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Copyright 2015-2017, the Linux Foundation, IDA, and the
+# CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+require 'test_helper'
+
+class ClientIpTest < ActiveSupport::TestCase
+  test 'ClientIP works correctly without X-Forwarded-For' do
+    class MockReq
+      def get_header(_x)
+        nil
+      end
+
+      def ip
+        '1.2.3.4'
+      end
+    end
+
+    m = MockReq.new
+    result = ClientIp.acquire(m)
+    assert '1.2.3.4', result
+  end
+
+  # In our production environment we must use SECOND from the end.
+  # Change this test, and ClientIp, if your environment is different.
+  test 'ClientIP works correctly with X-Forwarded-For, production env' do
+    class MockReq
+      def get_header(_x)
+        '1.1.1.1, 100.36.183.117, 157.52.82.3'
+      end
+
+      def ip
+        '1.2.3.4'
+      end
+    end
+
+    m = MockReq.new
+    result = ClientIp.acquire(m)
+    assert '100.36.183.117', result
+  end
+end


### PR DESCRIPTION
This commit uses results from testing to configure the
Rack::Attack gem so that it gets accurate client IP addresses.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>