### PR TITLE
In production, set config.assets.compile = false

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,10 +42,10 @@ Rails.application.configure do
   config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true
+  config.assets.compile = false
 
   # Asset digests allow you to set far-future HTTP expiration dates on all
-  # assets, # yet still be able to expire them through the digest params.
+  # assets, yet still be able to expire them through the digest params.
   config.assets.digest = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to


### PR DESCRIPTION
In production, set config.assets.compile = false
as a minor speed and memory performance improvement.

This is recommended by Heroku's documentation at:
https://devcenter.heroku.com/articles/rails-asset-pipeline#
compile-set-to-true-in-production
which says: "If you have enabled your application to config.assets.compile =
true in production, your application might be very slow...
This setting is also known to cause other run-time instabilities and is
generally not recommended. Instead we recommend either precompiling all
of your assets on deploy (which is the default)..."

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>