### PR TITLE
Show a "don't spam us" message in new badge entry

### DIFF
--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -16,6 +16,8 @@
   <br>
   <h2 class='center'><%= t('.new_badge') %></h2>
   <br>
+  <%= raw t('.tell_us') %>
+  <br>
   <% if current_user.provider == 'github'%>
      <h4><%= t '.may_select_html' %></h4>
      <br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -394,6 +394,13 @@ en:
         There may be a significant delay after submitting as we
         try to automatically fill in information.
       new_badge: New badge
+      tell_us: >
+        Please tell us about your free/libre/open source software (FLOSS)
+        project. This <b>MUST</b> be a FLOSS project; nothing else is permitted.
+        Do <b>NOT</b> add a site to try to improve a site's
+        search engine optimization (SEO); this spamming is
+        hurtful to real users and will not work anyway (because
+        all hyperlinks are marked as <tt>ugc</tt> and <tt>nofollow</tt>).
       may_select_html: >-
         You may select from one of your GitHub repos <em>OR</em>
         provide information about some other project.


### PR DESCRIPTION
This modifies the "create new badge entry" screen to
display a "don't spam us" message. I suspect many spammers
won't care, but some might, and it's a cheap way to
discourage spammers.

I've included technical text about ugc and nofollow for two reasons:

1. the technically savvy spammers will realize that
   we're not worth spamming, *and*
2. the technically savvy NON-spammers will see that
   we're trying to fight spam (and will appreciate us for that).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>