### PR TITLE
Websites with no logins can omit some hardening headers. Fixes #1174

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2687,6 +2687,9 @@ en:
           The key hardening headers are: Content Security Policy
           (CSP), HTTP Strict Transport Security (HSTS), X-Content-Type-Options
           (as "nosniff"), X-Frame-Options, and X-XSS-Protection.
+          Static web sites with no ability to log in via the web pages
+          may omit the CSP and X-XSS-Protection HTTP hardening headers,
+          because in that situation those headers are less effective.
       security_review:
         description: >-
           The project MUST have performed a security review within


### PR DESCRIPTION
@gregkh asked, "Does it make sense for those "missing headers" to even be
present for a static site that can not be changed or logged into? There
is no dynamic data there at all."

He makes a good point; in that case, some headers are not very effective.

This adds some detail to add an exception. In short:
Static web sites with no ability to log in via the web pages
may omit the CSP and X-XSS-Protection HTTP hardening headers,
because in that situation those headers are less effective.

Note that this text *allows* people to add the headers even when
they're less effective.  There are various reasons people may choose
to do that.  For example, if they plan to add login later,
they may choose to include the headers now.  We just don't
want to *require* something that's ineffective.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>