### PR TITLE
Document ActionController::TestCase is obsolete

### DIFF
--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -7,6 +7,9 @@
 require 'test_helper'
 require 'ipaddr'
 
+# TODO: ActionController::TestCase is obsolete. This should switch to using
+# ActionDispatch::IntegrationTest and then remove rails-controller-testing.
+# See: https://github.com/rails/rails/issues/22496
 class ApplicationControllerTest < ActionController::TestCase
   test 'fail_if_invalid_client_ip works correctly' do
     a = ApplicationController.new

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -6,6 +6,9 @@
 
 require 'test_helper'
 
+# TODO: ActionController::TestCase is obsolete. This should switch to using
+# ActionDispatch::IntegrationTest and then remove rails-controller-testing.
+# See: https://github.com/rails/rails/issues/22496
 class PasswordResetsControllerTest < ActionController::TestCase
   def setup
     ActionMailer::Base.deliveries.clear

--- a/test/controllers/project_stats_controller_test.rb
+++ b/test/controllers/project_stats_controller_test.rb
@@ -6,6 +6,9 @@
 
 require 'test_helper'
 
+# TODO: ActionController::TestCase is obsolete. This should switch to using
+# ActionDispatch::IntegrationTest and then remove rails-controller-testing.
+# See: https://github.com/rails/rails/issues/22496
 class ProjectStatsControllerTest < ActionController::TestCase
   setup do
     @project_stat = project_stats(:one)

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -7,6 +7,9 @@
 require 'test_helper'
 
 # rubocop:disable Metrics/ClassLength
+# TODO: ActionController::TestCase is obsolete. This should switch to using
+# ActionDispatch::IntegrationTest and then remove rails-controller-testing.
+# See: https://github.com/rails/rails/issues/22496
 class ProjectsControllerTest < ActionController::TestCase
   setup do
     @project = projects(:one)

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -6,6 +6,9 @@
 
 require 'test_helper'
 
+# TODO: ActionController::TestCase is obsolete. This should switch to using
+# ActionDispatch::IntegrationTest and then remove rails-controller-testing.
+# See: https://github.com/rails/rails/issues/22496
 class SessionsControllerTest < ActionController::TestCase
   setup do
     @user = users(:test_user_melissa)

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -6,8 +6,8 @@
 
 require 'test_helper'
 
-# Inherit from ActionDispatch::IntegrationTest because
-# ActionController::TestCase is now obsolete.
+# Note: we inherit from ActionDispatch::IntegrationTest, not
+# ActionController::TestCase, because the latter is obsolete.
 # rubocop: disable Metrics/BlockLength, Metrics/ClassLength
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest
   test 'should get home' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -7,6 +7,9 @@
 require 'test_helper'
 
 # rubocop:disable Metrics/ClassLength
+# TODO: ActionController::TestCase is obsolete. This should switch to using
+# ActionDispatch::IntegrationTest and then remove rails-controller-testing.
+# See: https://github.com/rails/rails/issues/22496
 class UsersControllerTest < ActionController::TestCase
   setup do
     @user = users(:test_user_melissa)


### PR DESCRIPTION
ActionController::TestCase is obsolete. The Rails developers want
people to switch to using ActionDispatch::IntegrationTest ; see:
https://github.com/rails/rails/issues/22496

However, this isn't immediately obvious in the code.
We include rails-controller-testing which keeps those tests running.

This commit clearly documents that as a "TODO" we want to
to switch from ActionController::TestCase to ActionDispatch::IntegrationTest ;
this will discourage people from adding tests using the
obsolete interface. It also encourages people to switch tests
to the newer system. Finally, it notes that once we remove all uses of
ActionController::TestCase we can remove the gem rails-controller-testing.

This merely commits comments, instead of "doing" anything.
But clearly documenting what needs to change, right where the code
needs to change, seems like a good first step to actually changing things.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>