### PR TITLE
Add word breaks and break-word to project table

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -1,6 +1,9 @@
 // Place all the styles related to the Projects controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+// We use "word-wrap: break-word;" to be compatible with IE and Edge,
+// even though word-wrap was renamed to overflow-wrap in CSS3. See:
+// https://makandracards.com/makandra/47957-html-making-browsers-wrap-long-words
 td.website {
   word-wrap: break-word;
   max-width: 150px;
@@ -8,4 +11,7 @@ td.website {
 td.license {
   word-wrap: break-word;
   max-width: 150px;
+}
+td.project_name {
+  word-wrap: break-word;
 }

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -4,6 +4,7 @@
 # CII Best Practices badge contributors
 # SPDX-License-Identifier: MIT
 
+# rubocop:disable Metrics/ModuleLength
 module ProjectsHelper
   MARKDOWN_RENDERER = Redcarpet::Render::HTML.new(
     filter_html: true, no_images: true,
@@ -145,4 +146,24 @@ module ProjectsHelper
     end
   end
   # rubocop:enable Metrics/MethodLength
+
+  # We sometimes insert <wbr> after sequences of these characters.
+  WORD_BREAK_DIVIDERS = /([,_\-.]+)/
+
+  # rubocop:disable Rails/OutputSafety
+  # This text is considered safe, so we can directly mark it as such.
+  SAFE_WORD_BREAK = '<wbr>'.html_safe
+  # rubocop:enable Rails/OutputSafety
+
+  # Insert wbr (HTML word break) after _ etc. per WORD_BREAK_DIVIDERS.
+  # The text is presumed to be unsafe.  We produce a safe (escaped) HTML result.
+  def word_breakdown(text)
+    safe_join(
+      text.split(WORD_BREAK_DIVIDERS).each_with_index.map do |fragment, i|
+        i.even? ? fragment : h(fragment) + SAFE_WORD_BREAK
+      end,
+      ''
+    )
+  end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/app/views/projects/_table.html.erb
+++ b/app/views/projects/_table.html.erb
@@ -20,8 +20,11 @@
     <% cache [project, locale] do %>
       <tr>
         <td><%= link_to project.id, project %></td>
-        <td><%= link_to (project.name.presence || t('.paren_name_unknown')),
-                project %></td>
+        <td class="project_name"><%=
+          link_to(
+            word_breakdown(project.name.presence || t('.paren_name_unknown')),
+            project
+          ) %></td>
         <td><span lang="en"><%= markdown(
                   (project.description || '').
                   truncate(160, separator: ' ')) %></span></td>
@@ -29,7 +32,7 @@
           <%# Defend against bad data - link only if plausible URL. %>
           <% if project.homepage_url.presence &&
                 project.homepage_url.match(/\Ahttps?:\/\//) %>
-            <a rel='nofollow' href="<%= project.homepage_url %>"><%= project.homepage_url %></a>
+            <a rel='nofollow' href="<%= project.homepage_url %>"><%= word_breakdown(project.homepage_url) %></a>
           <% else %>
             <%= project.homepage_url %>
           <% end %>


### PR DESCRIPTION
The "projects" table is wide, and that's a problem for
narrow screens (especially on mobile).
Part of the problem is that URLs don't easily break,
and some project names use characters like underscores
that are not automatically word breaks.

To resolve this, add word break hints on project names and
URLs, and also add word-wrap: break-word on project names
(word-wrap is already set on URLs).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>