### PR TITLE
Allow CORS access to individual user data

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -26,7 +26,8 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       '/projects', '/projects.json', '/projects/*',
       '/projects/**/*', '/project_stats*',
       '/en/projects', '/en/projects.json', '/en/projects/*',
-      '/en/projects/**/*', '/en/project_stats*'
+      '/en/projects/**/*', '/en/project_stats*',
+      '/users/*.json', '/en/users/*.json'
     ].freeze
     RESOURCE_PATTERNS.each do |resource_pattern|
       resource resource_pattern, headers: :any, methods: ALLOWED_METHODS

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -113,6 +113,8 @@ class UsersControllerTest < ActionController::TestCase
     assert_response :success
     refute_includes @response.body, '%40example.com'
     refute_includes @response.body, '@example.com'
+    assert_equal 'no-cache, no-store',
+                 @response.headers['Cache-Control']
   end
 
   test 'JSON should NOT show email address when logged in as another user' do
@@ -120,6 +122,8 @@ class UsersControllerTest < ActionController::TestCase
     get :show, params: { id: @user, format: :json, locale: :en }
     assert_response :success
     refute_includes @response.body, 'example.com'
+    assert_equal 'no-cache, no-store',
+                 @response.headers['Cache-Control']
   end
 
   # This is a change, due to the EU General Data Protection Regulation (GDPR)
@@ -133,6 +137,8 @@ class UsersControllerTest < ActionController::TestCase
     get :show, params: { id: @user, locale: :en }
     assert_response :success
     assert_includes @response.body, 'mailto:melissa%40example.com'
+    assert_equal 'no-cache, no-store',
+                 @response.headers['Cache-Control']
   end
 
   test 'should show email address when logged in as admin' do
@@ -140,6 +146,8 @@ class UsersControllerTest < ActionController::TestCase
     get :show, params: { id: @user, locale: :en }
     assert_response :success
     assert_includes @response.body, 'mailto:melissa%40example.com'
+    assert_equal 'no-cache, no-store',
+                 @response.headers['Cache-Control']
   end
 
   test 'JSON should show email address when logged in as admin' do
@@ -147,6 +155,8 @@ class UsersControllerTest < ActionController::TestCase
     get :show, params: { id: @user, format: :json, locale: :en }
     assert_response :success
     assert_includes @response.body, 'melissa@example.com'
+    assert_equal 'no-cache, no-store',
+                 @response.headers['Cache-Control']
   end
 
   test 'should redirect edit when not logged in' do


### PR DESCRIPTION
Allow access to .json data to individual users
by client-side JavaScript by adding it to the
CORS access control list.

This also adds tests to ensure that we force no caching
of user data.  We disable caching to greatly reduce the
risk of an unintentional leak of user data via a cache.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>