### PR TITLE
Refactor X-SMTPAPI and add tests for it

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -29,8 +29,8 @@ class ApplicationMailer < ActionMailer::Base
        '"opentrack" : { "settings" : { "enable" : 0 } } ' \
     '} }'
 
-  # Force fast failure on start if NORMAL_X_SMTPAPI is not valid JSON
-  JSON.parse(NORMAL_X_SMTPAPI)
+  # This forces fast failure on start if NORMAL_X_SMTPAPI is not valid JSON
+  NORMAL_X_SMTPAPI_JSON = JSON.parse(NORMAL_X_SMTPAPI).freeze
 
   # All mailer actions should call this unless they have a special need.
   # This allows us to have different values; we cannot override

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -16,6 +16,15 @@ class UserMailerTest < ActionMailer::TestCase
     assert_equal ['badgeapp@localhost'], mail.from
     assert_match user.activation_token, mail.body.encoded
     assert_match CGI.escape(user.email), mail.body.encoded
+    # Ensure that email has settings to disable tracking and delay sending
+    refute_nil mail['X-SMTPAPI'].unparsed_value
+    extensions = JSON.parse(mail['X-SMTPAPI'].unparsed_value)
+    assert_includes extensions, 'send_at'
+    assert extensions['send_at'] > Time.now.utc.to_i
+    assert_includes extensions, 'filters'
+    disable = { 'settings' => { 'enable' => 0 } }
+    assert_equal disable, extensions['filters']['clicktrack']
+    assert_equal disable, extensions['filters']['opentrack']
   end
 
   test 'password_reset' do
@@ -32,6 +41,14 @@ class UserMailerTest < ActionMailer::TestCase
     # Ensure that the reset token is actually being passed:
     assert_match user.reset_token, mail.parts[0].body.to_s
     assert_match CGI.escape(user.email), mail.body.encoded
+    # Ensure that email has settings to disable tracking
+    refute_nil mail['X-SMTPAPI'].unparsed_value
+    extensions = JSON.parse(mail['X-SMTPAPI'].unparsed_value)
+    refute_includes extensions, 'send_at'
+    assert_includes extensions, 'filters'
+    disable = { 'settings' => { 'enable' => 0 } }
+    assert_equal disable, extensions['filters']['clicktrack']
+    assert_equal disable, extensions['filters']['opentrack']
   end
 
   test 'direct_message' do


### PR DESCRIPTION
Sendgrid uses X-SMTPAPI in ways we depend on, in particular,
we want to forcibly disable clicktracking and ask for a
delay in sending activation emails.

This refactors the calculation of X-SMTPAPI to make it
easier to query/test, and adds tests for the value of
X-SMTPAPI in some sample emails.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>