### PR TITLE
Update projects_controller_test.rb

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -216,7 +216,8 @@ module SessionsHelper
   def session_expired
     return true unless session.key?(:time_last_used)
 
-    session[:time_last_used] < SESSION_TTL.ago.utc
+    last_used = session[:time_last_used]
+    last_used < SESSION_TTL.ago.utc
   end
 
   def validate_session_timestamp

--- a/test/controllers/projects_controller_special_test.rb
+++ b/test/controllers/projects_controller_special_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Copyright 2015-2017, the Linux Foundation, IDA, and the
+# CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+require 'test_helper'
+
+# TODO: ActionController::TestCase is obsolete. This should switch to using
+# ActionDispatch::IntegrationTest and then remove rails-controller-testing.
+# See: https://github.com/rails/rails/issues/22496
+# However, these tests are hard to transition, so these remain.
+class ProjectsControllerSpecialTest < ActionController::TestCase
+  tests ProjectsController
+
+  setup do
+    @project = projects(:one)
+  end
+
+  test 'should fail to edit due to old session' do
+    log_in_as(@project.user, time_last_used: 1000.days.ago.utc)
+    get :edit, params: { id: @project, locale: :en }
+    assert_response 302
+    assert_redirected_to login_path
+  end
+
+  test 'should fail to edit due to session time missing' do
+    log_in_as(@project.user, time_last_used: 1000.days.ago.utc)
+    session.delete(:time_last_used)
+    get :edit, params: { id: @project, locale: :en }
+    assert_response 302
+    assert_redirected_to login_path
+  end
+end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -7,20 +7,14 @@
 require 'test_helper'
 
 # rubocop:disable Metrics/ClassLength
-# TODO: ActionController::TestCase is obsolete. This should switch to using
-# ActionDispatch::IntegrationTest and then remove rails-controller-testing.
-# See: https://github.com/rails/rails/issues/22496
-class ProjectsControllerTest < ActionController::TestCase
+class ProjectsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @project = projects(:one)
     @project_two = projects(:two)
     @project_no_repo = projects(:no_repo)
-    @perfect_unjustified_project = projects(:perfect_unjustified)
     @perfect_passing_project = projects(:perfect_passing)
-    @perfect_silver_project = projects(:perfect_silver)
-    @perfect_project = projects(:perfect)
     @user = users(:test_user)
-    @user2 = users(:test_user_melissa)
+    @user2 = users(:test_user_melissa) # password 'password1'
     @admin = users(:admin_user)
   end
 
@@ -45,23 +39,26 @@ class ProjectsControllerTest < ActionController::TestCase
   # rubocop:enable Metrics/MethodLength
 
   test 'should get index' do
-    get :index, params: { locale: :en }
+    get '/en/projects'
     assert_response :success
-    assert_not_nil assigns(:projects)
     assert_includes @response.body, 'Badge status'
     refute_includes @response.body, 'target=[^ >]+>'
   end
 
   test 'new but not logged in' do
-    get :new, params: { locale: :en }
+    get '/en/projects/new'
     assert_response :success
     assert_includes @response.body, 'Log in with '
+    refute_includes @response.body,
+                    'What is the URL for the project home page ' \
+                    '(the URL for the project as a whole)'
   end
 
   test 'should get new' do
     log_in_as(@user)
-    get :new, params: { locale: :en }
+    get '/en/projects/new'
     assert_response :success
+    refute_includes @response.body, 'Log in with '
     assert_includes @response.body,
                     'What is the URL for the project home page ' \
                     '(the URL for the project as a whole)'
@@ -71,20 +68,28 @@ class ProjectsControllerTest < ActionController::TestCase
     log_in_as(@user)
     stub_request(:get, 'https://api.github.com/user/repos')
       .to_return(status: 200, body: '', headers: {})
+    # Use assert_difference to verify that project record created & email sent
     assert_difference [
       'Project.count', 'ActionMailer::Base.deliveries.size'
     ] do
-      post :create, params: {
+      post '/en/projects', params: { # Routes to 'create'
         project: {
           description: @project.description,
           license: @project.license,
           name: @project.name,
           repo_url: 'https://www.example.org/code',
           homepage_url: @project.homepage_url
-        },
-        locale: :en
+        }
       }
     end
+    # Ensure that we actually created the project with those values
+    new_project = Project.find_by(repo_url: 'https://www.example.org/code')
+    assert_equal @project.description, new_project.description
+    assert_equal @project.license, new_project.license
+    assert_equal @project.name, new_project.name
+    assert_equal 'https://www.example.org/code', new_project.repo_url
+    assert_equal @project.homepage_url, new_project.homepage_url
+    assert new_project.id != @project.id
   end
 
   test 'should create project with empty repo' do
