### PR TITLE
Add additional_rights to JSON output, fixes #1272

### DIFF
--- a/app/views/projects/_project.json.jbuilder
+++ b/app/views/projects/_project.json.jbuilder
@@ -4,6 +4,8 @@
 # This is a partial so "show" and "index" can share this.
 json.merge! project.attributes
 json.badge_level project.badge_level
+json.additional_rights project.additional_rights.pluck(:user_id)
+
 # rubocop:disable Rails/OutputSafety
 json.project_entry_attribution('Please credit '.html_safe +
                                project.user.name +

--- a/app/views/projects/show_json.json.jbuilder
+++ b/app/views/projects/show_json.json.jbuilder
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
-# JSON data doesn't depend on locale
+# JSON data doesn't depend on locale.
+
+# The JSON data *does* depend on the additional_rights value.
+# However, it is very rare for additional_rights to change, so we'll just
+# depend on the expiration time to invalidate old data, and for a short time
+# we'll return an obsolete additional_rights list.
+# If it's important to *immediately* return the current list,
+# then we could invalidate the cache value on a change to additional_rights,
+# or we could instead add this to the cache key:
+# additional_rights_list = project.additional_rights.pluck(:user_id).join(',')
+
 json.cache! @project, expires_in: 10.minutes do
   json.partial! 'project', project: @project
 end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -145,6 +145,7 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_equal 'Operating system for Pathfinder rover', body['description']
     assert_equal 'https://www.nasa.gov', body['homepage_url']
     assert_equal 'in_progress', body['badge_level']
+    assert_equal [], body['additional_rights']
   end
 
   test 'should get edit' do

--- a/test/vcr_cassettes/unit_test_github_basic_detective.yml
+++ b/test/vcr_cassettes/unit_test_github_basic_detective.yml
@@ -144,4 +144,75 @@ http_interactions:
       string: '{"Python":43}'
     http_version: 
   recorded_at: Sun, 07 Apr 2019 00:32:56 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/ciitest/test-repo/languages?client_id=3e90194c70b57b71188e&client_secret=d2e3f002838f611a514b84a1727bf6e500a67d2b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.9.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Sun, 07 Apr 2019 22:36:32 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '13'
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4999'
+      X-Ratelimit-Reset:
+      - '1554680192'
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Vary:
+      - Accept
+      Etag:
+      - '"bf576b13d7017f312a2ff759c9c7d512"'
+      Last-Modified:
+      - Mon, 06 Aug 2018 03:25:38 GMT
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - D526:5EF1:48F99F:990932:5CAA7B70
+    body:
+      encoding: UTF-8
+      string: '{"Python":43}'
+    http_version: 
+  recorded_at: Sun, 07 Apr 2019 22:36:32 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
Our JSON output for a project didn't include additional_rights
information because that is not stored in the projects table
(it's in another table).  However, it's clearly relevant to a project.
Therefore, add the additional_rights field to the JSON output.
We'll output it as a JSON array (that seems like the best way to
model it).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>