### PR TITLE
Update test/controllers/sessions_controller_test.rb

### DIFF
--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -6,40 +6,71 @@
 
 require 'test_helper'
 
-# TODO: ActionController::TestCase is obsolete. This should switch to using
-# ActionDispatch::IntegrationTest and then remove rails-controller-testing.
-# See: https://github.com/rails/rails/issues/22496
-class SessionsControllerTest < ActionController::TestCase
+class SessionsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:test_user_melissa)
   end
 
   test 'should get new' do
-    get :new, params: { locale: :en }
+    get '/en/sessions/new'
     assert_response :success
+
+    # Do quick text search to see if email input field exists
+    assert_match(
+      /<input [^>]+ type="email" name="session\[email\]" id="session_email" /,
+      @response.body
+    )
+    # Do a pickier check of the results using XPath selectors
+    assert_select(
+      'form/input[type="email"][name="session[email]"][id="session_email"]'
+    )
+
+    # Do quick text search for the password input field
+    # We use parentheses here to make it clear "/" is a regex, not a division.
+    assert_match(/<input [^>]+ type="password" /, @response.body)
+    # Do a pickier check using XPath selectors
+    assert_select(
+      'form/input[type="password"]' \
+      '[name="session[password]"][id="session_password"]'
+    )
+
+    # Ensure we have the link (button) for GitHub login.
+    assert_select 'a[data-method="post"][href="/auth/github?locale=en"]'
   end
 
-  test 'should redirect logged in' do
-    log_in_as(@user)
-    get :new, params: { locale: :en }
-    assert_not flash.empty?
+  test 'should redirect if already logged in' do
+    log_in_as(@user, password: 'password1')
+    get '/en/sessions/new'
+    assert_response :redirect
     assert_redirected_to root_url
+    follow_redirect!
+    assert_response :success
+    assert_not flash.empty?
   end
 
-  test 'login via session controller' do
-    post :create, params: {
+  test 'Simple login (directly)' do
+    # This is a trivial test; if this fails, more complicated tests will too.
+    # We include this trivial test so we can separately see if
+    # just the basics work.
+    post '/en/login', params: {
       session: {
         provider: 'local', email: 'test@example.org', password: 'password'
       }
     }
+    assert_response :redirect
+    assert_redirected_to root_url
+    follow_redirect!
     assert flash && flash[:success]
     assert flash[:success].include?('Logged in!')
   end
 
   test 'local login fails if deny_login' do
+    # WARNING: This test manipulates a global setting, namely
+    # Rails.application.config.deny_login. Parallel testing with *processes*
+    # is fine, parallel testing with *threads* will not work.
     old_deny = Rails.application.config.deny_login
     Rails.application.config.deny_login = true # Not thread-safe
-    post :create, params: {
+    post '/en/login', params: {
       session: {
         provider: 'local', email: 'test@example.org', password: 'password'
       }


### PR DESCRIPTION
Update test/controllers/sessions_controller_test.rb
so that instead of using the obsolete ActionController::TestCase
it is switched to using ActionDispatch::IntegrationTest.
See: https://github.com/rails/rails/issues/22496
I didn't worry about possible overlaps with existing tests;
the existing integration tests are generally long and focus on
important sequences, while these are short tests that check
specific issues.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>