### PR TITLE
Make submit URLs /projects/NUMBER not /projects/NUMBERedit

### DIFF
--- a/app/views/projects/_form_0.html.erb
+++ b/app/views/projects/_form_0.html.erb
@@ -24,7 +24,7 @@
   <div class="col-md-12">
  <div>
   <%# Don't provide criteria_level, as '0' is the default. %>
-  <%= bootstrap_form_for project, url: put_project_path(project) do |f| %>
+  <%= bootstrap_form_for project, url: project_path(project) do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <%= f.hidden_field :lock_version %>
 

--- a/app/views/projects/_form_1.html.erb
+++ b/app/views/projects/_form_1.html.erb
@@ -24,7 +24,7 @@
 <div class="row">
   <div class="col-md-12">
  <div>
-  <%= bootstrap_form_for project, url: put_project_path(project, criteria_level: '1') do |f| %>
+  <%= bootstrap_form_for project, url: project_path(project, criteria_level: '1') do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <%= f.hidden_field :lock_version %>
 

--- a/app/views/projects/_form_2.html.erb
+++ b/app/views/projects/_form_2.html.erb
@@ -24,7 +24,7 @@
 <div class="row">
   <div class="col-md-12">
  <div>
-  <%= bootstrap_form_for project, url: put_project_path(project, criteria_level: '2') do |f| %>
+  <%= bootstrap_form_for project, url: project_path(project, criteria_level: '2') do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <%= f.hidden_field :lock_version %>
 


### PR DESCRIPTION
The submit form accidentally had the word "edit" after the
project number because of how the form helper was used.
It doesn't *matter* because the extra text is ignored,
but it looks odd, and we want to keep everything clean.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>