### PR TITLE
Update CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,99 +1,79 @@
-# This configuration was automatically generated from a CircleCI 1.0 config.
-# It should include any build commands you had along with commands that CircleCI
-# inferred from your project structure. We strongly recommend you read all the
-# comments in this file to understand the structure of CircleCI 2.0, as the idiom
-# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
-# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
-# configuration as a reference rather than using it in production, though in most
-# cases it should duplicate the execution of your original 1.0 config.
 version: 2
 jobs:
   build:
     working_directory: ~/coreinfrastructure/best-practices-badge
     parallelism: 1
     shell: /bin/bash --login
-    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
-    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
-    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
-    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
-    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
-    # We have selected a pre-built image that mirrors the build environment we use on
-    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
-    # of each job. For more information on choosing an image (or alternatively using a
-    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
-    # To see the list of pre-built images that CircleCI provides for most common languages see
-    # https://circleci.com/docs/2.0/circleci-images/
     docker:
-    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+    - image: jdossett/cii-bestpractices:2.5.1-stretch
+      environment:
+        PG_HOST: localhost
+        PG_USER: ubuntu
+        RAILS_ENV: test
+        RACK_ENV: test
+    - image: circleci/postgres:9.6-ram
+      environment:
+        POSTGRES_USER: ubuntu
+        POSTGRES_DB: circle_ruby_test
     steps:
-    - run: sudo service postgresql start
-    # Machine Setup
-    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
-    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
     - checkout
-    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
-    # In many cases you can simplify this from what is generated here.
-    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    # Prepare for artifact and test results
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
     # Dependencies
-    #   This would typically go in either a build or a build-and-test job when using workflows
     # Restore the dependency cache
     - restore_cache:
         keys:
-        # This branch if available
-        - v1-dep-{{ .Branch }}-
-        # Default branch if not
-        - v1-dep-master-
-        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
-        - v1-dep-
-    # This is based on your 1.0 configuration file or project settings
-    - run: echo "Pre-dependency pwd=`pwd`"
-    - run: REALLY_GEM_UPDATE_SYSTEM=1 gem update --system
-    - run: gem install bundler --no-document
-    - run: bundle --version
-    # The following line was run implicitly in your 1.0 builds based on what CircleCI inferred about the structure of your project. In 2.0 you need to be explicit about which commands should be run. In some cases you can discard inferred commands if they are not relevant to your project.
-    - run: echo -e "export RAILS_ENV=test\nexport RACK_ENV=test" >> $BASH_ENV
-    - run: 'bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
-        --jobs=4 --retry=3 '
+        # Find a cache corresponding to this particular Gemfile.lock checksum
+        - v2-dep-{{ checksum "Gemfile.lock" }}
+        # Find the most recently generated cache used
+        - v2-dep-
+    - run:
+        name: Update Rubygems
+        command: sudo gem update --system --silent
+        environment:
+          REALLY_GEM_UPDATE_SYSTEM: 1
+    - run:
+        name: Update bundler to match Gemfile.lock
+        command: >
+          sudo gem install bundler --no-document
+          -v "$(cat Gemfile.lock | tail -1 | tr -d ' ')"
+    - run:
+        name: Bundler Version
+        command: bundle --version
+    - run:
+        name: Install Bundle
+        command: >
+          bundle check --path=vendor/bundle ||
+          bundle install --path=vendor/bundle --jobs=4 --retry=3
     # Save dependency cache
     - save_cache:
-        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        key: v2-dep-{{ checksum "Gemfile.lock" }}
         paths:
-        # This is a broad list of cache paths to include many possible development environments
-        # You can probably delete some of these entries
-        - vendor/bundle
-        - ~/.bundle
-    # The following line was run implicitly in your 1.0 builds based on what CircleCI inferred about the structure of your project. In 2.0 you need to be explicit about which commands should be run. In some cases you can discard inferred commands if they are not relevant to your project.
-    - run: |-
-        mkdir -p config && echo 'test:
-          database: circle_ruby_test
-          adapter: postgresql
-          encoding: unicode
-          pool: <%= (ENV["DB_POOL"] || ((ENV["RAILS_MAX_THREADS"] || 5 ).to_i + 1)).to_i %>
-          timeout: 5000
-          username: ubuntu
-          host: localhost
-        ' > config/database.yml
+          - vendor/bundle
+          - ~/.bundle
     - run:
+        name: Configure database
+        command: |
+          cd config/
+          cp {database.ci,database}.yml
+    - run:
+        name: Create database
         command: bundle exec rake db:create db:schema:load --trace