@@ -94,15 +99,14 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_difference [
       'Project.count', 'ActionMailer::Base.deliveries.size'
     ] do
-      post :create, params: {
+      post '/en/projects', params: { # Routes to 'create'
         project: {
           description: @project.description,
           license: @project.license,
           name: @project.name,
           repo_url: '',
           homepage_url: @project.homepage_url
-        },
-        locale: :en
+        }
       }
     end
   end
@@ -114,15 +118,14 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_no_difference [
       'Project.count', 'ActionMailer::Base.deliveries.size'
     ] do
-      post :create, params: {
+      post '/en/projects', params: { # Routes to 'create'
         project: {
           description: 'Some other project',
           license: @project.license,
           name: @project.name,
           repo_url: @project.repo_url,
           homepage_url: @project_two.homepage_url
-        },
-        locale: :en
+        }
       }
     end
   end
@@ -133,18 +136,18 @@ class ProjectsControllerTest < ActionController::TestCase
     # retrieve information about user repositories.
     url = 'https://api.github.com/user/repos?per_page=50&sort=pushed'
     stub_request(:get, url).to_return(status: 200, body: '', headers: {})
-    assert_no_difference('Project.count') do
-      post :create, params: { project: { name: @project.name } }
+    assert_no_difference('Project.count') do # Post routes to 'create'
+      post '/en/projects', params: { project: { name: @project.name } }
     end
     assert_no_difference('Project.count') do
-      post :create, format: :json, params: {
+      post '/en/projects.json', params: {
         project: { name: @project.name }
       }
     end
   end
 
   test 'should show project' do
-    get :show, params: { id: @project, locale: :en }
+    get "/en/projects/#{@project.id}"
     assert_response :success
     assert_includes @response.body,
                     'What is the human-readable name of the project'
@@ -158,7 +161,8 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   test 'should show project with criteria_level=1' do
-    get :show, params: { id: @project, criteria_level: '1', locale: :en }
+    # Use "/1" suffix to indicate criteria_level=1
+    get "/en/projects/#{@project.id}/1"
     assert_response :success
     assert_select(+'a[href=?]', 'https://www.nasa.gov')
     assert_select(+'a[href=?]', 'https://www.nasa.gov/pathfinder')
@@ -166,7 +170,8 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   test 'should show project with criteria_level=2' do
-    get :show, params: { id: @project, criteria_level: '2', locale: :en }
+    # Use parameter criteria_level
+    get "/en/projects/#{@project.id}?criteria_level=2"
     assert_response :success
     assert_select(+'a[href=?]', 'https://www.nasa.gov')
     assert_select(+'a[href=?]', 'https://www.nasa.gov/pathfinder')
@@ -174,7 +179,7 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   test 'should show project JSON data with locale' do
-    get :show_json, params: { id: @project, format: :json, locale: :en }
+    get "/en/projects/#{@project.id}.json"
     assert_response :success
     body = JSON.parse(response.body)
     assert_equal 'Pathfinder OS', body['name']
@@ -184,7 +189,7 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   test 'should show project JSON data without locale' do
-    get :show_json, params: { id: @project, format: :json }
+    get "/projects/#{@project.id}.json"
     assert_response :success
     body = JSON.parse(response.body)
     assert_equal 'Pathfinder OS', body['name']
@@ -196,9 +201,12 @@ class ProjectsControllerTest < ActionController::TestCase
 
   test 'should get edit' do
     log_in_as(@project.user)
-    get :edit, params: { id: @project, locale: :en }
+    assert_equal(
+      'Logged in! Last login: (No previous time recorded.)', flash['success']
+    )
+    get "/en/projects/#{@project.id}/edit"
     assert_response :success
-    assert_not_empty flash
+    assert_includes @response.body, 'Edit Project Badge Status'
   end
 
   test 'should get edit as additional rights user' do
@@ -211,9 +219,9 @@ class ProjectsControllerTest < ActionController::TestCase
     )
     new_right.save!
     log_in_as(test_user)
-    get :edit, params: { id: @project, locale: :en }
+    get "/en/projects/#{@project.id}/edit" # Invokes "edit"
     assert_response :success
-    assert_not_empty flash
+    assert_includes @response.body, 'Edit Project Badge Status'
   end
 
   # rubocop:disable Metrics/BlockLength
