### PR TITLE
Add .well-known/security.txt, fixes #1372

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Feedback and contributions are very welcome!
 Here's help on how to make contributions, divided into the following sections:
 
 * general information,
-* vulnerability reporting,
+* [vulnerability reporting](#how_to_report_vulnerabilities),
 * documentation changes,
 * code changes,
 * how to check proposed changes before submitting them,
@@ -167,7 +167,7 @@ Since they are often not visible, they can cause silent problems
 and misleading unexpected changes.
 For example, some editors (e.g., Atom) quietly delete them by default.
 
-## Vulnerability reporting (security issues)
+## <span id="how_to_report_vulnerabilities">Vulnerability reporting (security issues)</a>
 
 If you find a significant vulnerability, or evidence of one,
 please send an email to the security contacts that you have such

--- a/CREDITS
+++ b/CREDITS
@@ -39,7 +39,14 @@ create and close issues, accept proposed changes,
 and release versions of software, as well administrate the production system.
 This is enough to meet the "access_continuity" criterion.
 
+We currently don't have any security vulnerabilities that have been
+found externally by others. If someone *has* done so, and would like to
+be credited, we will gladly do so! If we've accidentally forgotten to give
+you credit, our apologies; please let us know so we can quickly fix that.
+We *want* people to report any vulnerabilities our system has, so that
+we can quickly fix them. Please see our information on
+[how_to_report_vulnerabilities](CONTRIBUTING.md#how_to_report_vulnerabilities).
+
 Karl Fogel not only provided us helpful inputs, but his book
 "Producing Open Secure Software" <http://producingoss.com/>
 was an important basis for identifying many project best practices - thank you!
-

--- a/doc/security.md
+++ b/doc/security.md
@@ -15,7 +15,8 @@ easier to put them all in one document.
 
 Sadly, perfection is rare; we really want your help.
 If you find a vulnerability, please see
-[CONTRIBUTING.md](../CONTRIBUTING.md) for how to submit a vulnerability report.
+[CONTRIBUTING.md#how_to_report_vulnerabilities](../CONTRIBUTING.md#how_to_report_vulnerabilities)
+for how to submit a vulnerability report.
 For more technical information on the implementation, see
 [implementation.md](implementation.md).
 

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,10 @@
+# Security risk contact information, per https://securitytxt.org/
+Contact: https://github.com/coreinfrastructure/best-practices-badge/blob/master/CONTRIBUTING.md#vulnerability-reporting-security-issues
+Acknowledgments: https://github.com/coreinfrastructure/best-practices-badge/blob/master/CREDITS
+Preferred-Languages: en
+Canonical: https://bestpractices.coreinfrastructure.org/.well-known/security.txt
+#
+# We try hard to keep the badge application secure. If you find a vulnerability,
+# please let us know so that we can fix it!  For a broader context on how we
+# try to keep this software secure, see its assurance case here:
+# https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/security.md


### PR DESCRIPTION
Add .well-known/security.txt as recommended in https://securitytxt.org/

This adds a simplified direct link to the text about how to
report vulnerabilities, to make it easier to get there immediately.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>