### PR TITLE
Allow N/A in implement_secure_design, fixes #1354

### DIFF
--- a/criteria/criteria.yml
+++ b/criteria/criteria.yml
@@ -1141,6 +1141,8 @@
     - Secure development knowledge: !!omap
       - implement_secure_design:
           category: MUST
+          na_allowed: true
+          na_justification_required: true
           met_justification_required: true
           rationale: >
             This was inspired by the


### PR DESCRIPTION
The text of silver criterion implement_secure_design
expressly allows N/A, but the UI does not permit N/A.
Fix that.

This fixes fixes #1354.  We thank @fzipi for reporting this!

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>