### PR TITLE
Fix format of "we have updated our requirements" text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -468,8 +468,8 @@ en:
         below if you don't know how to do that).
       lost_badge: Project has lost a badge.
       static_analysis_updated_html: >-
-        We have updated our requirements for the criterion <a
-        href="#static_analysis">static_analysis</a>. Please add
+        We have updated our requirements for the criterion
+        static_analysis. Please add
         a justification for this criterion.
       save_and_continue: Save (and continue)
       submit_and_exit: Submit (and exit)

--- a/test/features/login_test.rb
+++ b/test/features/login_test.rb
@@ -65,8 +65,7 @@ class LoginTest < CapybaraFeatureTest
     visit edit_project_path(@project, locale: :en)
     assert has_content? 'This is not the production system'
     assert has_content? 'We have updated our requirements for the criterion ' \
-                        '<a href="#static_analysis">static_analysis</a>. ' \
-                        'Please add a justification for '\
+                        'static_analysis. Please add a justification for ' \
                         'this criterion.'
 
     fill_in 'project_name', with: 'It doesnt matter'


### PR DESCRIPTION
We have a message saying
"We have updated our requirements for the criterion static_analysis",
but the Rails semantics for safe HTML in flash messages has changed.
As a result, its formatting is now wrong.

Instead of trying to significantly rework
app/controllers/projects_controller.rb, just remove the
not-really-necessary hypertext link.
This message only occurs in rare situations, and the hypertext link
isn't all that important.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>