### PR TITLE
Modify new_activation_link_created to note delay

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,8 +300,8 @@ en:
     redirect_existing: That user already exists. Did you mean
       to sign in?
     new_activation_link_created: >-
-      New activation link created. Please check your email to
-      activate your account.
+      New activation link created. Please check your email in a few minutes to
+      activate your account. (There is some intentional delay to counter spam.)
     please_log_in: Please log in.
   project_stats:
     index:


### PR DESCRIPTION
We've intentionally added a short delay after signing in before
the user receives the activation link.

This commit specifically mentions that delay to the user, so that the
user won't be surprised by that.  It also mentions why the delay
(it's an anti-spam measure). That should reduce the annoyance level of
real users, and it may help discourage spammers.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>