### PR TITLE
Update UsersControllerTest

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -145,6 +145,8 @@ module SessionsHelper
   def log_out
     forget(current_user)
     session.delete(:user_id)
+    session.delete(:session_id)
+    session.delete(:time_last_used)
     @current_user = nil
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,6 +276,7 @@ en:
     edit:
       update_user_info: Update User Information
       save_changes: Save changes
+      inadequate_privileges: Sorry, you are not allowed to do that.
     update:
       profile_updated: Profile updated
     show:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -153,6 +153,7 @@ Capybara.server = :puma, { Silent: true }
 # checking.
 
 module ActiveSupport
+  # rubocop: disable Metrics/ClassLength
   class TestCase
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical
     # order.
@@ -290,5 +291,19 @@ module ActiveSupport
       end
       ''
     end
+
+    # Re-implement assert_select - return true iff a CSS selection
+    # using *selector* contains exactly "contents".
+    # The problem is that assert_select fails oddly when running a global
+    # "rails test" (though it works fine if running "rails test FILENAME").
+    # To solve this, we re-implement assert_select so we have a working version.
+    def my_assert_select(selector, contents)
+      results = css_select(selector)
+      results.each do |selection|
+        return true if selection.content == contents
+      end
+      false
+    end
   end
+  # rubocop: enable Metrics/ClassLength
 end


### PR DESCRIPTION
Update UsersControllerTest to use ActionDispatch::IntegrationTest
instead of the obsolete ActionController::TestCase.

This changes all of its tests to use the router instead of
calling the controller directly, with the result that the tests
are more like the "real thing". I also added a number of
checks to ensure that the test didn't merely *run* but also
produced expected *results*.  In process it was revealed that
a case wasn't covered: if a user deletes himself, he should
automatically be logged off. This doesn't seems to be a *security*
problem (since the "non-user" would have no rights), but it
would leave the user in a weird state, so let's fix that.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>