### PR TITLE
Restore railroader to the set of checks run on CircleCI

### DIFF
--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -35,7 +35,6 @@ task(:default).clear.enhance %w[
 # This is a shorter list; many checks are run by a separate "pronto" task.
 # Temporarily includes "railroader", we hope to move that to pronto.
 # Removed bundle_doctor due to CircleCI failures
-# Temporarily removed railroader due to vulnerable haml library
 # Temporarily removed fasterer
 task(:ci).clear.enhance %w[
   rbenv_rvm_setup
@@ -46,6 +45,7 @@ task(:ci).clear.enhance %w[
   whitespace_check
   yaml_syntax_check
   report_code_statistics
+  railroader
 ]
 
 # Simple smoke test to avoid development environment misconfiguration


### PR DESCRIPTION
We removed railroader because of problems running it.
Now that we can run it again, restore it to the set of
checks run on CircleCI.

In the longer term we move all of this to its own container,
but let's get the checks in use for now.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>