@@ -233,13 +241,11 @@ class ProjectsControllerTest < ActionController::TestCase
       user_id: @admin.id
     )
     previous_update = @project.updated_at
-    # Run patch (the point of the test)
-    patch :update, params: {
-      id: @project,
+    # Run patch (the point of the test), which invokes the 'update' method
+    patch "/en/projects/#{@project.id}", params: {
       project: { name: @project.name }, # *Something* so not empty.
       additional_rights_changes:
-        "+ #{users(:test_user_mark).id}, #{users(:test_user_melissa).id}",
-      locale: :en
+        "+ #{users(:test_user_mark).id}, #{users(:test_user_melissa).id}"
     }
     # Check that results are what was expected
     assert_redirected_to project_path(assigns(:project))
@@ -268,12 +274,11 @@ class ProjectsControllerTest < ActionController::TestCase
     ).save!
     assert_equal 2, AdditionalRight.where(project_id: @project.id).count
     log_in_as(@project.user)
-    patch :update, params: {
-      id: @project.id,
+    # Run patch (the point of the test), which invokes the 'update' method
+    patch "/en/projects/#{@project.id}", params: {
       project: { name: @project.name }, # *Something* so not empty.
       additional_rights_changes:
-        "- #{users(:test_user_melissa).id}, #{users(:test_user_mark).id}",
-      locale: :en
+        "- #{users(:test_user_melissa).id}, #{users(:test_user_mark).id}"
     }
     # TODO: Weird http/https discrepancy in test
     # assert_redirected_to project_path(@project, locale: :en)
@@ -291,51 +296,78 @@ class ProjectsControllerTest < ActionController::TestCase
     ).save!
     assert_equal 2, AdditionalRight.where(project_id: @project.id).count
     log_in_as(users(:test_user_melissa))
