### PR TITLE
Disable turbolinks-cache-control due to incompatibility with Chartkick

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= csrf_meta_tags %>
+  <%= yield :special_head_values %>
 <%# The following are the same for a given locale, cache for speed -%>
 <% cache locale do # do not cache csrf_meta_tags -%>
   <title>BadgeApp</title>

--- a/app/views/project_stats/index.html.erb
+++ b/app/views/project_stats/index.html.erb
@@ -1,3 +1,14 @@
+<%# Disable turbolinks-cache-control due to incompatibility with Chartkick.
+    Chartkick doesn't work well with Turbolinks, because it requires a
+    "load" event that turbolinks does not provide.
+    We disable turbolinks in hyperlinks *to* this page.
+    In addition, we disable turbolinks-cache-control so that when a user
+    goes *back* to this page, the page won't be handled by turoblinks
+    (and thus the load event will occur).  This is unfortunate, but
+    making it work is more important. %>
+<% content_for :special_head_values do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
+<% end %>
 <%= javascript_include_tag 'project-stats', defer: true%>
 
 <%


### PR DESCRIPTION
Chartkick doesn't work well with Turbolinks, because it requires a
"load" event that turbolinks does not provide.
Disable turbolinks in hyperlinks *to* the page that uses Chartkick.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>