### PR TITLE
Allow repo_url mod if REPO_URL_CHANGE_DELAY days pass

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -418,7 +418,7 @@ class ProjectsController < ApplicationController
     params.permit([:criteria_level])
   end
 
-  # Return an extracted URL with its scheme ('http:') & trailing '/' removed.
+  # Return an extracted URL without its scheme ('http:') & trailing '/'.
   def extracted_url(url)
     url.split('://', 2)[1].chomp('/')
   end
@@ -434,7 +434,10 @@ class ProjectsController < ApplicationController
     extracted_url(url1) == extracted_url(url2)
   end
 
-  REPO_URL_CHANGE_DELAY = 180 # Number of days before repo_url change allowed
+  # Number of days before a user may change repo_url. See below.
+  # NOTE: If you change this value, you may also need to change
+  # file config/locales/en.yml key repo_url_limits.
+  REPO_URL_CHANGE_DELAY = 180
 
   # Return true iff the project can change its repo_url because the
   # REPO_URL_CHANGE_DELAY has expired

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -453,8 +453,11 @@ en:
       more_non_whitespace: Must have at least 15 non-whitespace characters.
     edit:
       edit_status: Edit Project Badge Status
-      repo_url_limits: You may only change your repo_url from
-        http to https
+      repo_url_limits: >-
+        You may only change your repo_url if it is
+        (1) more than 180 days since it was last changed, or
+        (2) it is only a switch between http and https.
+        Please file an issue (with rationale) if you need to change it sooner.
       changed_since_html: >-
         Another user has made a change to that record since you
         accessed the edit form. <br>Please open a new <a href="%{edit_url}"

--- a/db/migrate/20191021173151_add_repo_url_updated_at_to_projects.rb
+++ b/db/migrate/20191021173151_add_repo_url_updated_at_to_projects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRepoUrlUpdatedAtToProjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :repo_url_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_12_170808) do
+ActiveRecord::Schema.define(version: 2019_10_21_173151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -362,6 +362,7 @@ ActiveRecord::Schema.define(version: 2018_06_12_170808) do
     t.string "achieve_silver_status", default: "Unmet", null: false
     t.text "achieve_silver_justification"
     t.integer "tiered_percentage"
+    t.datetime "repo_url_updated_at"
     t.index ["achieved_passing_at"], name: "index_projects_on_achieved_passing_at"
     t.index ["badge_percentage_0"], name: "index_projects_on_badge_percentage_0"
     t.index ["badge_percentage_1"], name: "index_projects_on_badge_percentage_1"

--- a/doc/security.md
+++ b/doc/security.md
@@ -122,7 +122,7 @@ The following sections are organized following the assurance case figures:
   This is a merger of the second and third assurance case figures
   (implementation is shown in a separate figure because there is so much
   to it, but in the text we merge the contents of these two figures).
-* We then discuss securuity implemented by other life cycle processes,
+* We then discuss security implemented by other life cycle processes,
   broken into the main 12207 headings:
   agreement processes, organizational project-enabling processes, and
   technical management processes.
@@ -630,6 +630,23 @@ However, only an administrator with deployment platform access
 is authorized to do that, and few people have that privilege.
 The deployment platform infrastructure verifies authentication and
 authorization.
+
+There is an odd special case involving the repository URL `repo_url`.
+We are trying to counter subtle attacks where
+a project tries to claim the good reputation or effort of another project
+by constantly switching its `repo_url` to other projects and/or nonsense.
+The underlying problem is that names/identities are hard; the `repo_url`
+(when present) is the closest to an "identity" that we have for a project.
+We have to allow it to change sometimes (because it sometimes does), but
+it should be a rare "sticky" event.
+There are various special cases, e.g., you can always set the `repo_url`
+if it's nil, the setter is an admin, or if only the scheme is changed.
+But otherwise normal users can't change the `repo_urls` in less than
+`REPO_URL_CHANGE_DELAY` days (a constant set in the projects controller).
+Allowing users to change `repo_urls`, but only
+with large delays, reduces the administration effort required.
+By doing this, we help protect the integrity of the overall database
+from potentially-malicious authorized users.
 
 #### Modification to official application requires authorization via GitHub
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -583,7 +583,7 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_redirected_to project_path(@project, locale: :en)
   end
 
-  test 'should fail to change tail of non-blank repo_url' do
+  test 'should succeed and fail to change tail of non-blank repo_url' do
     new_repo_url = @project_two.repo_url + '_new'
     log_in_as(@project_two.user)
     patch :update, params: {
@@ -592,10 +592,24 @@ class ProjectsControllerTest < ActionController::TestCase
       },
       locale: :en
     }
+    # Check for success
+    @project_two.reload
+    assert_equal @project_two.repo_url, new_repo_url
+
+    # Now let's do it again. *This* should fail, it's too soon.
+    second_repo_url = new_repo_url + '_second'
+    patch :update, params: {
+      id: @project_two, project: {
+        repo_url:  second_repo_url
+      },
+      locale: :en
+    }
+    # Ensure the second attempt failed.
     assert_not_empty flash
     assert_template :edit
     @project_two.reload
-    assert_not_equal @project_two.repo_url, new_repo_url
+    assert_not_equal @project_two.repo_url, second_repo_url
+    assert_equal @project_two.repo_url, new_repo_url
   end
 
   test 'should change https to http in non-blank repo_url' do


### PR DESCRIPTION
Allow a project to modify its repo_url, but only after
REPO_URL_CHANGE_DELAY days (currently 180 days) since the last
time its repo_url changed.  This should reduce admin effort
while still countering a subtle attack.

We are trying to counter subtle attacks where
a project tries to claim the good reputation or effort of another project
by constantly switching its repo_url to other projects and/or nonsense.
The underlying problem is that names/identities are hard; the repo_url
(when present) is the closest to an "identity" that we have for a project.
We have to allow it to change sometimes (because it sometimes does), but
it should be a rare "sticky" event.

There are various special cases, e.g., you can always set the repo_url
if it's nil, the setter is an admin, or if only the scheme is changed.
But otherwise normal users can't change the repo_urls in less than
REPO_URL_CHANGE_DELAY days.

Allowing users to change repo_urls, but only
with large delays, reduces administration effort while still
countering the attack.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>