### PR TITLE
If additional rights list changes, invalidate cache. Fixes #1255

### DIFF
--- a/app/views/projects/_form_0.html.erb
+++ b/app/views/projects/_form_0.html.erb
@@ -12,7 +12,12 @@
     </div>
   </div>
 <% end %>
-<% cache_if is_disabled, [project, locale] do %>
+<%
+   # If the additional rights list changes, invalidate the cache.
+   # If the performance is too slow, we could directly expire it instead,
+   # but that adds a maintenance headache.
+   additional_rights_list = project.additional_rights.pluck(:user_id).join(',')
+   cache_if is_disabled, [project, locale, additional_rights_list] do %>
 <%= render(partial: 'form_early',
            locals:
              {


### PR DESCRIPTION
If someone edits additional rights, the changes don't
necessarily show on the project list, because we show the
old cached value instead.

This commit adds the list of additional rights to the cache key.
This ensures that when the list changes, the cache is invalidated.

If the performance is too slow, we could directly expire this
specific cache entry instead.  However, that adds a maintenance headache:
that would then create a subtle dependency on the cache key.
So let's try the "hard to get wrong" approach first, and switch
to the faster-performing version only if necessary.
I don't expect it to really impact performance, because for most
project this is an empty list.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>