-        environment:
-          RAILS_ENV: test
-          RACK_ENV: test
-    # Test
-    #   This would typically be a build job when using workflows, possibly combined with build
-    # This is based on your 1.0 configuration file or project settings
-    - run: '[[ ! -s "$(git rev-parse --git-dir)/shallow" ]] || git fetch --unshallow'
-    # The following line was run implicitly in your 1.0 builds based on what CircleCI inferred about the structure of your project. In 2.0 you need to be explicit about which commands should be run. In some cases you can discard inferred commands if they are not relevant to your project.
+    # Start testing
     - run:
+        name: Check for whitespace issues.
+        command: '[[ ! -s "$(git rev-parse --git-dir)/shallow" ]] || git fetch --unshallow'
+    - run:
+        name:  Run test suite
         command: bundle exec rake test
-        environment:
-          RAILS_ENV: test
-          RACK_ENV: test
-    # This is based on your 1.0 configuration file or project settings
-    - run: bundle exec pronto run -f github text -c=$(git log --pretty=format:%H | tail -1) --exit-code
+    - run:
+        name:  Run pronto GitHub
+        command: >
+          bundle exec pronto run -f github text
+          -c=$(git log --pretty=format:%H | tail -1) --exit-code
     # Temporarily disable bundle doctor; trying to run it produces an error.
     # - run: bundle exec bundle doctor
     # Ignore CVE-2015-9284 (omniauth); We have mitigated this with a
@@ -123,7 +103,7 @@ jobs:
         path: /tmp/circleci-test-results
   deploy-master:
     docker:
-      - image: buildpack-deps:trusty
+      - image: buildpack-deps:bionic
     steps:
       - checkout
       - run:
@@ -144,7 +124,7 @@ jobs:
           command: script/fastly_test
   deploy-staging:
     docker:
-      - image: buildpack-deps:trusty
+      - image: buildpack-deps:bionic
     steps:
       - checkout
       - run:
@@ -162,7 +142,7 @@ jobs:
           no_output_timeout: 400s
   deploy-production:
     docker:
-      - image: buildpack-deps:trusty
+      - image: buildpack-deps:bionic
     steps:
       - checkout
       - run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -932,8 +932,10 @@ Then run the following command:
 ~~~~
 
 Note at the end of this script a `git commit -as` will be initiated
-if everything worked correctly.
-You will need to be sure to run `git push` after doing this.
+if everything worked correctly. Next you should update the CircleCI build
+image and `.circleci/config.yml` as indicated in the dockerfiles
+[README](dockerfiles/README.md).  You will then need to commit those changes.
+and run `git push`.
 
 For more details about updating Ruby versions with rbenv, see
 <https://github.com/rbenv/ruby-build> and

--- a/config/database.ci.yml
+++ b/config/database.ci.yml
@@ -1,0 +1,8 @@
+test:
+  database: circle_ruby_test
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= (ENV["DB_POOL"] || ((ENV["RAILS_MAX_THREADS"] || 5 ).to_i + 1)).to_i %>
+  timeout: 5000
+  username: ubuntu
+  host: localhost

--- a/dockerfiles/2.5.1-stretch/Dockerfile
+++ b/dockerfiles/2.5.1-stretch/Dockerfile
@@ -1,0 +1,6 @@
+FROM circleci/ruby:2.5.1-stretch-node-browsers-legacy
+
+# skip installing gem documentation
+RUN sudo apt-get update && sudo apt-get install -y cmake
+
+USER circleci

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -1,0 +1,29 @@
+# CII Best Practices CircleCI Dockerfiles
+
+This directory contains directories and Dockerfiles for the custom
+images used in the app's CI pipeline on CircleCI.  When upgrading ruby,
+it is best to copy the folder and name it according to the CircleCI base
+image you are using.
+
+To upgrade the docker image you must have an account on DockerHub and docker
+installed on your computer (Install instructions are
+[here](https://docs.docker.com/install/). You can then run the following steps.
+
+1. Copy the existing file and directory as described above.
+2. Modify the Dockerfile to point to the correct base image.
+3. Log in to DockerHub
+    ~~~~sh
+    docker login -u <username>
+    ~~~~
+4. Build the docker image (replace `<tag>` below with for example
+   `2.5.1-stretch`.
+    ~~~~sh
+    docker build -t <username>/cii-bestpractices:<tag> .
+    ~~~~
+5. Push your image.
+    ~~~~sh
+    docker push <username>/cii-bestpractices:<tag>
+    ~~~~
+
+Once completed you can then update `.circleci/conifg.yml` to use the new image.
+You should also add your new Dockerfile to vesion control.


### PR DESCRIPTION
Our CircleCI configuration was woefully outdated, running on an ubuntu 14.04 image.  This PR updates the CircleCI config to run on a custom ruby:2.5.1-stretch image.

Also included is a Dockerfile to build the custom image and documentation updates.