### PR TITLE
Clarify know_secure_design depends on details.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1488,6 +1488,7 @@ en:
         description: >-
           The project MUST have at least one primary developer
           who knows how to design secure software.
+          (See ‘details’ for the exact requirements.)
         details: >-
           This requires understanding the following design principles,
           including the 8 principles from <a href="http://web.mit.edu/Saltzer/www/publications/protection/">Saltzer


### PR DESCRIPTION
Criterion know_secure_design says that
"The project MUST have at least one primary developer
who knows how to design secure software."
However, if you don't have the details showing, it's not obvious
what that really requires; the details provide that information.

That's technically true for many criteria, but for this particular
criterion that is *especially* important.

This commit simply adds a note,
"(See ‘details’ for the exact requirements.)".
There's no substantive change, but we hope that this change
will make it easier to apply.

See the discussion here:
https://github.com/coreinfrastructure/best-practices-badge/issues/1211

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>