### PR TITLE
Clarify that SPDX license expressions do not include quote marks

### DIFF
--- a/app/views/projects/_form_0.html.erb
+++ b/app/views/projects/_form_0.html.erb
@@ -219,11 +219,13 @@
                 # "(GPL-2.0+ WITH Bison-exception-2.2)".  See:
                 # https://spdx.org/spdx-specification-21-web-version
                 # Errors here do not cause *security* issues, so we're not
-                # too strict.
+                # too strict, but we want to check inputs so that our
+                # data is much more likely to be accurate.
                 f.text_field :license,
                              class: 'form-control', hide_label: true,
                              pattern: '(|[()A-Za-z0-9\-.+ ]*)',
-                             title: 'License in SPDX license expression format, e.g., "MIT" or "GPL-3.0+"',
+                             title:
+                               t('projects.form_basics.license.title'),
                              placeholder:
                                t('projects.form_basics.license.placeholder'),
                              list: 'license_list', disabled: is_disabled %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -654,7 +654,11 @@ en:
           Please use <a href="https://spdx.org/licenses/">SPDX
           license expression format</a>; examples include "Apache-2.0",
           "BSD-2-Clause", "BSD-3-Clause", "GPL-2.0+", "LGPL-3.0+",
-          "MIT", and "(BSD-2-Clause OR Ruby)".
+          "MIT", and "(BSD-2-Clause OR Ruby)".  Do <b>not</b> include
+          single quotes or double quotes.
+        title: >-
+          License in SPDX license expression format, e.g., "MIT" or "GPL-3.0+",
+          without single quotes or double quotes
         placeholder: FLOSS License
     misc:
       in_javascript:


### PR DESCRIPTION
Make it clear in the section for entering SPDX license expressions
that single quotes and double quotes should not be included.
Note that in both the details and in the field title
(as a side-effect, internationalize the field title).

We hope that this will resolve this reported problem:
https://github.com/coreinfrastructure/best-practices-badge/issues/1226

That said, even if this doesn't resolve *that* problem, clarifying
what we need and internationalizing the title is a good idea.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>