### PR TITLE
Re-enable railroader static analyzer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ AllCops:
     - 'db/migrate/2016*.rb'
     - 'bin/**'
     - 'node_modules/**/*'
+    - 'railroader/**/*'
 Documentation:
   Enabled: false
 Lint/HandleExceptions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -973,5 +973,5 @@ git remote add upstream \
 
 If the version of Ruby has changed (in the Gemfile),
 use the 'Ruby itself can be updated' instructions.
-If gems have been added or their versions changed,
-run "bundle install" to install the new ones.
+If gems have been added or their versions changed, run
+"bundle install" to install the new ones.

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -65,14 +65,17 @@ end
 desc 'Run rails_best_practices with options'
 task :rails_best_practices do
   sh 'bundle exec rails_best_practices ' \
-      '--features --spec --without-color'
+      '--features --spec --without-color --exclude railroader/'
 end
 
 desc 'Setup railroader if needed'
 task 'railroader/bin/railroader' do
   # "gem install" doesn't honor Gemfile.lock, so use git clone + bundle install
   sh 'mkdir -p railroader'
-  sh 'cd railroader; git clone --depth 1 https://github.com/david-a-wheeler/railroader.git ./ ; cp ../.ruby-version .; bundle install'
+  sh 'cd railroader; ' \
+     'git clone --depth 1 ' \
+     'https://github.com/david-a-wheeler/railroader.git ./ ; ' \
+     'cp ../.ruby-version .; bundle install'
 end
 
 desc 'Run railroader'
@@ -81,7 +84,8 @@ task railroader: %w[railroader/bin/railroader] do
   # sh 'bundle exec railroader --quiet --no-pager'
   # Workaround to run correct version of railroader & its dependencies.
   # We have to set BUNDLE_GEMFILE so bundle works inside the rake task
-  sh 'cd railroader; echo "About to try"; BUNDLE_GEMFILE=$(pwd)/Gemfile bundle exec bin/railroader --quiet --no-pager $(dirname $(pwd))'
+  sh 'cd railroader; BUNDLE_GEMFILE=$(pwd)/Gemfile ' \
+     'bundle exec bin/railroader --quiet --no-pager $(dirname $(pwd))'
 end
 
 desc 'Run bundle if needed'
@@ -205,9 +209,8 @@ desc 'Check YAML syntax (except project.yml, which is not straight YAML)'
 task :yaml_syntax_check do
   # Don't check "project.yml" - it's not a straight YAML file, but instead
   # it's processed by ERB (even though the filename doesn't admit it).
-  sh "find . -name '*.yml' ! -name 'projects.yml' " \
-     "! -path './vendor/*' -exec bundle exec yaml-lint {} + | " \
-     "grep -v '^Checking the content of' | grep -v 'Syntax OK'"
+  sh "find . -name '*.yml' ! -name 'projects.yml' ! -path './railroader/*' " \
+     "! -path './vendor/*' -exec bundle exec yaml-lint {} + \;"
 end
 
 # The following are invoked as needed.

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -68,12 +68,20 @@ task :rails_best_practices do
       '--features --spec --without-color'
 end
 
+desc 'Setup railroader if needed'
+task 'railroader/bin/railroader' do
+  # "gem install" doesn't honor Gemfile.lock, so use git clone + bundle install
+  sh 'mkdir -p railroader'
+  sh 'cd railroader; git clone --depth 1 https://github.com/david-a-wheeler/railroader.git ./ ; cp ../.ruby-version .; bundle install'
+end
+
 desc 'Run railroader'
-task :railroader do
-  # TEMPORARILY DISABLE - old haml is vulnerable
-  puts('WARNING!!: Railroader temporarily disabled due to haml gem issue')
+task railroader: %w[railroader/bin/railroader] do
   # Disable pager, so that "rake" can keep running without halting.
   # sh 'bundle exec railroader --quiet --no-pager'
+  # Workaround to run correct version of railroader & its dependencies.
+  # We have to set BUNDLE_GEMFILE so bundle works inside the rake task
+  sh 'cd railroader; echo "About to try"; BUNDLE_GEMFILE=$(pwd)/Gemfile bundle exec bin/railroader --quiet --no-pager $(dirname $(pwd))'
 end
 
 desc 'Run bundle if needed'

--- a/script/report_code_statistics
+++ b/script/report_code_statistics
@@ -2,7 +2,7 @@
 echo
 direct=$(sed -e '1,/^DEPENDENCIES/d' -e '/^RUBY VERSION/,$d' \
              -e '/^$/d' Gemfile.lock | wc -l)
-indirect=$(bundle show | tail -n +2 | wc -l)
+indirect=$(bundle list | tail -n +2 | wc -l)
 echo "Number of gems (direct dependencies only) = $direct"
 echo "Number of gems (including indirect dependencies) = $indirect"
 echo


### PR DESCRIPTION
This re-enables the use of the "railroader" static analyzer.
Unfortunately "gem install" doesn't honor Gemfile.lock, only Gemfile.
Implement some workarounds so we can get this working again.
(The intent is to have a cleaner approach longer-term, but we
want to get this working *now*).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>