### PR TITLE
Omit the license field from /projects

### DIFF
--- a/app/views/projects/_table.html.erb
+++ b/app/views/projects/_table.html.erb
@@ -6,7 +6,6 @@
       <th><%= sortable_header t('.name'), 'name' %></th>
       <th><%= t '.description' %></th>
       <th><%= sortable_header t('.website'), 'homepage_url' %></th>
-      <th><%= t '.license' %></th>
       <th><%= t '.owner' %></th>
       <th><%= sortable_header t('.last_achieved'), 'achieved_passing_at' %></th>
       <th><%= sortable_header t('.pachieved'), 'tiered_percentage' %></th>
@@ -38,7 +37,6 @@
           <% end %>
           <% end %>
         </td>
-        <td class='license'><%= project.license %></td>
         <td><%= link_to project.user_display_name, project.user,
                         rel: 'nofollow' %></td>
         <td><%= project.achieved_passing_at&.


### PR DESCRIPTION
The /projects page is wide, especially for mobile devices.
Few people really need to see the license at this level.
So remove it so that it's not as wide (or that other kinds of
information can be seen more readily).

The information is still available; users can always get license data
from an individual project, or download the database.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>