### PR TITLE
When showing delay convert seconds to hours

### DIFF
--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -18,7 +18,7 @@ class AccountActivationsController < ApplicationController
       flash[:success] = t('account_activations.activated') + ' ' +
                         t(
                           'account_activations.delay',
-                          count: LOCAL_LOGIN_COOLOFF_TIME
+                          count: LOCAL_LOGIN_COOLOFF_TIME / 3600.0
                         )
       # We do *not* log in user. This reduces the number of paths that
       # automatically log in, and increases the likelihood


### PR DESCRIPTION
Local login delay is recorded in seconds, but displayed in hours.
Add the forgotten "divide by 3600".

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>