### PR TITLE
Implement and document simple FAIL2BAN capability

### DIFF
--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -116,6 +116,18 @@ The application is configured by various environment variables:
     - logins/ip: RATE_LOGINS_IP_LIMIT, RATE_LOGINS_IP_PERIOD
     - logins/email: RATE_LOGINS_EMAIL_LIMIT, RATE_LOGINS_EMAIL_PERIOD
     - signup/ip: RATE_SIGNUP_IP_LIMIT, RATE_SIGNUP_IP_PERIOD
+* FAIL2BAN_details - fail2ban settings (where repeated failures can lead
+  to a temporary ban).  This blocks an IP address that is
+  repeatedly making suspicious requests.
+  After FAIL2BAN_MAXRETRY blocked requests in FAIL2BAN_FINDTIME seconds,
+  we block all requests from that client IP for FAIL2BAN_BANTIME seconds.
+  A request is blocked if req.path matches the regex FAIL2BAN_PATH or
+  req.query_string matches the regex FAIL2BAN_QUERY.
+  The source code includes some plausible defaults in
+  "config/initializers/rack_attack.rb"; the production settings
+  are not public.  This isn't the same thing as having a *real*
+  web application firewall, but it's simple and counters some
+  trivial attacks.
 
 You can make cryptographically random values (such as keys)
 using "rails secret".  E.g., to create 64 random hexadecimal digits, use:

--- a/doc/security.md
+++ b/doc/security.md
@@ -1245,6 +1245,14 @@ config/initializers/rack_attack.rb.  These settings are
 - logins/email
 - signup/ip
 
+We also have a set of simple FAIL2BAN settings that temporarily
+bans an IP address if it makes too many "suspicious" requests.
+The exact production settings are not documented here, since we
+don't want to tell attackers what we look for.
+This isn't the same thing as having a *real*
+web application firewall, but it's simple and counters some
+trivial attacks.
+
 To determine the remote client IP address (for our purposes) we use the
 the next-to-last value of the comma-space-separated value
 "HTTP_X_FORWARDED_FOR" (from the HTTP header X-Forwarded-For).


### PR DESCRIPTION
This commit adds a "FAIL2BAN" capability.
This capability blocks an IP address that is
repeatedly making suspicious requests.

After FAIL2BAN_MAXRETRY blocked requests in FAIL2BAN_FINDTIME seconds,
we block all requests from that client IP for FAIL2BAN_BANTIME seconds.
A request is blocked if req.path matches the regex FAIL2BAN_PATH or
req.query_string matches the regex FAIL2BAN_QUERY.

The source code includes some plausible defaults in
"config/initializers/rack_attack.rb"; the production settings
are not public.  This isn't the same thing as having a *real*
web application firewall, but it's simple and counters some
trivial attacks.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>