### PR TITLE
Ignore vulnerability CVE-2018-1000544 in rubyzip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,9 @@ jobs:
     # This is based on your 1.0 configuration file or project settings
     - run: bundle exec pronto run -f github text -c=$(git log --pretty=format:%H | tail -1) --exit-code
     - run: bundle doctor
-    - run: bundle exec bundle audit check --update
+    # Ignore CVE-2018-1000544 (rubyzip); it does not affect production.  See:
+    # https://github.com/coreinfrastructure/best-practices-badge/issues/1222
+    - run: bundle exec bundle audit check --update --ignore CVE-2018-1000544
     - run: bundle exec rake whitespace_check
     - run: script/report_code_statistics
     # Save test results

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -113,7 +113,9 @@ task :bundle_audit do
         echo "Cannot update bundle-audit database; using current data."
       fi
       if [ "$apply_bundle_audit" = 't' ] ; then
-        bundle exec bundle audit check
+        # Ignore CVE-2018-1000544 (rubyzip); it does not affect production. See:
+        # https://github.com/coreinfrastructure/best-practices-badge/issues/1222
+        bundle exec bundle audit check --ignore CVE-2018-1000544
       else
         true
       fi


### PR DESCRIPTION
Ignore CVE-2018-1000544 (a vulnerability in rubyzip).
It does not affect production. See:
https://github.com/coreinfrastructure/best-practices-badge/issues/1222
https://github.com/rubyzip/rubyzip/pull/371
https://nvd.nist.gov/vuln/detail/CVE-2018-1000544

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>