### PR TITLE
Add tooltip on /projects table to explain tiered percentage, fixes #1175

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -122,4 +122,20 @@ module ProjectsHelper
     "<a href=\"#{url_for(new_params)}\" rel=\"nofollow\">#{title}</a>".html_safe
     # rubocop:enable Rails/OutputSafety
   end
+
+  # Given tiered percentage as integer value, return its string representation
+  # Returns nil if given blank value.
+  def tiered_percent_as_string(value)
+    return nil if value.blank?
+    partial = value % 100
+    if value < 100
+      I18n.t 'projects.index.in_progress_next', percent: partial
+    elsif value < 200
+      I18n.t 'projects.index.passing_next', percent: partial
+    elsif value < 300
+      I18n.t 'projects.index.silver_next', percent: partial
+    elsif value >= 300
+      I18n.t 'projects.form_early.level.2'
+    end
+  end
 end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -125,8 +125,9 @@ module ProjectsHelper
 
   # Given tiered percentage as integer value, return its string representation
   # Returns nil if given blank value.
+  # rubocop:disable Metrics/MethodLength
   def tiered_percent_as_string(value)
-    return nil if value.blank?
+    return if value.blank?
     partial = value % 100
     if value < 100
       I18n.t 'projects.index.in_progress_next', percent: partial
@@ -138,4 +139,5 @@ module ProjectsHelper
       I18n.t 'projects.form_early.level.2'
     end
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/views/projects/_table.html.erb
+++ b/app/views/projects/_table.html.erb
@@ -40,7 +40,9 @@
                         rel: 'nofollow' %></td>
         <td><%= project.achieved_passing_at&.
                   to_formatted_s(:db) %></td>
-        <td><%= project.tiered_percentage %>%</td>
+        <td><span data-toggle="tooltip" data-placement="bottom" title="<%=
+                    tiered_percent_as_string(project.tiered_percentage)
+             %>"><%= project.tiered_percentage %>%</span></td>
         <td><%= link_to "<img src='/projects/#{project.id}/badge'
                   alt='#{t('.badge_level', id: project.id,
                             percent: project.tiered_percentage)}'>".html_safe,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -359,6 +359,9 @@ en:
       silver_200: Silver (200%+ tiered)
       gold_in_progress_variable: Silver, partial gold (%{percent}%+ tiered)
       gold_300: Gold (300%)
+      in_progress_next: In Progress, %{percent}% completed for passing
+      passing_next: Passing, %{percent}% completed for silver
+      silver_next: Silver, %{percent}% completed for gold
       add_link: Add
       add_new: Add New Project
       badge_status: Badge status

--- a/test/helpers/projects_helper_test.rb
+++ b/test/helpers/projects_helper_test.rb
@@ -90,4 +90,17 @@ class ProjectsHelperTest < ActionView::TestCase
       markdown('<a href="https://www.dwheeler.com" target="_blank">Hello</a>')
     )
   end
+
+  test 'Ensure tiered_percent_as_string works' do
+    assert_nil tiered_percent_as_string(nil)
+    assert_equal 'In Progress, 74% completed for passing',
+                 tiered_percent_as_string(74)
+    assert_equal 'Passing, 23% completed for silver',
+                 tiered_percent_as_string(123)
+    assert_equal 'Silver, 52% completed for gold', tiered_percent_as_string(252)
+    assert_equal 'Gold', tiered_percent_as_string(300)
+    # I18n.with_locale(:fr) do
+    #    assert_equal 'WRONG', tiered_percent_as_string(74)
+    # end
+  end
 end


### PR DESCRIPTION
Add a tooltip on the /projects table for each tiered percentage value,
to explain it in detail.  This should make it easier for
newcomers to understand what numbers like "187%" means.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>