### PR TITLE
Add a "system announcement" capability

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -66,3 +66,32 @@
     </nav>
   </div>
 </header>
+<% if in_development? %>
+  <div class="row">
+  <div class="alert alert-danger alert-dismissable text-center">
+    <a href="#" class="close" data-dismiss="alert" aria-label="<%= t('projects.misc.close') %>">&times;</a>
+    <%= t('projects.misc.in_development_warning_html') %>
+  </div>
+  </div>
+<% end %>
+<% if ENV.has_key?('SYSTEM_ANNOUNCEMENT') %>
+  <%
+    # Show system announcement from environment variable if available.
+    # Use SYSTEM_ANNOUNCEMENT_<locale> if available, else SYSTEM_ANNOUNCEMENT
+    locale_key = "SYSTEM_ANNOUNCEMENT_#{I18n.locale}"
+    if ENV.has_key?(locale_key)
+      announcement = ENV[locale_key]
+    else
+      announcement = ENV['SYSTEM_ANNOUNCEMENT']
+    end
+    # Announcement is from the environment variable region, which is a
+    # trusted source.  Therefore, allow <b> etc.
+    announcement = announcement.html_safe
+  %>
+  <div class="row">
+  <div class="alert alert-danger alert-dismissable text-center">
+    <a href="#" class="close" data-dismiss="alert" aria-label="<%= t('projects.misc.close') %>">&times;</a>
+    <%= announcement %>
+  </div>
+  </div>
+<% end %>

--- a/app/views/projects/delete_form.html.erb
+++ b/app/views/projects/delete_form.html.erb
@@ -1,12 +1,6 @@
 <%# TODO: nav_extras? %>
 
 <div class="row">
-  <% if in_development? %>
-  <div class="alert alert-danger alert-dismissable text-center">
-    <a href="#" class="close" data-dismiss="alert" aria-label="<%= t('projects.misc.close') %>">&times;</a>
-    <%= t('projects.misc.in_development_warning_html') %>
-  </div>
-  <% end %>
   <div class="col-md-2 col-sm-3">
     <div class="main-badge-ques"></div>
   </div>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,11 +1,5 @@
 <% if logged_in? %>
   <div class="row">
-    <% if in_development? %>
-    <div class="alert alert-danger alert-dismissable text-center">
-      <a href="#" class="close" data-dismiss="alert" aria-label="<%= t('projects.misc.close') %>">&times;</a>
-      <%= t('projects.misc.in_development_warning_html') %>
-    </div>
-    <% end %>
     <div class="col-md-2 col-sm-3">
       <div class="main-badge-ques"></div>
     </div>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -12,12 +12,6 @@
 %>
 <% if logged_in? %>
   <div class='row'>
-    <% if in_development? %>
-      <div class="alert alert-danger alert-dismissable text-center">
-        <a href="#" class="close" data-dismiss="alert" aria-label="<%= t('projects.misc.close') %>">&times;</a>
-        <%= t('projects.misc.in_development_warning_html') %>
-      </div>
-    <% end %>
   <div class="col-md-12">
   <br>
   <h2 class='center'><%= t('.new_badge') %></h2>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -12,12 +12,6 @@
 <% end %>
 
 <div class="row">
-  <% if in_development? %>
-  <div class="alert alert-danger alert-dismissable text-center">
-    <a href="#" class="close" data-dismiss="alert" aria-label="<%= t('projects.misc.close') %>">&times;</a>
-    <%= t('projects.misc.in_development_warning_html') %>
-  </div>
-  <% end %>
   <div class="col-md-2 col-sm-3">
     <div class="main-badge-ques"></div>
   </div>

--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -46,6 +46,8 @@ Then point your web browser at "localhost:3000".
 
 The application is configured by various environment variables:
 
+* SYSTEM_ANNOUNCEMENT and SYSTEM_ANNOUNCEMENT_locale : Show these
+  system-wide announcements (e.g., to announce a soon-to-occur shutdown)
 * PUBLIC_HOSTNAME (default 'localhost')
 * BADGEAPP_MAX_REMINDERS (default 2): Number of email reminders to send
   to inactive projects when running "rake reminders".


### PR DESCRIPTION
Add a "system announcement" capability.
If environment variables SYSTEM_ANNOUNCEMENT
(and optionally SYSTEM_ANNOUNCEMENT_locale) are set, show them on
every application page as an announcement.

The immediate purpose is so that we can warn about a
soon-to-occur brief shutdown for a database upgrade.
But this is a general-purpose mechanism that can be used for other
purposes as well.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>