### PR TITLE
Add rel=nofollow to generated markdown hyperlinks, fixes #1185

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -7,7 +7,8 @@
 module ProjectsHelper
   MARKDOWN_RENDERER = Redcarpet::Render::HTML.new(
     filter_html: true, no_images: true,
-    no_styles: true, safe_links_only: true
+    no_styles: true, safe_links_only: true,
+    link_attributes: { rel: 'nofollow' }
   )
   MARKDOWN_PROCESSOR = Redcarpet::Markdown.new(
     MARKDOWN_RENDERER,

--- a/test/helpers/projects_helper_test.rb
+++ b/test/helpers/projects_helper_test.rb
@@ -19,7 +19,7 @@ class ProjectsHelperTest < ActionView::TestCase
 
   test 'markdown - bare URL' do
     assert_equal(
-      '<p><a href="http://www.dwheeler.com">' \
+      '<p><a href="http://www.dwheeler.com" rel="nofollow">' \
       "http://www.dwheeler.com</a></p>\n",
       markdown('http://www.dwheeler.com')
     )
@@ -27,9 +27,28 @@ class ProjectsHelperTest < ActionView::TestCase
 
   test 'markdown - angles around URL' do
     assert_equal(
-      '<p><a href="http://www.dwheeler.com">' \
+      '<p><a href="http://www.dwheeler.com" rel="nofollow">' \
       "http://www.dwheeler.com</a></p>\n",
       markdown('<http://www.dwheeler.com>')
+    )
+  end
+
+  test 'markdown - hyperlinks are generated with nofollow' do
+    assert_equal(
+      '<p><a href="http://www.dwheeler.com" rel="nofollow">' \
+      "Hello</a></p>\n",
+      markdown('[Hello](http://www.dwheeler.com)')
+    )
+  end
+
+  test 'markdown - raw HTML a stripped out (enforcing nofollow)' do
+    # Allowing <a href="..."> would let people insert a link without nofollow,
+    # so we don't allow the use of <a ...>.  People can insert a hyperlink,
+    # but they have to use the markdown format [test](URL), and that format
+    # gives us an opportunity to forcibly insert rel="nofollow".
+    assert_equal(
+      "<p>Junk</p>\n",
+      markdown('<a href="https://www.dwheeler.com">Junk</a>')
     )
   end
 


### PR DESCRIPTION
To discourage SEO spam we generate rel="nofollow" in the hypertext link
for project_homepage_url and project_repo_url. We should do that for all
user-provided data.  This commit eliminates a missing case, namely,
do this with markdown data from users in the project badge entry page.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>