### PR TITLE
Fix typo in crypto_credential_agility; fixes #1340

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2440,7 +2440,7 @@ en:
           (such as passwords and dynamic tokens) and private cryptographic
           keys in files that are separate from other information
           (such as configuration files, databases, and logs),
-          and permit users to update and replacement them without
+          and permit users to update and replace them without
           code recompilation. If the project never processes authentication
           credentials and private cryptographic keys, select "not
           applicable" (N/A).


### PR DESCRIPTION
Fix a trivial word error in silver criterion
crypto_credential_agility. In the text
"permit users to update and replacement them ...",
change the word "replacement" should be "replace".

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>