### PR TITLE
Accessibility fix of collapsible navigation hamburger, fixes #1217

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
     <nav>
       <div class="navbar-header">
 
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#collapsingRightNav">
+        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#collapsingRightNav" aria-label="<%= t(:toggle_navigation, scope: :layouts) %>">
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
     zh-CN: Chinese (Simplified) / 简体中文 (zh-CN)
   layouts:
     cii_best_practices: CII Best Practices
+    toggle_navigation: Toggle collapsible navigation
     projects: Projects
     users: Users
     account: Account


### PR DESCRIPTION
If the screen width is narrow (e.g., a smartphone), we show a
collapsible navigation bar, but we did not have an accessibility
label for it.  That's a problem for blind users.

This commit adds an aria-label to the navbar-toggle.
Since it's a text label, it must be internationalized.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>