### PR TITLE
Update recommended license list to SPDX 3.0. Fixes #1192

### DIFF
--- a/app/lib/floss_license_detective.rb
+++ b/app/lib/floss_license_detective.rb
@@ -14,6 +14,13 @@ class FlossLicenseDetective < Detective
   OUTPUTS = %i[floss_license_osi_status floss_license_status].freeze
 
   # From: http://opensource.org/licenses/alphabetical
+  # Note: We accept the older GNU license forms, e.g., "GPL-2.0", and
+  # the newer SPDX 3.0 license names, e.g.,
+  # "GPL-2.0-only" and "GPL-2.0-or-later".
+  # SPDX 3.0 does not provide a way to say, "GPL version 2.0 is acceptable,
+  # and I don't know if later versions are acceptable"; in practice,
+  # "GPL-2.0" is being used that way.
+  # See: https://spdx.org/news/news/2018/01/license-list-30-released
   OSI_LICENSES_FROM_OSI_WEBSITE = [
     'Academic Free License 3.0 (AFL-3.0)',
     'Adaptive Public License (APL-1.0)',
@@ -38,10 +45,24 @@ class FlossLicenseDetective < Detective
     'Fair License (Fair)',
     'Frameworx License (Frameworx-1.0)',
     'GNU Affero General Public License v3 (AGPL-3.0)',
+    'GNU Affero General Public License v3 only (AGPL-3.0-only)',
+    'GNU Affero General Public License v3 or later (AGPL-3.0-or-later)',
     'GNU General Public License version 2.0 (GPL-2.0)',
+    'GNU General Public License version 2.0 only (GPL-2.0-only)',
+    'GNU General Public License version 2.0 or later (GPL-2.0-or-later)',
     'GNU General Public License version 3.0 (GPL-3.0)',
+    'GNU General Public License version 3.0 only (GPL-3.0-only)',
+    'GNU General Public License version 3.0 or later (GPL-3.0-or-later)',
     'GNU Library or "Lesser" General Public License version 2.1 (LGPL-2.1)',
+    'GNU Library or "Lesser" General Public License version 2.1 only ' \
+      '(LGPL-2.1-only)',
+    'GNU Library or "Lesser" General Public License version 2.1 or later ' \
+      '(LGPL-2.1-or-later)',
     'GNU Library or "Lesser" General Public License version 3.0 (LGPL-3.0)',
+    'GNU Library or "Lesser" General Public License version 3.0 only ' \
+      '(LGPL-3.0-only)',
+    'GNU Library or "Lesser" General Public License version 3.0 or later ' \
+      '(LGPL-3.0-or-later)',
     'Historical Permission Notice and Disclaimer (HPND)',
     'IBM Public License 1.0 (IPL-1.0)',
     'IPA Font License (IPA)',

--- a/app/views/projects/_form_0.html.erb
+++ b/app/views/projects/_form_0.html.erb
@@ -229,8 +229,8 @@
                              list: 'license_list', disabled: is_disabled %>
            <!-- Some examples from http://wiki.spdx.org/view/FileNoticeExamples -->
            <datalist class="hidden" id="license_list">
-              <option value="AGPL-3.0">AGPL-3.0 {GNU Affero General Public License 3.0}</option>
-              <option value="AGPL-3.0+">AGPL-3.0 {GNU Affero General Public License 3.0 or later}</option>
+              <option value="AGPL-3.0-only">AGPL-3.0-only {GNU Affero General Public License 3.0 only}</option>
+              <option value="AGPL-3.0-or-later">AGPL-3.0-or-later {GNU Affero General Public License 3.0 or later}</option>
               <option value="Apache-2.0">Apache-2.0 {Apache License 2.0}</option>
               <option value="Artistic-1.0">Artistic-1.0 {Artistic License 1.0}</option>
               <option value="Artistic-1.0-Perl">Artistic-1.0-Perl {Artistic License 1.0, Perl}</option>
@@ -242,24 +242,28 @@
               <option value="BSL-1.0">BSL-1.0 {Boost Software License 1.0}</option>
               <option value="CC0-1.0">CC0-1.0 {Creative Commons Zero v1.0 Universal}</option>
               <option value="CC-BY-3.0">CC-BY-3.0 {Creative Commons Attribution 3.0}</option>
+              <option value="CC-BY-3.0+">CC-BY-3.0+ {Creative Commons Attribution 3.0 or later}</option>
               <option value="CC-BY-4.0">CC-BY-4.0 {Creative Commons Attribution 4.0}</option>
+              <option value="CC-BY-4.0+">CC-BY-4.0+ {Creative Commons Attribution 4.0 or later}</option>
               <option value="CC-BY-SA-3.0">CC-BY-SA-3.0 {Creative Commons Attribution ShareAlike 3.0}</option>
+              <option value="CC-BY-SA-3.0+">CC-BY-SA-3.0+ {Creative Commons Attribution ShareAlike 3.0 or later}</option>
               <option value="CC-BY-SA-4.0">CC-BY-SA-4.0 {Creative Commons Attribution ShareAlike 4.0}</option>
+              <option value="CC-BY-SA-4.0+">CC-BY-SA-4.0+ {Creative Commons Attribution ShareAlike 4.0 or later}</option>
               <option value="CDDL-1.0">CDDL-1.0 {Common Development and Distribution License 1.0}</option>
               <option value="CDDL-1.1">CDDL-1.1 {Common Development and Distribution License 1.1}</option>
               <option value="CPL-1.0">CPL-1.0 {Common Public License 1.0}</option>
               <option value="CECILL-B">CECILL-B {CeCILL-B Free Software License Agreement}</option>
               <option value="EPL-1.0">EPL-1.0 {Eclipse Public License 1.0}</option>
               <option value="EPL-2.0">EPL-2.0 {Eclipse Public License 2.0}</option>
-              <option value="GPL-2.0">GPL-2.0 {GNU General Public License version 2.0 only}</option>
-              <option value="GPL-2.0+">GPL-2.0+ {GNU General Public License version 2.0 or later}</option>
-              <option value="GPL-3.0">GPL-3.0 {GNU General Public License version 3.0 only}</option>
-              <option value="GPL-3.0+">GPL-3.0+ {GNU General Public License version 3.0 or later}</option>
+              <option value="GPL-2.0-only">GPL-2.0-only {GNU General Public License version 2.0 only}</option>
+              <option value="GPL-2.0-or-later">GPL-2.0-or-later {GNU General Public License version 2.0 or later}</option>
+              <option value="GPL-3.0-only">GPL-3.0-only {GNU General Public License version 3.0 only}</option>
+              <option value="GPL-3.0-or-later">GPL-3.0-or-later {GNU General Public License version 3.0 or later}</option>
               <option value="ISC">ISC {ISC license}</option>
-              <option value="LGPL-2.1+">LGPL-2.1 {GNU Lesser General Public License version 2.1 only}</option>
-              <option value="LGPL-2.1+">LGPL-2.1+ {GNU Lesser General Public License version 2.1 or later}</option>
-              <option value="LGPL-3.0">LGPL-3.0 {GNU Lesser General Public License version 3.0 only}</option>
-              <option value="LGPL-3.0+">LGPL-3.0+ {GNU Lesser General Public License version 3.0 or later}</option>
+              <option value="LGPL-2.1-only">LGPL-2.1-only {GNU Lesser General Public License version 2.1 only}</option>
+              <option value="LGPL-2.1-or-later">LGPL-2.1-or-later {GNU Lesser General Public License version 2.1 or later}</option>
+              <option value="LGPL-3.0-only">LGPL-3.0-only {GNU Lesser General Public License version 3.0 only}</option>
+              <option value="LGPL-3.0-or-later">LGPL-3.0-or-later {GNU Lesser General Public License version 3.0 or later}</option>
               <option value="MS-PL">MS-PL {Microsoft Public License}</option>
               <option value="MIT">MIT</option>
               <option value="MPL-1.0">MPL-1.0 {Mozilla Public License 1.0}</option>
@@ -269,9 +273,9 @@
               <option value="Unlicense">Unlicense {The Unlicense}</option>
               <option value="Zlib">Zlib {zlib License}</option>
               <option value="zlib-acknowledgement">zlib-acknowledgement {zlib/libpng License with Acknowledgement}</option>
-              <option value="(GPL-3.0+ WITH Bison-Exception)">(GPL-3.0+ WITH Bison-Exception)</option>
-              <option value="(LGPL-2.0+ AND AML)">(LGPL-2.0+ AND AML) {must meet both the GNU Lesser General Public License version 2.1 or later AND the Apple MIT License}</option>
-              <option value="(MPL-1.1 OR GPL-2.0+ OR LGPL-2.1+)">(MPL-1.1 OR GPL-2.0+ OR LGPL-2.1+)</option>
+              <option value="(GPL-3.0-or-later WITH Bison-Exception)">(GPL-3.0-or-later WITH Bison-Exception)</option>
+              <option value="(LGPL-2.1-or-later AND AML)">(LGPL-2.1-or-later AND AML) {must meet both the GNU Lesser General Public License version 2.1 or later AND the Apple MIT License}</option>
+              <option value="(MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later)">(MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later)</option>
               <option value="(Ruby OR BSD-2-Clause)">(Ruby OR BSD-2-Clause)</option>
            </datalist>
             <br>


### PR DESCRIPTION
Update to the SDPX 3.0 license list in the dropdown suggestions. See:

* https://spdx.org/news/news/2018/01/license-list-30-released
* https://spdx.org/licenses/

The key difference is that GPL-related licenses, like GPL version 2.0,
are now "GPL-2.0-only" or "GPL-2.0-or-later".  See the announcement
for more information.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>