### PR TITLE
DO NOT MERGE: Tweak Edit and Delete actions in project headers

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -23,12 +23,12 @@
         <%= yield :nav_extras %>
         <li><%= link_to Icon[:'fa-list'] + t(:projects, scope: :layouts), projects_path %></li>
 
-        <% if logged_in? %>
-          <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%=
-              Icon[:'fa-user']
-            %><%= t(:account, scope: :layouts) %><b class="caret"></b></a>
-            <ul class="dropdown-menu reverse-dropdown">
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%=
+            Icon[:'fa-user']
+          %><%= t(:account, scope: :layouts) %><b class="caret"></b></a>
+          <ul class="dropdown-menu reverse-dropdown">
+            <% if logged_in? %>
               <li><%= link_to Icon[:'fa-address-card'] + t(:profile, scope: :layouts), current_user %></li>
               <% if current_user.provider == 'local' %>
                 <li><%= link_to t(:settings, scope: :layouts), edit_user_path(current_user) %></li>
@@ -37,12 +37,12 @@
               <li>
                 <%= link_to t(:logout_html, scope: :layouts), logout_path, method: "delete" %>
               </li>
-            </ul>
-          </li>
-        <% else %>
-          <li><%= link_to t(:signup_html, scope: :layouts), signup_path %></li>
-          <li><%= link_to t(:login_html, scope: :layouts), login_path %></li>
-        <% end %>
+            <% else %>
+              <li><%= link_to t(:signup_html, scope: :layouts), signup_path %></li>
+              <li><%= link_to t(:login_html, scope: :layouts), login_path %></li>
+            <% end %>
+          </ul>
+        </li>
         <% cache [I18n.locale, request.original_fullpath] do %>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,4 +1,9 @@
 <% if logged_in? %>
+  <% if can_control? %>
+    <% provide :nav_extras do %>
+      <li><%= link_to Icon[:'fa-times-circle'] + t('.delete'), project_path(@project) + '/delete_form', rel: 'nofollow' %></li>
+    <% end %>
+  <% end %>
   <div class="row">
     <% if in_development? %>
     <div class="alert alert-danger alert-dismissable text-center">

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,9 +1,4 @@
 <% if logged_in? %>
-  <% if can_control? %>
-    <% provide :nav_extras do %>
-      <li><%= link_to Icon[:'fa-times-circle'] + t('.delete'), project_path(@project) + '/delete_form', rel: 'nofollow' %></li>
-    <% end %>
-  <% end %>
   <div class="row">
     <% if in_development? %>
     <div class="alert alert-danger alert-dismissable text-center">
@@ -15,7 +10,14 @@
       <div class="main-badge-ques"></div>
     </div>
     <div class="col-md-7 col-sm-6">
-      <h1 class="m-t-0 h2"><%= t('.edit_status') %></h1>
+      <h1 class="m-t-0 h2"><%= t('.edit_status') %>
+    <% if can_control? %>
+      &nbsp;&nbsp;<%= link_to Icon[:'fa-times-circle'] +
+            t('projects.show.delete'),
+            project_path(@project) + '/delete_form', rel: 'nofollow',
+            class: 'btn btn-danger' %>
+    <% end %>
+    </h1>
   <%= render "form_#{@criteria_level}", project: @project, is_disabled: false %>
 <% else %>
   <% flash.now[:danger] = t('users.please_log_in') %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,14 +1,7 @@
-<% provide :nav_extras do %>
-    <%
-      # Cache the value of "can_edit?".  In some cases it will cause us
-      # to query GitHub, and we don't want to make duplicate external requests
-      @cached_can_edit = can_edit?
-      if @cacned_can_edit %>
+<% if logged_in? %>
+  <% provide :nav_extras do %>
       <li><%= link_to Icon[:'fa-edit'] + t('.edit'), edit_project_path(@project, criteria_level: @criteria_level), rel: 'nofollow' %></li>
-    <% end %>
-    <% if can_control? %>
-      <li><%= link_to Icon[:'fa-times-circle'] + t('.delete'), project_path(@project) + '/delete_form', rel: 'nofollow' %></li>
-    <% end %>
+  <% end %>
 <% end %>
 
 <div class="row">
@@ -38,15 +31,5 @@
   <%= t '.last_achieved_html', when: @project.achieved_passing_at %>
 <% end %>
 
-<br><br>
-<p>
-<%= link_to t('.back'), projects_path %>
-<% if @cacned_can_edit %>
-  <%= link_to t('.edit'), edit_project_path(@project), rel: 'nofollow' %>
-<% end %>
-<% if can_control? %>
-  <%= link_to t('.delete'), { action: :destroy, id: @project.id }, method: :delete, data: { confirm: t('.confirm_delete', project_id: @project.id) } %>
-<% end %>
-</p>
 </div>
 </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,7 +1,7 @@
-<% if logged_in? %>
-  <% provide :nav_extras do %>
-      <li><%= link_to Icon[:'fa-edit'] + t('.edit'), edit_project_path(@project, criteria_level: @criteria_level), rel: 'nofollow' %></li>
-  <% end %>
+<%# Always show this, logged in or not. This makes it possible to
+    serve the entire page from the CDN %>
+<% provide :nav_extras do %>
+    <li><%= link_to Icon[:'fa-edit'] + t('.edit'), edit_project_path(@project, criteria_level: @criteria_level), rel: 'nofollow' %></li>
 <% end %>
 
 <div class="row">


### PR DESCRIPTION
Tweak headers for projects:

* Change Edit so that it displays if a user is logged in,
  not if the user can actually edit.  Checking if a user can
  really edit can involve a lot of interaction with GitHub,
  and it might be better to only do that when you really *must*
  do so.
* Change Delete so that it displays on the edit screen, not the
  show screen.  This reduces the number of headers in the show
  screen, and it also reduces the risk of someone accidentally
  deleting their project when they were just showing it.
* Remove the small Back / Edit / Delete entries at the bottom.
  They were small, and it's not clear how many people even
  noticed them.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>