### PR TITLE
Embed expiry in cookies (FORCES LOGOFF BY ALL USERS)

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -25,11 +25,3 @@ ActiveSupport.to_time_preserves_timezone = false
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = false
-
-# To improve security, Rails 5.2.* embeds the expiry information
-# also in encrypted or signed cookies value.
-# This new embed information make those cookies incompatible with
-# versions of Rails older than 5.2.
-# That would log off users who are trying to save values, so disable for now.
-Rails.application.config.action_dispatch.use_authenticated_cookie_encryption =
-  false

--- a/doc/security.md
+++ b/doc/security.md
@@ -1883,6 +1883,14 @@ secure=true (which is irrelevant because we always use HTTPS but it
 can't hurt), and SameSite=Lax (which counters CSRF attacks on
 web browsers that support it).
 
+We also use the Rails 5.2 default setting which embeds
+the expiry information in encrypted or signed cookies value to
+improve security.
+Embedding and checking expiration data
+makes it harder to exploit these cookies.
+See
+[expiry in signed or encrypted cookie is now embedded in the cookies values](https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#expiry-in-signed-or-encrypted-cookie-is-now-embedded-in-the-cookies-values).
+
 #### CSRF token hardening
 
 We use two additional CSRF token hardening techniques


### PR DESCRIPTION
To improve security, by default Rails 5.2 changed to embed
the expiry information in encrypted or signed cookies value.

This commit switches to the Rails 5.2 default, which hardens our
software. As a side-effect, this logs off all users.

Up to this point we have disabled the Rails 5.2 default because we
didn't want to force a mass logoff by all users.
We disabled it by setting
Rails.application.config.action_dispatch.use_authenticated_cookie_encryption
to false.  However, now that we have a new "announcement" mechanism,
we can *warn* users before they get logged off.
So now we can switch to this new behavior without hurting our users.

For more information, see
[Upgrading Ruby on Rails expiry info](https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#expiry-in-signed-or-encrypted-cookie-is-now-embedded-in-the-cookies-values).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>