### PR TITLE
Enable David A. Wheeler to get log issues from Google, fixes #1223

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -15,7 +15,7 @@ class StaticPagesController < ApplicationController
   # There's no value in redirecting these pages to a locale,
   # so do *not* redirect them to a URL based on locale.
   skip_before_action :redir_missing_locale,
-                     only: %i[robots error_404]
+                     only: %i[robots error_404 google_verifier]
 
   def home; end
 
@@ -38,6 +38,16 @@ class StaticPagesController < ApplicationController
       template: '/static_pages/error_404.html.erb',
       layout: false,
       status: 404
+    )
+  end
+
+  # Weird special case: For David A. Wheeler to get log issues from Google,
+  # we have to have a special file to let Google verify access.
+  def google_verifier
+    render(
+      template: '/static_pages/google_verifier.txt',
+      layout: false,
+      status: 200
     )
   end
 

--- a/app/views/static_pages/google_verifier.txt
+++ b/app/views/static_pages/google_verifier.txt
@@ -1,0 +1,1 @@
+google-site-verification: google75f94b1182a77eb8.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,13 @@ Rails.application.routes.draw do
   get '/projects/:id/badge' => 'projects#badge',
       defaults: { format: 'svg' }
 
+  # Weird special case: for David A. Wheeler to get log issues from Google,
+  # we have to let Google verify this.  Locale is irrelevant.
+  # It isn't really HTML, even though the filename extension is .html. See:
+  # https://github.com/coreinfrastructure/best-practices-badge/issues/1223
+  get '/google75f94b1182a77eb8.html' => 'static_pages#google_verifier',
+      defaults: { format: 'text' }
+
   # Now handle the normal case: routes with an optional locale prefix.
   # We include almost all routes inside a :locale header,
   # where the locale is optional.  This approach (using an optional value)

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -178,5 +178,13 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
     assert_includes @response.body, 'Error 404: Page Not Found'
     assert_includes @response.body, 'Sorry, no such page exists.'
   end
+
+  # Test Google verifier.  We need this so David A. Wheeler can get
+  # Google error messages.
+  test 'Google verifier' do
+    get '/google75f94b1182a77eb8.html'
+    assert_equal "google-site-verification: google75f94b1182a77eb8.html\n",
+                 @response.body
+  end
 end
 # rubocop: enable Metrics/BlockLength, Metrics/ClassLength


### PR DESCRIPTION
We need to receive Google notifications about problems with our site that
are generated by Google's webcrawler. In particular, I need to be able
to see them! To do this, we need to tweak our routes so that this URL:

https://bestpractices.coreinfrastructure.org/google75f94b1182a77eb8.html

Will generate this content exactly:

google-site-verification: google75f94b1182a77eb8.html

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>