-    patch :update, params: {
-      id: @project.id,
+    # Run patch (the point of the test), which invokes the 'update' method
+    patch "/en/projects/#{@project.id}", params: {
       project: { name: @project.name }, # *Something* so not empty.
-      additional_rights_changes:
-        "- #{users(:test_user_mark).id}",
-      locale: :en
+      additional_rights_changes: "- #{users(:test_user_mark).id}"
     }
-    assert_redirected_to project_path(assigns(:project))
+    # TODO: Currently we don't report an error if a non-owner
+    # tries to remove an "additional rights" user, we just ignore it.
+    # If we add an error report, we should check for that error report here.
+    assert_redirected_to root_path(locale: 'en')
     assert_equal 2, AdditionalRight.where(project_id: @project.id).count
   end
 
-  test 'should not get edit as user without additional rights' do
+  test 'should not get edit page as user without additional rights' do
     # This *expressly* tests that a normal logged-in
-    # user cannot edit another project's data without authorization.
-    # Without additional rights, can't edit.  This is paired with
+    # user cannot request the edit page of another project's data
+    # without authorization.
+    # Without additional rights, you can't edit.  This is paired with the
     # previous test, to ensure that *only* the additional right provides
-    # the necessary rights.  This is a key test: we *prevent* users
-    # logged in with one normal account from editing others' data.
+    # the necessary rights.
     test_user = users(:test_user_mark)
     log_in_as(test_user)
-    get :edit, params: { id: @project, locale: :en }
-    assert_response 302
-    assert_redirected_to root_path
+    get "/en/projects/#{@project.id}/edit" # Routes to 'edit'
+    assert_redirected_to root_url
   end
 
-  test 'should fail to edit due to old session' do
-    log_in_as(@project.user, time_last_used: 1000.days.ago.utc)
-    get :edit, params: { id: @project, locale: :en }
-    assert_response 302
-    assert_redirected_to login_path
-  end
+  # Having trouble translating this test, will do later.
+  # test 'should fail to get edit page due to old session' do
+  #   log_in_as(@project.user)
+  #   assert_equal(
+  #     'Logged in! Last login: (No previous time recorded.)', flash['success']
+  #   )
+  #   session[:time_last_used] = 1000.days.ago.utc
+  #   get "/en/projects/#{@project.id}/edit" # Routes to 'edit'
+  #   assert_response 302
+  #   assert_redirected_to login_path
+  #   # follow_redirect!
+  #   # refute_includes @response.body, 'Edit Project Badge Status'
+  # end
 
-  test 'should fail to edit due to session time missing' do
-    log_in_as(@project.user, time_last_used: 1000.days.ago.utc)
-    session.delete(:time_last_used)
-    get :edit, params: { id: @project, locale: :en }
-    assert_response 302
-    assert_redirected_to login_path
-  end
+  # test 'should fail to edit due to session time missing' do
+  #   log_in_as(@project.user, time_last_used: 1000.days.ago.utc)
+  #   session.delete(:time_last_used)
+  #   get :edit, params: { id: @project, locale: :en }
+  #   assert_response 302
+  #   assert_redirected_to login_path
+  # end
 
-  test 'should update project' do
+  test 'should update project (using patch)' do
     log_in_as(@project.user)
     new_name = @project.name + '_updated'
-    patch :update, params: {
-      id: @project, locale: :en, project: {
+    # Run patch (the point of the test), which invokes the 'update' method
+    patch "/en/projects/#{@project.id}", params: {
+      project: {
+        description: @project.description,
+        license: @project.license,
+        name: new_name,
+        repo_url: @project.repo_url,
+        homepage_url: @project.homepage_url
+      }
+    }
+    assert_redirected_to project_path(assigns(:project))
+    @project.reload
+    assert_equal @project.name, new_name
+  end
+
+  test 'should update project (using put)' do
+    log_in_as(@project.user)
+    new_name = @project.name + '_updated'
+    # Run put (the point of the test), which invokes the 'update' method
+    # A separate test uses "patch" instead; both should work.
+    put "/en/projects/#{@project.id}", params: {
+      project: {
         description: @project.description,
         license: @project.license,
         name: new_name,
@@ -352,8 +384,9 @@ class ProjectsControllerTest < ActionController::TestCase
     # Note: no log_in_as
     old_name = @project.name
     new_name = old_name + '_updated'
-    patch :update, params: {
-      id: @project, project: {
+    # Run patch (the point of the test), which invokes the 'update' method
+    patch "/en/projects/#{@project.id}", params: {
+      project: {
         description: @project.description,
         license: @project.license,
         name: new_name,
@@ -374,22 +407,27 @@ class ProjectsControllerTest < ActionController::TestCase
       name: '',
       homepage_url: 'example.org' # bad url
     }
-    patch :update, params: {
-      id: @project, project: new_project_data, locale: :en
+    # Run patch (the point of the test), which invokes the 'update' method
+    patch "/en/projects/#{@project.id}", params: {
+      project: new_project_data
     }
     # "Success" here only in the HTTP sense - we *do* get a form...
     assert_response :success
     # ... but we just get the edit form.
-    assert_template :edit
+    assert_includes @response.body, 'Edit Project Badge Status'
 
     # Do the same thing, but as for JSON
-    patch :update, params: {
-      id: @project, format: :json, project: new_project_data, locale: :en
+    patch "/en/projects/#{@project.id}.json", params: {
+      project: new_project_data
     }
     assert_response :unprocessable_entity
   end
 
-  test 'should fail to update stale project' do
+  # rubocop: disable Metrics/BlockLength
+  test 'should fail to update stale project due to optimistic locking' do
+    # Check for proper handling of project[lock_version] in the HTML like
+    # <input type="hidden" value="73" name="project[lock_version]"
+    # id="project_lock_version" />
     new_name1 = @project.name + '_updated-1'
     new_project_data1 = { name: new_name1 }
     new_name2 = @project.name + '_updated-2'
@@ -398,82 +436,98 @@ class ProjectsControllerTest < ActionController::TestCase
       lock_version: @project.lock_version
     }
     log_in_as(@project.user)
-    patch :update, params: {
-      id: @project, project: new_project_data1, locale: :en
+    patch "/en/projects/#{@project.id}", params: {
+      project: new_project_data1
     }
     assert_redirected_to project_path(@project, locale: :en)
-    get :edit, params: { id: @project, locale: :en }
-    patch :update, params: {
-      id: @project, project: new_project_data2, locale: :en
+    get "/en/projects/#{@project.id}/edit"
+    assert_includes @response.body, 'Edit Project Badge Status'
+    assert_includes @response.body, new_name1
+    refute_includes @response.body, new_name2
+    patch "/en/projects/#{@project.id}", params: {
+      project: new_project_data2
     }
-    assert_not_empty flash
-    assert_template :edit
+    assert_includes flash['danger'],
+                    'Another user has made a change to that record ' \
+                    'since you accessed the edit form.'
+    assert_includes @response.body, 'Edit Project Badge Status'
+    # Return to the user the *unsaved* values in the edit field, along with
+    # the error message. That way, the user can store them separately
+    # (say as a printout).
+    refute_includes @response.body, new_name1
+    assert_includes @response.body, new_name2
+    # Now reload the actually-stored record to check on what's in the database.
     assert_difference '@project.lock_version' do
       @project.reload
     end
     assert_equal @project.name, new_name1
   end
+  # rubocop: enable Metrics/BlockLength
 
   test 'should fail update project with invalid control in name' do
     log_in_as(@project.user)
     old_name = @project.name
     new_name = @project.name + "\x0c"
-    patch :update, params: {
-      id: @project, project: {
+    patch "/en/projects/#{@project.id}", params: {
+      project: {
         description: @project.description,
         license: @project.license,
         name: new_name,
         repo_url: @project.repo_url,
         homepage_url: @project.homepage_url
-      },
-      locale: :en
+      }
     }
     # "Success" here only in the HTTP sense - we *do* get a form...
     assert_response :success
     # ... but we just get the edit form.
-    assert_template :edit
+    assert_includes @response.body, 'Edit Project Badge Status'
     assert_equal @project.name, old_name
   end
 
   test 'should fail to update other users project' do
-    new_name = @project_two.name + '_updated'
+    old_name = @project_two.name
+    new_name = old_name + '_updated'
     assert_not_equal @user, @project_two.user
     log_in_as(@user)
-    patch :update, params: {
-      id: @project_two, project: { name: new_name }, locale: :en
+    patch "/en/projects/#{@project_two.id}", params: {
+      project: { name: new_name }
     }
     assert_redirected_to root_url(locale: :en)
+    @project_two.reload
+    assert_equal old_name, @project_two.name
   end
 
   test 'admin can update other users project' do
     new_name = @project.name + '_updated'
     log_in_as(@admin)
     assert_not_equal @admin, @project.user
-    patch :update, params: {
-      id: @project, project: { name: new_name }, locale: :en
+    patch "/en/projects/#{@project.id}", params: {
+      project: { name: new_name }
     }
     assert_redirected_to project_path(assigns(:project))
     @project.reload
-    assert_equal @project.name, new_name
+    assert_equal new_name, @project.name
   end
 
   test 'A perfect passing project should have the passing badge' do
-    get :badge,
-        params: { id: @perfect_passing_project, format: 'svg', locale: :en }
+    # NOTICE!! Badge URLs do *NOT* have a locale prefix
+    get "/projects/#{@perfect_passing_project.id}/badge",
+        params: { format: 'svg' }
     assert_response :success
     assert_equal contents('badge-passing.svg'), @response.body
   end
 
   test 'A perfect silver project should have the silver badge' do
-    get :badge,
-        params: { id: @perfect_silver_project, format: 'svg', locale: :en }
+    @perfect_silver_project = projects(:perfect_silver)
+    get "/projects/#{@perfect_silver_project.id}/badge",
+        params: { format: 'svg' }
     assert_response :success
     assert_equal contents('badge-silver.svg'), @response.body
   end
 
   test 'A perfect silver project should have the silver badge in JSON' do
-    get :badge,
-        params: { id: @perfect_silver_project, format: 'json', locale: :en }
+    @perfect_silver_project = projects(:perfect_silver)
+    get "/projects/#{@perfect_silver_project.id}/badge.json"
     assert_response :success
     json_data = JSON.parse(@response.body)
     assert_equal 'silver', json_data['badge_level']
@@ -481,27 +535,29 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   test 'A perfect project should have the gold badge' do
-    get :badge, params: { id: @perfect_project, format: 'svg' }
+    @perfect_project = projects(:perfect)
+    get "/projects/#{@perfect_project.id}/badge"
     assert_response :success
     assert_equal contents('badge-gold.svg'), @response.body
   end
 
   test 'A perfect unjustified project should have in progress badge' do
-    get :badge, params: { id: @perfect_unjustified_project, format: 'svg' }
+    @perfect_unjustified_project = projects(:perfect_unjustified)
+    get "/projects/#{@perfect_unjustified_project.id}/badge"
     assert_response :success
     assert_includes @response.body, 'in progress'
   end
 
   test 'An in-progress project must reply in_progress in JSON' do
-    get :badge, params: { id: @project, format: 'json' }
+    get "/projects/#{@project.id}/badge.json"
     assert_response :success
     json_data = JSON.parse(@response.body)
     assert_equal 'in_progress', json_data['badge_level']
     assert_equal @project.id, json_data['id'].to_i
   end
 
-  test 'An empty project should not have the badge; it should be in progress' do
-    get :badge, params: { id: @project, format: 'svg' }
+  test 'An empty project should not have a badge; it should be in progress' do
+    get "/projects/#{@project.id}/badge"
     assert_response :success
     assert_includes @response.body, 'in progress'
   end
@@ -510,26 +566,21 @@ class ProjectsControllerTest < ActionController::TestCase
     log_in_as(@admin)
     assert_nil @perfect_passing_project.lost_passing_at
     assert_not_nil @perfect_passing_project.achieved_passing_at
-    patch :update, params: {
-      id: @perfect_passing_project, project: {
-        interact_status: 'Unmet'
-      },
-      locale: :en
+    patch "/en/projects/#{@perfect_passing_project.id}", params: {
+      project: { interact_status: 'Unmet' }
     }
+    follow_redirect!
     @perfect_passing_project.reload
     assert_not_nil @perfect_passing_project.lost_passing_at
     assert @perfect_passing_project.lost_passing_at > 5.minutes.ago.utc
     assert_not_nil @perfect_passing_project.achieved_passing_at
-    patch :update, params: {
-      id: @perfect_passing_project, project: {
-        interact_status: 'Met'
-      },
-      locale: :en
+    patch "/en/projects/#{@perfect_passing_project.id}", params: {
+      project: { interact_status: 'Met' }
     }
     assert_not_nil @perfect_passing_project.lost_passing_at
+    assert_not_nil @perfect_passing_project.achieved_passing_at
     # These tests should work, but don't; it appears our workaround for
     # the inadequately reset database interferes with them.
-    # assert_not_nil @perfect_passing_project.achieved_passing_at
     # assert @perfect_passing_project.achieved_passing_at > 5.minutes.ago.utc
     # assert @perfect_passing_project.achieved_passing_at >
     #        @perfect_passing_project.lost_passing_at
@@ -537,7 +588,7 @@ class ProjectsControllerTest < ActionController::TestCase
 
   test 'Can display delete form' do
     log_in_as(@project.user)
-    get :delete_form, params: { id: @project, locale: :en }
+    get "/en/projects/#{@project.id}/delete_form"
     assert_response :success
     assert_includes @response.body, 'Warning'
   end
@@ -546,15 +597,13 @@ class ProjectsControllerTest < ActionController::TestCase
     log_in_as(@project.user)
     num = ActionMailer::Base.deliveries.size
     assert_difference('Project.count', -1) do
-      delete :destroy,
-             params:
-             {
-               id: @project,
-               deletion_rationale: 'The front page is not purple enough.',
-               locale: :en
+      # The "delete" request routes to the controller method "destroy"
+      delete "/en/projects/#{@project.id}",
+             params: {
+               deletion_rationale: 'The front page is not purple enough.'
              }
     end
-    assert_not_empty flash
+    assert_equal 'Project was successfully deleted.', flash['success']
     assert_redirected_to projects_path
     assert_equal num + 1, ActionMailer::Base.deliveries.size
   end
@@ -562,30 +611,21 @@ class ProjectsControllerTest < ActionController::TestCase
   test 'should NOT destroy own project if rationale too short' do
     log_in_as(@project.user)
     assert_no_difference('Project.count', ActionMailer::Base.deliveries.size) do
-      delete :destroy,
-             params:
-             {
-               id: @project,
-               deletion_rationale: 'Nah.',
-               locale: :en
-             }
+      delete "/en/projects/#{@project.id}",
+             params: { deletion_rationale: 'Nah.' }
     end
-    assert_not_empty flash
+    assert_equal 'Must have at least 20 characters.', flash['danger']
     assert_redirected_to delete_form_project_path(@project)
   end
 
   test 'should NOT destroy own project if rationale has few non-whitespace' do
     log_in_as(@project.user)
     assert_no_difference('Project.count', ActionMailer::Base.deliveries.size) do
-      delete :destroy,
-             params:
-             {
-               id: @project,
-               deletion_rationale: ' x y ' + ("\n" * 30),
-               locale: :en
-             }
+      delete "/en/projects/#{@project.id}",
+             params: { deletion_rationale: ' x y ' + ("\n" * 30) }
     end
-    assert_not_empty flash
+    assert_equal 'Must have at least 15 non-whitespace characters.',
+                 flash['danger']
     assert_redirected_to delete_form_project_path(@project)
   end
 
@@ -594,123 +634,122 @@ class ProjectsControllerTest < ActionController::TestCase
     num = ActionMailer::Base.deliveries.size
     assert_not_equal @admin, @project.user
     assert_difference('Project.count', -1) do
-      delete :destroy, params: { id: @project, locale: :en }
+      delete "/en/projects/#{@project.id}" # calls controller method "destroy"
     end
-
     assert_redirected_to projects_path(locale: :en)
     assert_equal num + 1, ActionMailer::Base.deliveries.size
   end
 
-  test 'should not destroy project if no one is logged in' do
-    log_in_as(@user2)
+  test 'should not destroy project if logged in as different user' do
+    log_in_as(@user2, password: 'password1')
+    # Verify that we are actually logged in
+    assert_equal @user2.id, session[:user_id]
     assert_no_difference('Project.count', ActionMailer::Base.deliveries.size) do
-      delete :destroy, params: { id: @project, locale: :en }
+      delete "/en/projects/#{@project.id}" # calls controller method "destroy"
     end
   end
 
-  test 'should not destroy project if logged in as different user' do
+  test 'should not destroy project if not logged in' do
     # Notice that we do *not* call log_in_as.
     assert_no_difference('Project.count', ActionMailer::Base.deliveries.size) do
-      delete :destroy, params: { id: @project, locale: :en }
+      delete "/en/projects/#{@project.id}" # calls controller method "destroy"
     end
   end
 
   test 'should redirect to project page if project repo exists' do
     log_in_as(@user)
     assert_no_difference('Project.count') do
-      post :create, params: {
-        project: { repo_url: @project.repo_url }, locale: :en
+      post '/en/projects', params: { # Routes to 'create'
+        project: { repo_url: @project.repo_url }
       }
     end
     assert_redirected_to project_path(@project, locale: :en)
   end
 
-  test 'should succeed and fail to change tail of non-blank repo_url' do
+  test 'should succeed and then fail to change non-blank repo_url' do
+    # We rate limit changing repo_url - ensure that works.
+    assert @project_two.user.id, @user2.id # Check test fixtures
+    log_in_as(@user2, password: 'password1')
+    # Verify that we are actually logged in
+    assert_equal @user2.id, session[:user_id]
     new_repo_url = @project_two.repo_url + '_new'
-    log_in_as(@project_two.user)
-    patch :update, params: {
-      id: @project_two, project: {
-        repo_url:  new_repo_url
-      },
-      locale: :en
+    patch "/en/projects/#{@project_two.id}", params: {
+      project: { repo_url:  new_repo_url }
     }
     # Check for success
     @project_two.reload
-    assert_equal @project_two.repo_url, new_repo_url
+    assert_equal new_repo_url, @project_two.repo_url
 
     # Now let's do it again. *This* should fail, it's too soon.
     second_repo_url = new_repo_url + '_second'
-    patch :update, params: {
-      id: @project_two, project: {
-        repo_url:  second_repo_url
-      },
-      locale: :en
+    patch "/en/projects/#{@project_two.id}", params: {
+      project: { repo_url:  second_repo_url }
     }
     # Ensure the second attempt failed.
     assert_not_empty flash
-    assert_template :edit
+    assert_includes @response.body, 'Edit Project Badge Status'
     @project_two.reload
-    assert_not_equal @project_two.repo_url, second_repo_url
-    assert_equal @project_two.repo_url, new_repo_url
+    assert_equal new_repo_url, @project_two.repo_url
+    assert_not_equal second_repo_url, @project_two.repo_url
   end
 
   test 'should change https to http in non-blank repo_url' do
+    assert @project_two.user.id, @user2.id # Check test fixtures
+    log_in_as(@user2, password: 'password1')
+    # Verify that we are actually logged in
+    assert_equal @user2.id, session[:user_id]
     old_repo_url = @project_two.repo_url
     new_repo_url = 'http://www.nasa.gov/mav'
-    log_in_as(@project_two.user)
-    patch :update, params: {
-      id: @project_two, project: {
-        repo_url:  new_repo_url
-      },
-      locale: :en
+    patch "/en/projects/#{@project_two.id}", params: { # Invokes "update"
+      project: { repo_url:  new_repo_url }
     }
     @project_two.reload
     assert_not_equal @project_two.repo_url, old_repo_url
     assert_equal @project_two.repo_url, new_repo_url
     # Check that PaperTrail properly recorded the old version
     assert_equal 'update', @project_two.versions.last.event
-    assert_equal @project_two.user.id, @project_two.versions.last.whodunnit.to_i
-    assert_equal old_repo_url, @project_two.versions.last.reify.repo_url
+    assert_equal @project_two.user.id,
+                 @project_two.versions.last.whodunnit.to_i
+    assert_equal old_repo_url,
+                 @project_two.versions.last.reify.repo_url
   end
 
   test 'admin can change other users non-blank repo_url' do
-    new_repo_url = @project_two.repo_url + '_new'
     log_in_as(@admin)
     assert_not_equal @admin, @project.user
-    patch :update, params: {
-      id: @project_two, project: {
-        repo_url:  new_repo_url
-      },
-      locale: :en
+    new_repo_url = @project_two.repo_url + '_new'
+    patch "/en/projects/#{@project_two.id}", params: { # Invokes "update"
+      project: { repo_url:  new_repo_url }
     }
     @project_two.reload
     assert_equal @project_two.repo_url, new_repo_url
   end
 
   test 'should redirect with empty query params removed' do
-    get :index, params: { q: '', status: 'passing', locale: :en }
-    assert_redirected_to 'http://test.host/en/projects?status=passing'
+    get '/en/projects?q=&status=passing' # Calls controller method "index"
+    assert_redirected_to '/en/projects?status=passing'
   end
 
   test 'should redirect with all query params removed' do
-    get :index, params: { q: '', status: '', locale: :en }
-    assert_redirected_to 'http://test.host/en/projects'
+    get '/en/projects?q=&status='
+    assert_redirected_to '/en/projects'
   end
 
   test 'should remove invalid parameter' do
-    get :index, params: { role: 'admin', status: 'passing', locale: :en }
-    assert_redirected_to 'http://test.host/en/projects?status=passing'
+    get '/en/projects?bogus1=bogus2&status=passing'
+    assert_redirected_to '/en/projects?status=passing'
   end
 
   test 'query JSON for passing projects' do
-    get :index, params: { gteq: '100', format: 'json', locale: :en }
+    get '/en/projects.json?gteq=100'
     assert_response :success
     body = JSON.parse(response.body)
-    # Current test fixtures have 3 cases - this test will need to be
-    # modified if new ones are added.
-    assert_equal 3, body.length
+    # We don't want to have to edit this test if we merely add new
+    # test fixtures, so we'll just make sure we have at least 3 and
+    # do a sanity check of the response.
+    assert body.length >= 3
     0.upto(body.length - 1) do |i|
-      assert_equal 100, body[i]['badge_percentage_0']
+      assert body[i]['badge_percentage_0'] >= 100
     end
   end
 
@@ -721,7 +760,7 @@ class ProjectsControllerTest < ActionController::TestCase
     # *omit* the query string (which is often fine, but not in this case).
     # Specifically test to ensure the query string is retained.
     #
-    get :index, params: { gteq: '100', locale: :en }
+    get '/en/projects?gteq=100'
     assert_response :success
 
     # There's a weird test environment artifact I haven't been
@@ -754,20 +793,22 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   test 'Check ids= projects index query' do
-    get :index, params: {
-      format: :json,
-      ids: "#{@project.id},#{@project_two.id}",
-      locale: :en
-    }
+    # %2c is the comma
+    get "/en/projects.json?ids=#{@project.id}%2c#{@project_two.id}"
+    follow_redirect!
     assert_response :success
     body = JSON.parse(response.body)
     assert_equal 2, body.length
+    assert_equal @project.id, body[0]['id']
+    assert_equal @project_two.id, body[1]['id']
   end
 
   test 'should redirect http to https' do
+    # Rails.application.config.force_ssl is off in testing, turn it on.
+    # This is NOT a thread-safe test.
     old = Rails.application.config.force_ssl
     Rails.application.config.force_ssl = true
-    get :index, params: { locale: :en }
+    get 'http://test.host/en/projects'
     assert_redirected_to 'https://test.host/en/projects'
     Rails.application.config.force_ssl = old
   end


### PR DESCRIPTION
Switch from ActionController::TestCase to
ActionDispatch::IntegrationTest.

A few tests are hard to convert, because the IntegrationTest
cannot manipulate the session, as documented in:
https://stackoverflow.com/questions/37796129/
unable-to-set-session-hash-in-rails-5-controller-test

So for the moment, those few tests are *not* converted and
are instead in the new file projects_controller_special_test.rb.
This means we still have a use of the deprecated
class ActionController::TestCase, but it is very small,
and that means that the rest of the tests are using
ActionDispatch::IntegrationTest (which has more realistic
tests, because it also tests the routing system).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>