### PR TITLE
Update bundler to version 2.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -546,4 +546,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.17.3
+   2.0.2


### PR DESCRIPTION
Update bundler to 2.0.2 using:

    gem install bundler
    rbenv rehash
    bundle update --bundler

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>