### PR TITLE
Handle malformed criteria level, fixes #1257

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -67,7 +67,21 @@ class ProjectsController < ApplicationController
   end
 
   # GET /projects/1
-  def show; end
+  def show
+    # Fix malformed queries of form "/en/projects/188?criteria_level,2"
+    # These produce parsed.query_values of {"criteria_level,2"=>nil}
+    # They end up as weird special keys, so this is the easy way to detect them
+    # We fix these malformed queries to increase the chance that a user
+    # will find the intended data.
+    parsed = Addressable::URI.parse(request.original_url)
+    if parsed&.query_values&.include?('criteria_level,2')
+      redirect_to project_path(@project, criteria_level: 2), status: 301
+    elsif parsed&.query_values&.include?('criteria_level,1')
+      redirect_to project_path(@project, criteria_level: 1), status: 301
+    elsif parsed&.query_values&.include?('criteria_level,0')
+      redirect_to project_path(@project, criteria_level: 0), status: 301
+    end
+  end
 
   # GET /projects/1.json
   def show_json

--- a/test/integration/project_get_test.rb
+++ b/test/integration/project_get_test.rb
@@ -101,4 +101,31 @@ class ProjectGetTest < ActionDispatch::IntegrationTest
     # verify that caching varies depending on the Origin.
     assert_equal('Accept-Encoding, Origin', @response.headers['Vary'])
   end
+
+  test 'Redirect malformed query string criteria_level,2' do
+    get project_path(id: @project_one.id, locale: 'en') + '?criteria_level,2'
+    # Should redirect
+    assert_response 301
+    assert_redirected_to project_path(
+      id: @project_one.id, locale: 'en', criteria_level: 2
+    )
+  end
+
+  test 'Redirect malformed query string criteria_level,1' do
+    get project_path(id: @project_one.id, locale: 'de') + '?criteria_level,1'
+    # Should redirect
+    assert_response 301
+    assert_redirected_to project_path(
+      id: @project_one.id, locale: 'de', criteria_level: 1
+    )
+  end
+
+  test 'Redirect malformed query string criteria_level,0' do
+    get project_path(id: @project_one.id, locale: 'fr') + '?criteria_level,0'
+    # Should redirect
+    assert_response 301
+    assert_redirected_to project_path(
+      id: @project_one.id, locale: 'fr', criteria_level: 0
+    )
+  end
 end


### PR DESCRIPTION
The production website is getting crawled using a large number of
malformed requests of the form "?criteria_level,2". E.g.:

at=info method=GET path="/en/projects/188?criteria_level,2"

This commit produces a permanent redirect (301) to point
malformed queries to the correct queries.
That way, the crawler can learn what it SHOULD be querying instead.

If there's something on OUR site that is GENERATING these bad URLs,
I'd like to fix that, but I haven't found anything.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>