### PR TITLE
Ignore vulnerability CVE-2015-9284 in omniauth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,11 @@ jobs:
     - run: bundle exec pronto run -f github text -c=$(git log --pretty=format:%H | tail -1) --exit-code
     # Temporarily disable bundle doctor; trying to run it produces an error.
     # - run: bundle exec bundle doctor
-    - run: bundle exec bundle audit check --update
+    # Ignore CVE-2015-9284 (omniauth); We have mitigated this with a
+    # third-party countermeasure (omniauth-rails_csrf_protection) in:
+    # https://github.com/coreinfrastructure/best-practices-badge/pull/1298
+    # - run: bundle exec bundle audit check --update
+    - run: bundle exec bundle audit check --update --ignore CVE-2015-9284
     - run: bundle exec rake whitespace_check
     - run: script/report_code_statistics
     # Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
     # The following line was run implicitly in your 1.0 builds based on what CircleCI inferred about the structure of your project. In 2.0 you need to be explicit about which commands should be run. In some cases you can discard inferred commands if they are not relevant to your project.
     - run: echo -e "export RAILS_ENV=test\nexport RACK_ENV=test" >> $BASH_ENV
     - run: '{ bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
-        --jobs=4 --retry=3; } && bundle clean --path=vendor/bundle'
+        --jobs=4 --retry=3; } && bundle clean'
     # Save dependency cache
     - save_cache:
         key: v1-dep-{{ .Branch }}-{{ epoch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,8 @@ jobs:
     - run: bundle --version
     # The following line was run implicitly in your 1.0 builds based on what CircleCI inferred about the structure of your project. In 2.0 you need to be explicit about which commands should be run. In some cases you can discard inferred commands if they are not relevant to your project.
     - run: echo -e "export RAILS_ENV=test\nexport RACK_ENV=test" >> $BASH_ENV
-    - run: 'bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
-        --jobs=4 --retry=3 '
+    - run: 'bundle check --path=vendor/bundle || { bundle install --path=vendor/bundle
+        --jobs=4 --retry=3 && bundle clean --path=vendor/bundle; }'
     # Save dependency cache
     - save_cache:
         key: v1-dep-{{ .Branch }}-{{ epoch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,8 @@ jobs:
     - run: bundle --version
     # The following line was run implicitly in your 1.0 builds based on what CircleCI inferred about the structure of your project. In 2.0 you need to be explicit about which commands should be run. In some cases you can discard inferred commands if they are not relevant to your project.
     - run: echo -e "export RAILS_ENV=test\nexport RACK_ENV=test" >> $BASH_ENV
-    - run: 'bundle check --path=vendor/bundle || { bundle install --path=vendor/bundle
-        --jobs=4 --retry=3 && bundle clean --path=vendor/bundle; }'
+    - run: '{ bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
+        --jobs=4 --retry=3; } && bundle clean --path=vendor/bundle'
     # Save dependency cache
     - save_cache:
         key: v1-dep-{{ .Branch }}-{{ epoch }}

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -113,7 +113,10 @@ task :bundle_audit do
         echo "Cannot update bundle-audit database; using current data."
       fi
       if [ "$apply_bundle_audit" = 't' ] ; then
-        bundle exec bundle audit check
+        # Ignore CVE-2015-9284 (omniauth); We have mitigated this with a
+        # third-party countermeasure (omniauth-rails_csrf_protection) in:
+        # https://github.com/coreinfrastructure/best-practices-badge/pull/1298
+        bundle exec bundle audit check --ignore CVE-2015-9284
       else
         true
       fi


### PR DESCRIPTION
Ignore CVE-2015-9284 (a vulnerability in omniauth).
We have mitigated this with a third-party countermeasure
(omniauth-rails_csrf_protection) in #1298

Signed-off-by: Jason Dossett <jdossett@utdallas.edu>