### PR TITLE
Force reload in /project_stats via turbolinks-visit-control

### DIFF
--- a/app/views/project_stats/index.html.erb
+++ b/app/views/project_stats/index.html.erb
@@ -1,13 +1,12 @@
-<%# Disable turbolinks-cache-control due to incompatibility with Chartkick.
+<%# Force turbolinks to reload due to incompatibility with Chartkick.
     Chartkick doesn't work well with Turbolinks, because it requires a
-    "load" event that turbolinks does not provide.
+    "load" event that turbolinks does not normally provide.
     We disable turbolinks in hyperlinks *to* this page.
-    In addition, we disable turbolinks-cache-control so that when a user
-    goes *back* to this page, the page won't be handled by turoblinks
+    In addition, we require a reload when turbolinks visits this page
     (and thus the load event will occur).  This is unfortunate, but
-    making it work is more important. %>
+    making this page work is more important. %>
 <% content_for :special_head_values do %>
-  <meta name="turbolinks-cache-control" content="no-cache">
+  <meta name="turbolinks-visit-control" content="reload">
 <% end %>
 <%= javascript_include_tag 'project-stats', defer: true%>
 


### PR DESCRIPTION
Modify HTML head to make /project_stats work with turbolinks.
Instead of using name="turbolinks-cache-control" content="no-cache",
use name="turbolinks-visit-control" content="reload".

For more information, see:
https://github.com/turbolinks/turbolinks#
ensuring-specific-pages-trigger-a-full-reload

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>