### PR TITLE
Do not redirect if there is no such page and no locale

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -7,10 +7,15 @@
 class StaticPagesController < ApplicationController
   include SessionsHelper
 
-  # These paths don't get locale data in the URLs, so do *not* try to
-  # redirect them to a URL based on locale.
+  # If a page is *invariant* regardless of locale, don't bother
+  # to figure out what the locale is.
+  skip_before_action :set_locale_to_best_available,
+                     only: %i[robots]
+
+  # There's no value in redirecting these pages to a locale,
+  # so do *not* redirect them to a URL based on locale.
   skip_before_action :redir_missing_locale,
-                     only: %i[robots error_404_no_locale_redir]
+                     only: %i[robots error_404]
 
   def home; end
 
@@ -20,6 +25,10 @@ class StaticPagesController < ApplicationController
   # http://rubyjunky.com/cleaning-up-rails-4-production-logging.html
   # This is intentionally short and does *NOT* use the standard layout,
   # to minimize CPU and bandwidth use during an attack.
+  # Note that due to skip_before_action we don't redirect the URL,
+  # as there's no need to do so and skipping a redirect will save a roundtrip.
+  # We *do* try to guess the locale, since we can then provide a
+  # locale-specific error message.
   def error_404
     # The default router already logs things, so we don't need to do more.
     # You can do something like this to log more information, but be sure
@@ -30,10 +39,6 @@ class StaticPagesController < ApplicationController
       layout: false,
       status: 404
     )
-  end
-
-  def error_404_no_locale_redir
-    error_404
   end
 
   def robots


### PR DESCRIPTION
If there's no such page, and no locale in the URL,
we've been redirecting to a URL with a locale.
This wastes time in a round-trip and two calls for
no such page.  Instead, simply reply with an error page.

This results in less code and is faster.  It also eliminates
an bug where we redirect to "/" if given a URL
that looks like a locale ("/no-such-page").

This commit includes a number of extra tests to test various
circumstances. In particular, in error pages
we use the URL locale if given, and if there isn't one, we use
'Accept-Language' header provided by the browser to
determine the locale to use in an error page.

This also stops trying to figure out the locale for
/robots.txt.  We don't need that information at all, robots.txt
doesn't depend on the locale.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>