### PR TITLE
Document avatar security/privacy and add a little privacy

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -6,7 +6,13 @@
 
 module UsersHelper
   # Returns avatar image tag for the given user.
+  # 'referrerpolicy' is experimental; we use it to try to give our users
+  # additional privacy.  See:
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
   def avatar_for(user)
-    image_tag(user.avatar_url, alt: user.name, class: 'avatar', size: '80x80')
+    image_tag(
+      user.avatar_url, alt: user.name, class: 'avatar', size: '80x80',
+                       'referrerpolicy': 'no-referrer'
+    )
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -6,9 +6,21 @@
 
 module UsersHelper
   # Returns avatar image tag for the given user.
-  # 'referrerpolicy' is experimental; we use it to try to give our users
-  # additional privacy.  See:
+  # We use 'referrerpolicy' to try to give our users additional privacy,
+  # by not revealing exactly what page the user is merely viewing
+  # when retrieving this avatar.
+  # Officially 'referrerpolicy' is experimental, see:
   # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
+  # However, as of 2019-08-28 'referrerpolicy' in an HTMLImageElement
+  # is supported by Chrome 51, Firefox 50, Opera 38, Safari 11.1,
+  # Android webview 51, Chrome for Android 51, Firefox for Android 50,
+  # and Opera for Android 41; thus, this is widely supported. See:
+  # https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/
+  # referrerPolicy
+  # We don't necessarily mind reporting where a user came from when they
+  # *choose* to navigate to a link, but we want to try to provide
+  # additional privacy when the user is viewing information they may not
+  # realize is being transcluded (because they did not actively select it).
   def avatar_for(user)
     image_tag(
       user.avatar_url, alt: user.name, class: 'avatar', size: '80x80',

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -80,9 +80,11 @@ The BadgeApp web application MUST:
    its requirements.
 10. **Protect users and their privacy.**  In particular, we MUST
    comply with the EU General Data Protection Regulation (GDPR).
-   Don't expose user email addresses,
-   and don't expose user activities to unrelated sites
+   We don't expose user email addresses,
+   and we don't expose user activities to unrelated sites
    (including social media sites) without that user's consent.
+   In particular, we do not include "like" buttons that reveal that the
+   user viewed that particular page.
 11. **Be accessible.**
    We strive to comply with the
    <a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility
@@ -109,7 +111,7 @@ The BadgeApp web application MUST:
    We need these aggregate statistics to monitor the
    status of the badging project, and focus primarily on projects.
    These are aggregations, to help preserve user privacy.
-   See /project_stats and /criteria for these statistics.
+   See `/project_stats` and `/criteria` for these statistics.
 
 We do *not* need to support offline editing of data.
 

--- a/doc/security.md
+++ b/doc/security.md
@@ -261,28 +261,59 @@ learning about our users' activities (and thus maintaining user privacy):
   We have considered ways to further limit information sharing even
   though they are related sites, but law and technology currently limit this.
   We could download these images and re-serve them, but copying the images
-  into our own site could be considered a copyright violation
-  and would also impose significant extra resources.
-  Thus, since we cannot serve avatars ourselves,
-  at the very least the requestor's externally-visible IP address
+  into our own site might be considered a copyright violation
+  and would also impose the need for significant extra resources.
+  Thus, since we cannot serve avatars ourselves, we must direct requestors
+  to them, so at the very least the requestor's externally-visible IP address
   will be visible to the external avatar server.
-  We would like to limit third-party cookies and requestor headers at least.
-  We have not found a *good* way to prevent third-party cookies from being
-  sent in this case;
+  We would like to limit third-party cookies and requestor headers.
+  Unfortunately, we have not found a *good* way to prevent
+  third-party cookies from being sent in this case;
   [there are discussions on how to disable third party cookies for img tags](https://stackoverflow.com/questions/51549390/how-to-disable-third-party-cookie-for-img-tags),
   but currently-known
   mechanisms are complex, require inline CSS invocations,
   and have dubious reliability.
-  As far as hiding the requestor header, we have added the experimental
+  We hope that future web standards will add the ability to easily
+  prevent the unnecessary revelation of third-party cookies.
+  The story is somewhat better for requestor headers.
+  We have added the experimental
   `referrerpolicy="no-referrer"` attribute to the image
   as discussed in the
   [Mozilla img documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img).
+  While this attribute is technically experimental,
+  [the referrerpolicy attribute on images is widely supported](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy).
 
 For example, there is no reason that general-purpose social
 networking sites *must* see what our users are doing on our site, so we try to
 ensure that general-purpose social networking sites
 do not see what our users are doing unless the users
 take specific intentional actions to share information about themselves.
+In particular, we do not include "like" buttons that reveal that the
+user viewed that particular page.
+We do have "like" buttons, but they only reveal anything to a social networking
+site when a user actively selects the button, and *not* to other users
+who are simply viewing the page.
+Similarly, we do not embed any third-party analytics services.
+
+Note that this is different from what happens when a user actively
+clicks on a hypertext link to go to a different web site.
+In this case, the user *actively* selected to visit that different web site,
+and thus consented to the usual actions of visiting a different web site.
+The different web site must know the IP address of the user anyway
+(to send the data), and any cookies received by the different site
+will be a first-party cookie the site has previously sent
+(not the third-party cookies that are of bigger concern for privacy).
+In addition, we continue to allow referrer information to be sent in this case.
+When a user actively selects a hypertext link, it is normal web behavior
+for the receiving site to be provided with information on the referrer
+via the "referer" (sic) HTTP header as specified in
+[RFC 1945 (HTTP 1.0)](https://tools.ietf.org/html/rfc1945#page-44).
+This referrer information reports where the user "came from".
+This information is useful for many circmstances, including notifying
+recipients that people are discovering their site using our site.
+In short, our site merely continues to provide normal default web behavior.
+When users expressly choose to click on a link from our site, there is
+more express consent, so we do not see this an issue.
 
 Of course, to access the Internet the user must use various services and
 computers, and some of those could be privacy-exposing.

--- a/doc/security.md
+++ b/doc/security.md
@@ -203,20 +203,21 @@ We must first define what we mean by an unrelated site.
 A "related" site is a site that we are directly using to provide our service,
 in particular our cloud provider (Heroku which runs on
 Amazon's EC2 cloud-computing platform), CDN provider (Fastly),
-authorization services provider (GitHub), and logging / intrusion detection
-service.
+authorization and avatar services provider (GitHub),
+external avatar services (Gravatar),
+and logging / intrusion detection service.
 As a practical matter, related sites must (under various circumstances)
 receive some information about the user (at least that the user
 is trying to do something).
 In those cases we have selected partners we believe are trustworthy, and
-we have a direct relationship with them.
+we have some kind of relationship with them.
 
 However, there is no reason unrelated sites
 *must* see what our users are doing,
 so we take many steps to prevent unrelated sites from
 learning about our users' activities (and thus maintaining user privacy):
 
-* We directly serve all our assets ourselves,
+* We directly serve all our own assets ourselves,
   including JavaScipt, images, and fonts.
   Since we serve them ourselves, and never serve information via external
   third parties,
@@ -244,6 +245,44 @@ learning about our users' activities (and thus maintaining user privacy):
   *only* receives information when the user takes a direct action to
   request it (e.g., a click), and that site only receives information from
   the specific user who requested it.
+* User avatars are handled specially. We consider
+  the few avatar-serving domains that we use as related sites.
+  This issue may not be obvious, so here we'll drill into it.
+  A user can choose a representative avatar
+  (currently via GitHub or Gravatar).
+  Anyone who views that user's information page will
+  receive an img reference to that avatar so that they can see it.
+  External avatar images are only shown from specific domains
+  ('secure.gravatar.com' or 'avatars.githubusercontent.com'), they are
+  only included if the user has an avatar, and they are only shown to
+  others if that user's information was requested.
+  This functionality is useful, because these images can help others remember
+  who the user is.
+  We have considered ways to further limit information sharing even
+  though they are related sites, but law and technology currently limit this.
+  We could download these images and re-serve them, but copying the images
+  into our own site could be considered a copyright violation
+  and would also impose significant extra resources.
+  Thus, since we cannot serve avatars ourselves,
+  at the very least the requestor's externally-visible IP address
+  will be visible to the external avatar server.
+  We would like to limit third-party cookies and requestor headers at least.
+  We have not found a *good* way to prevent third-party cookies from being
+  sent in this case;
+  [there are discussions on how to disable third party cookies for img tags](https://stackoverflow.com/questions/51549390/how-to-disable-third-party-cookie-for-img-tags),
+  but currently-known
+  mechanisms are complex, require inline CSS invocations,
+  and have dubious reliability.
+  As far as hiding the requestor header, we have added the experimental
+  `referrerpolicy="no-referrer"` attribute to the image
+  as discussed in the
+  [Mozilla img documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img).
+
+For example, there is no reason that general-purpose social
+networking sites *must* see what our users are doing on our site, so we try to
+ensure that general-purpose social networking sites
+do not see what our users are doing unless the users
+take specific intentional actions to share information about themselves.
 
 Of course, to access the Internet the user must use various services and
 computers, and some of those could be privacy-exposing.


### PR DESCRIPTION
Document that avatar services are considered "related sites"
for purposes of security/privacy, and explain what they're all about.

In addition, add the experimental
`referrerpolicy="no-referrer"` attribute to the avatar image
as discussed in the
[Mozilla img documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)
to provide additional privacy.
We aren't required to do this by our policies, but in general we
try to maximize privacy while still providing our services.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>