### PR TITLE
 Ignore vulnerability CVE-2015-9284 in omniauth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,11 @@ jobs:
     - run: bundle exec pronto run -f github text -c=$(git log --pretty=format:%H | tail -1) --exit-code
     # Temporarily disable bundle doctor; trying to run it produces an error.
     # - run: bundle exec bundle doctor
-    - run: bundle exec bundle audit check --update
+    # Ignore CVE-2015-9284 (omniauth); We have mitigated this with a
+    # third-party countermeasure (omniauth-rails_csrf_protection) in:
+    # https://github.com/coreinfrastructure/best-practices-badge/pull/1298
+    # - run: bundle exec bundle audit check --update
+    - run: bundle exec bundle audit check --update --ignore CVE-2015-9284
     - run: bundle exec rake whitespace_check
     - run: script/report_code_statistics
     # Save test results

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -116,7 +116,10 @@ task :bundle_audit do
         echo "Cannot update bundle-audit database; using current data."
       fi
       if [ "$apply_bundle_audit" = 't' ] ; then
-        bundle exec bundle audit check
+        # Ignore CVE-2015-9284 (omniauth); We have mitigated this with a
+        # third-party countermeasure (omniauth-rails_csrf_protection) in:
+        # https://github.com/coreinfrastructure/best-practices-badge/pull/1298
+        bundle exec bundle audit check --ignore CVE-2015-9284
       else
         true
       fi


### PR DESCRIPTION
Ignore CVE-2015-9284 (a vulnerability in omniauth). We have mitigated this with a third-party countermeasure (omniauth-rails_csrf_protection) in #1298