### PR TITLE
Report achievement of higher badge levels

### DIFF
--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -131,13 +131,14 @@ class ReportMailer < ApplicationMailer
   # We currently only send these out in English, so it's not internationalized
   # (no point in asking the translators to do unnecessary work).
   def report_monthly_announcement(
-    projects, month, last_stat_in_prev_month, last_stat_in_prev_prev_month
+    projects, month_display,
+    last_stat_in_prev_month, last_stat_in_prev_prev_month
   )
     @report_destination = ENV['REPORT_MONTHLY_EMAIL']
     return if @report_destination.blank?
 
     @projects = projects
-    @month = month
+    @month_display = month_display
     @last_stat_in_prev_month = last_stat_in_prev_month
     @last_stat_in_prev_prev_month = last_stat_in_prev_prev_month
     set_standard_headers

--- a/app/models/criteria.rb
+++ b/app/models/criteria.rb
@@ -55,10 +55,11 @@ class Criteria
       @criteria.each_value { |level_data| yield level_data }
     end
 
-    def each_key
-      instantiate if @criteria.blank?
-      @criteria.each_key { |level_key| yield level_key }
-    end
+    # No longer needed. Instead use "Project::LEVEL_IDS.each"
+    # def each_key
+    #   instantiate if @criteria.blank?
+    #   @criteria.each_key { |level_key| yield level_key }
+    # end
 
     # This returns an array of all levels where a particular criterion of
     # a given name is present.

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -32,7 +32,21 @@ class Project < ApplicationRecord
   MAX_TEXT_LENGTH = 8192 # Arbitrary maximum to reduce abuse
   MAX_SHORT_STRING_LENGTH = 254 # Arbitrary maximum to reduce abuse
 
+  # All badge level internal names *including* in_progress
+  # NOTE: If you add a new level, modify compute_tiered_percentage
   BADGE_LEVELS = %w[in_progress passing silver gold].freeze
+
+  # All badge level internal names that indicate *completion*,
+  # so COMPLETED_BADGE_LEVELS[0] is 'passing'.
+  # Note: This is the *internal* lowercase name, e.g., for field names.
+  # For *printed* names use t("projects.form_early.level.#{level}")
+  # Note that drop() does NOT mutate the original value.
+  COMPLETED_BADGE_LEVELS = BADGE_LEVELS.drop(1).freeze
+
+  # All badge levels as IDs. Useful for enumerating "all levels" as:
+  # Project::LEVEL_IDS.each do |level| ... end
+  LEVEL_ID_NUMBERS = 0..(COMPLETED_BADGE_LEVELS.length - 1)
+  LEVEL_IDS = LEVEL_ID_NUMBERS.map(&:to_s)
 
   PROJECT_OTHER_FIELDS = %i[
     name description homepage_url repo_url cpe implementation_languages
@@ -300,16 +314,19 @@ class Project < ApplicationRecord
     updated_at >= ENTRY_LICENSE_EXPLICIT_DATE
   end
 
-  # Update the badge percentage for a given level,
-  # and update relevant event datetime if needed.
+  # Update the badge percentage for a given level (expressed as a number;
+  # 0=passing), and update relevant event datetime if needed.
+  # It presumes the lower-level percentages (if relevant) are calculated.
   def update_badge_percentage(level)
     old_badge_percentage = self["badge_percentage_#{level}".to_sym]
-    update_prereqs(level) unless level == Criteria.keys[0]
+    update_prereqs(level) unless level.to_i.zero?
     self["badge_percentage_#{level}".to_sym] =
       calculate_badge_percentage(level)
-    update_passing_times(old_badge_percentage) if level == '0'
+    update_passing_times(level, old_badge_percentage)
   end
 
+  # Compute the 'tiered percentage' value 0..300. This gives partial credit,
+  # but only if you've completed a previous level.
   def compute_tiered_percentage
     if badge_percentage_0 < 100
       badge_percentage_0
@@ -326,10 +343,10 @@ class Project < ApplicationRecord
 
   # Update the badge percentages for all levels.
   def update_badge_percentages
-    Criteria.each_key do |level|
+    Project::LEVEL_IDS.each do |level|
       update_badge_percentage(level)
     end
-    update_tiered_percentage
+    update_tiered_percentage # Update the 'tiered_percentage' number 0..300
   end
 
   # Return owning user's name for purposes of display.
@@ -458,15 +475,22 @@ class Project < ApplicationRecord
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   # Return which projects should be announced as getting badges in the
-  # month target_month
-  def self.projects_first_passing_in(target_month)
+  # month target_month with level (as a number, 0=passing)
+  def self.projects_first_in(level, target_month)
+    name = COMPLETED_BADGE_LEVELS[level] # field name, e.g. 'passing'
+    # We could omit listing projects which have lost & regained their
+    # badge by adding this line:
+    # .where('lost_#{name}_at IS NULL')
+    # However, it seems reasonable to note projects that have lost their
+    # badge but have since regained it (especially since it could have
+    # happened within this month!). After all, we want to encourage
+    # projects that have lost their badge levels to regain them.
     Project
-      .select('id, name, achieved_passing_at')
-      .where('badge_percentage_0 = 100')
-      .where('achieved_passing_at >= ?', target_month.at_beginning_of_month)
-      .where('achieved_passing_at <= ?', target_month.at_end_of_month)
-      .where('lost_passing_at IS NULL')
-      .reorder('achieved_passing_at')
+      .select("id, name, achieved_#{name}_at")
+      .where("badge_percentage_#{level} >= 100")
+      .where("achieved_#{name}_at >= ?", target_month.at_beginning_of_month)
+      .where("achieved_#{name}_at <= ?", target_month.at_end_of_month)
+      .reorder("achieved_#{name}_at")
   end
 
   def self.recently_reminded
@@ -548,33 +572,46 @@ class Project < ApplicationRecord
     ((portion * 100.0) / total).round
   end
 
-  def update_passing_times(old_badge_percentage)
-    if badge_percentage_0 == 100 && old_badge_percentage < 100
-      self.achieved_passing_at = Time.now.utc
-    elsif badge_percentage_0 < 100 && old_badge_percentage == 100
-      self.lost_passing_at = Time.now.utc
+  # Update achieved_..._at & lost_..._at fields given level as number
+  # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/AbcSize
+  def update_passing_times(level, old_badge_percentage)
+    level_name = COMPLETED_BADGE_LEVELS[level.to_i] # E.g., 'passing'
+    current_percentage = self["badge_percentage_#{level}".to_sym]
+    # If something is wrong, don't modify anything!
+    return if current_percentage.blank? || old_badge_percentage.blank?
+    current_percentage_i = current_percentage.to_i
+    old_badge_percentage_i = old_badge_percentage.to_i
+    if current_percentage_i >= 100 && old_badge_percentage_i < 100
+      self["achieved_#{level_name}_at".to_sym] = Time.now.utc
+    elsif current_percentage_i < 100 && old_badge_percentage_i >= 100
+      self["lost_#{level_name}_at".to_sym] = Time.now.utc
     end
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 
+  # Given numeric level 1+, set the value of
+  # achieve_{previous_level_name}_status to either Met or Unmet, based on
+  # the achievement of the *previous* level. This is a simple way to ensure
+  # that to pass level X when X > 0, you must meet the criteria of level X-1.
+  # We *only* set the field if it currently has a different value.
   # When filling in the prerequisites, we do not fill in the justification
   # for them. The justification is only there as it makes implementing this
   # portion of the code simpler.
-  # rubocop:disable Metrics/AbcSize
   def update_prereqs(level)
-    index = Criteria.keys.index(level)
-    return if index.zero?
+    level = level.to_i
+    return if level <= 0
+    # The following works because BADGE_LEVELS[1] is 'passing', etc:
+    achieved_previous_level = "achieve_#{BADGE_LEVELS[level]}_status".to_sym
 
-    if self["badge_percentage_#{Criteria.keys[index - 1]}".to_sym] >= 100
-      return if self["achieve_#{BADGE_LEVELS[index]}_status".to_sym] == 'Met'
-
-      status = 'Met'
+    if self["badge_percentage_#{level - 1}".to_sym] >= 100
+      return if self[achieved_previous_level] == 'Met'
+      self[achieved_previous_level] = 'Met'
     else
-      return if self["achieve_#{BADGE_LEVELS[index]}_status".to_sym] == 'Unmet'
-
-      status = 'Unmet'
+      return if self[achieved_previous_level] == 'Unmet'
+      self[achieved_previous_level] = 'Unmet'
     end
-    self["achieve_#{BADGE_LEVELS[index]}_status".to_sym] = status
   end
-  # rubocop:enable Metrics/AbcSize
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/views/project_stats/index.csv.erb
+++ b/app/views/project_stats/index.csv.erb
@@ -1,22 +1,16 @@
-id,created_at,percent_ge_0,percent_ge_25,percent_ge_50,percent_ge_75,percent_ge_90,percent_ge_100,created_since_yesterday,updated_since_yesterday,updated_at,reminders_sent,reactivated_after_reminder,active_projects,active_in_progress,projects_edited,active_edited_projects,active_edited_in_progress
-<%# See: http://nithinbekal.com/posts/rails-csv-export/ %>
 <% require 'csv' -%>
+<%# See: http://nithinbekal.com/posts/rails-csv-export/ -%>
+<%=
+  # Generate headers. This presumes that ActiveRecord's "column_names"
+  # returns a list in the same order that "attributes.values" will.
+  # This code just generates whatever order is convenient, presuming that
+  # receivers will use the CSV heading name (not field position) if they care
+  # about which field they get.
+  # We could use @project_stats[0].attributes.keys, but that would fail
+  # if the database was empty.
+  columns = @project_stats.column_names
+  CSV.generate_line(columns)
+-%>
 <%- @project_stats.each do |stat| -%>
-<%= CSV.generate_line([
-      stat.id, stat.created_at,
-      stat.percent_ge_0, stat.percent_ge_25, stat.percent_ge_50,
-      stat.percent_ge_75, stat.percent_ge_90, stat.percent_ge_100,
-      stat.created_since_yesterday,stat.updated_since_yesterday,
-      stat.updated_at, stat.reminders_sent, stat.reactivated_after_reminder,
-      stat.active_projects, stat.active_in_progress,
-      stat.projects_edited, stat.active_edited_projects,
-      stat.active_edited_in_progress] +
-      (stat.percent_1_ge_25 ?
-      [
-        stat.percent_1_ge_25, stat.percent_1_ge_50,
-        stat.percent_1_ge_75, stat.percent_1_ge_90, stat.percent_1_ge_100,
-        stat.percent_2_ge_25, stat.percent_2_ge_50,
-        stat.percent_2_ge_75, stat.percent_2_ge_90, stat.percent_2_ge_100
-      ] : [])
- ) -%>
+<%=   CSV.generate_line(stat.attributes.values) -%>
 <%- end -%>

--- a/app/views/report_mailer/report_monthly_announcement.html.erb
+++ b/app/views/report_mailer/report_monthly_announcement.html.erb
@@ -1,6 +1,6 @@
 <p>
 This is an automated monthly status report of the best practices
-badge application covering the month <%= @month %>.
+badge application covering the month <%= @month_display %>.
 
 <% if @last_stat_in_prev_month && @last_stat_in_prev_prev_month %>
 <p>
@@ -8,30 +8,59 @@ Here are some selected statistics for most recent completed month,
 preceded by the same statistics for the end of the month before that.
 
 <table border="1">
-<tr><th>Ending dates</th><td><%= @last_stat_in_prev_prev_month.created_at.strftime('%Y-%m-%d') %></td><td><%= @last_stat_in_prev_month.created_at.strftime('%Y-%m-%d') %>
-<tr><th>Total Projects</th><td><%= @last_stat_in_prev_prev_month.percent_ge_0 %></td><td><%= @last_stat_in_prev_month.percent_ge_0 %>
-<tr><th>Projects 25%+</th><td><%= @last_stat_in_prev_prev_month.percent_ge_25 %></td><td><%= @last_stat_in_prev_month.percent_ge_25 %>
-<tr><th>Projects 50%+</th><td><%= @last_stat_in_prev_prev_month.percent_ge_50 %></td><td><%= @last_stat_in_prev_month.percent_ge_50 %>
-<tr><th>Projects 75%+</th><td><%= @last_stat_in_prev_prev_month.percent_ge_75 %></td><td><%= @last_stat_in_prev_month.percent_ge_75 %>
-<tr><th>Projects 90%+</th><td><%= @last_stat_in_prev_prev_month.percent_ge_90 %></td><td><%= @last_stat_in_prev_month.percent_ge_90 %>
-<tr><th>Projects passing</th><td><%= @last_stat_in_prev_prev_month.percent_ge_100 %></td><td><%= @last_stat_in_prev_month.percent_ge_100 %>
+<tr><th>Ending dates</th><td><%=
+  @last_stat_in_prev_prev_month.created_at.strftime('%Y-%m-%d')
+%></td><td><%=
+  @last_stat_in_prev_month.created_at.strftime('%Y-%m-%d')
+%></td></tr>
+<% Project::LEVEL_IDS.each do |level|
+     ProjectStat::STAT_VALUES.each do |percentage|
+        next if level.to_i != 0 && percentage.to_i.zero?
+%><tr><th><%= ProjectStat.percent_field_description(level, percentage)
+%></th><td><%=
+    @last_stat_in_prev_prev_month[
+      ProjectStat.percent_field_name(level, percentage)]
+%></td><td><%=
+    @last_stat_in_prev_month[
+      ProjectStat.percent_field_name(level, percentage)]
+%></td></tr>
+<%    end
+   end %>
 </table>
 <% end %>
 
-<% if @projects && !@projects.empty? %>
+<%
+new_achievements = false
+Project::LEVEL_ID_NUMBERS.each do |level|
+  if @projects[level] && !@projects[level].blank? %>
 <p>
-Here are the projects that first achieved
-a passing badge in <%= @month %>:
+Here are the projects that first achieved a
+<%= t("projects.form_early.level.#{level}") %> badge in <%= @month_display %>:
 
 <ol>
-<% @projects.each do |project| %>
+<%
+    @projects[level].each do |project|
+      new_achievements = true
+%>
 <li><a href="https://bestpractices.coreinfrastructure.org/projects/<%= project.id %>"><%= project.name %> at <%= project.achieved_passing_at %></a>
-<% end %>
+<%
+    end # each
+%>
 </ol>
 
+<%
+  end # if there are projects
+end # each level
+%>
+
+<%
+if new_achievements
+%>
 <p>
 We congratulate them all!
-<% end %>
+<%
+end
+%>
 
 <p>
 Do you know a project that doesn't have a badge yet?

--- a/app/views/report_mailer/report_monthly_announcement.text.erb
+++ b/app/views/report_mailer/report_monthly_announcement.text.erb
@@ -1,31 +1,62 @@
 This is an automated monthly status report of the best practices
-badge application covering the month <%= @month %>.
+badge application covering the month <%= @month_display %>.
 
-<% if @last_stat_in_prev_month && @last_stat_in_prev_prev_month %>
+<%
+if @last_stat_in_prev_month && @last_stat_in_prev_prev_month
+%>
 Here are some selected statistics for most recent completed month,
 preceded by the same statistics for the end of the month before that.
 
-Ending dates:      <%= @last_stat_in_prev_prev_month.created_at.strftime('%Y-%m-%d') %>  <%= @last_stat_in_prev_month.created_at.strftime('%Y-%m-%d') %>
-Total Projects:    <%= '%10d' % @last_stat_in_prev_prev_month.percent_ge_0 %>  <%= '%10d' % @last_stat_in_prev_month.percent_ge_0 %>
-Projects 25%+:     <%= '%10d' % @last_stat_in_prev_prev_month.percent_ge_25 %>  <%= '%10d' % @last_stat_in_prev_month.percent_ge_25 %>
-Projects 50%+:     <%= '%10d' % @last_stat_in_prev_prev_month.percent_ge_50 %>  <%= '%10d' % @last_stat_in_prev_month.percent_ge_50 %>
-Projects 75%+:     <%= '%10d' % @last_stat_in_prev_prev_month.percent_ge_75 %>  <%= '%10d' % @last_stat_in_prev_month.percent_ge_75 %>
-Projects 90%+:     <%= '%10d' % @last_stat_in_prev_prev_month.percent_ge_90 %>  <%= '%10d' % @last_stat_in_prev_month.percent_ge_90 %>
-Projects passing:  <%= '%10d' % @last_stat_in_prev_prev_month.percent_ge_100 %>  <%= '%10d' % @last_stat_in_prev_month.percent_ge_100 %>
-<% end %>
+<%= '%-35s' % 'Ending dates:'
+%> <%=
+  @last_stat_in_prev_prev_month.created_at.strftime('%Y-%m-%d')
+%>  <%=
+  @last_stat_in_prev_month.created_at.strftime('%Y-%m-%d') %>
+<%
+  Project::LEVEL_IDS.each do |level|
+    ProjectStat::STAT_VALUES.each do |percentage|
+      next if level.to_i != 0 && percentage.to_i.zero?
+%><%= '%-35s' % ProjectStat.percent_field_description(level, percentage)
+%> <%= '%10d' % @last_stat_in_prev_prev_month[
+      ProjectStat.percent_field_name(level, percentage)]
+%> <%= '%10d' % @last_stat_in_prev_month[
+      ProjectStat.percent_field_name(level, percentage)]
+%>
+<%
+    end  # do
+  end # do
+end # if (there are two stats)
+%>
 
-<% if @projects && !@projects.empty? %>
+<%
+new_achievements = false
+Project::LEVEL_IDS.each do |level|
+  if @projects[level.to_i] && !@projects[level.to_i].empty? %>
+
 Here are the projects that first achieved
-a passing badge in <%= @month %>:
+a <%= t("projects.form_early.level.#{level}") %> badge in <%= @month_display %>:
 
-<% @projects.each do |project| %>
+<%
+    @projects[level.to_i].each do |project|
+      new_achievements = true -%>
 * <%= project.name %>
   at <%= project.achieved_passing_at %>
   https://bestpractices.coreinfrastructure.org/projects/<%= project.id %>
-<% end %>
+<%
+    end # loop over projects
+%>
+<%
+  end # if there are projects at this level
+end # loop over all levels
+%>
 
+<%
+if new_achievements
+%>
 We congratulate them all!
-<% end %>
+<%
+end
+%>
 
 Do you know a project that doesn't have a badge yet?
 Please suggest to them that they get a badge now, by visiting:

--- a/db/migrate/20200507141751_add_silver_at.rb
+++ b/db/migrate/20200507141751_add_silver_at.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddSilverAt < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :achieved_silver_at, :datetime
+    add_index :projects, :achieved_silver_at
+    add_column :projects, :lost_silver_at, :datetime
+    add_index :projects, :lost_silver_at
+
+    add_column :projects, :achieved_gold_at, :datetime
+    add_index :projects, :achieved_gold_at
+    add_column :projects, :lost_gold_at, :datetime
+    add_index :projects, :lost_gold_at
+  end
+end

--- a/db/migrate/20200508145537_add_first_achieved.rb
+++ b/db/migrate/20200508145537_add_first_achieved.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Record when a badge was *first* achieved, ignoring any
+# later losses and re-achievements. At this time we won't
+# index this, because we're not exposing this to search.
+# Right now the goal is to simply record the information,
+# because it's easy to get as we go & hard to get later.
+# We can always index and make it searchable later.
+class AddFirstAchieved < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :first_achieved_passing_at, :datetime
+    add_column :projects, :first_achieved_silver_at, :datetime
+    add_column :projects, :first_achieved_gold_at, :datetime
+
+    # Lie about it being reversible so this migration can be quietly reversed
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE projects
+            SET first_achieved_passing_at = achieved_passing_at
+            WHERE achieved_passing_at IS NOT NULL;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_07_141751) do
+ActiveRecord::Schema.define(version: 2020_05_08_145537) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -367,6 +367,9 @@ ActiveRecord::Schema.define(version: 2020_05_07_141751) do
     t.datetime "lost_silver_at"
     t.datetime "achieved_gold_at"
     t.datetime "lost_gold_at"
+    t.datetime "first_achieved_passing_at"
+    t.datetime "first_achieved_silver_at"
+    t.datetime "first_achieved_gold_at"
     t.index ["achieved_gold_at"], name: "index_projects_on_achieved_gold_at"
     t.index ["achieved_passing_at"], name: "index_projects_on_achieved_passing_at"
     t.index ["achieved_silver_at"], name: "index_projects_on_achieved_silver_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_27_184707) do
+ActiveRecord::Schema.define(version: 2020_05_07_141751) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -363,14 +363,22 @@ ActiveRecord::Schema.define(version: 2020_01_27_184707) do
     t.text "achieve_silver_justification"
     t.integer "tiered_percentage"
     t.datetime "repo_url_updated_at"
+    t.datetime "achieved_silver_at"
+    t.datetime "lost_silver_at"
+    t.datetime "achieved_gold_at"
+    t.datetime "lost_gold_at"
+    t.index ["achieved_gold_at"], name: "index_projects_on_achieved_gold_at"
     t.index ["achieved_passing_at"], name: "index_projects_on_achieved_passing_at"
+    t.index ["achieved_silver_at"], name: "index_projects_on_achieved_silver_at"
     t.index ["badge_percentage_0"], name: "index_projects_on_badge_percentage_0"
     t.index ["badge_percentage_1"], name: "index_projects_on_badge_percentage_1"
     t.index ["badge_percentage_2"], name: "index_projects_on_badge_percentage_2"
     t.index ["created_at"], name: "index_projects_on_created_at"
     t.index ["homepage_url"], name: "index_projects_on_homepage_url"
     t.index ["last_reminder_at"], name: "index_projects_on_last_reminder_at"
+    t.index ["lost_gold_at"], name: "index_projects_on_lost_gold_at"
     t.index ["lost_passing_at"], name: "index_projects_on_lost_passing_at"
+    t.index ["lost_silver_at"], name: "index_projects_on_lost_silver_at"
     t.index ["name"], name: "index_projects_on_name"
     t.index ["repo_url"], name: "index_projects_on_repo_url"
     t.index ["repo_url"], name: "nonempty_repo_urls", unique: true, where: "((repo_url IS NOT NULL) AND ((repo_url)::text <> ''::text))"

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -80,12 +80,13 @@ end
 
 desc 'Run railroader'
 task railroader: %w[railroader/bin/railroader] do
+  # TEMPORARY: DISABLE
   # Disable pager, so that "rake" can keep running without halting.
   # sh 'bundle exec railroader --quiet --no-pager'
   # Workaround to run correct version of railroader & its dependencies.
   # We have to set BUNDLE_GEMFILE so bundle works inside the rake task
-  sh 'cd railroader; BUNDLE_GEMFILE=$(pwd)/Gemfile ' \
-     'bundle exec bin/railroader --quiet --no-pager $(dirname $(pwd))'
+  # sh 'cd railroader; BUNDLE_GEMFILE=$(pwd)/Gemfile ' \
+  #    'bundle exec bin/railroader --quiet --no-pager $(dirname $(pwd))'
 end
 
 desc 'Run bundle if needed'

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -17,7 +17,6 @@ task(:default).clear.enhance %w[
   rubocop
   markdownlint
   rails_best_practices
-  railroader
   license_okay
   license_finder_report.html
   whitespace_check
@@ -30,6 +29,8 @@ task(:default).clear.enhance %w[
 ]
 # Temporarily removed fasterer
 # Waiting for Ruby 2.4 support: https://github.com/seattlerb/ruby_parser/issues/239
+# Temporarily removed railroader because of local install problems;
+# it's still run by the CI for every pull request
 
 # Run Continuous Integration (CI) check processes.
 # This is a shorter list; many checks are run by a separate "pronto" task.
@@ -85,8 +86,8 @@ task railroader: %w[railroader/bin/railroader] do
   # sh 'bundle exec railroader --quiet --no-pager'
   # Workaround to run correct version of railroader & its dependencies.
   # We have to set BUNDLE_GEMFILE so bundle works inside the rake task
-  # sh 'cd railroader; BUNDLE_GEMFILE=$(pwd)/Gemfile ' \
-  #    'bundle exec bin/railroader --quiet --no-pager $(dirname $(pwd))'
+  sh 'cd railroader; BUNDLE_GEMFILE=$(pwd)/Gemfile ' \
+     'bundle exec bin/railroader --quiet --no-pager $(dirname $(pwd))'
 end
 
 desc 'Run bundle if needed'

--- a/test/controllers/project_stats_controller_test.rb
+++ b/test/controllers/project_stats_controller_test.rb
@@ -40,26 +40,39 @@ class ProjectStatsControllerTest < ActionDispatch::IntegrationTest
     assert @response.body.include?('Percentage of projects earning badges')
   end
 
+  # rubocop:disable Metrics/BlockLength
   test 'should get index, CSV format' do
     get '/en/project_stats.csv'
     assert_response :success
     contents = CSV.parse(@response.body, headers: true)
     assert_equal 'id', contents.headers[0]
-    assert_equal %w[
-      id created_at percent_ge_0
-      percent_ge_25 percent_ge_50 percent_ge_75
-      percent_ge_90 percent_ge_100
-      created_since_yesterday updated_since_yesterday
-      updated_at reminders_sent
-      reactivated_after_reminder active_projects
-      active_in_progress projects_edited
+
+    expected_headers = %w[
+      id percent_ge_0 percent_ge_25 percent_ge_50
+      percent_ge_75 percent_ge_90 percent_ge_100
+      created_since_yesterday updated_since_yesterday created_at
+      updated_at reminders_sent reactivated_after_reminder
+      active_projects active_in_progress projects_edited
       active_edited_projects active_edited_in_progress
-    ], contents.headers
+      percent_1_ge_25 percent_1_ge_50 percent_1_ge_75
+      percent_1_ge_90 percent_1_ge_100 percent_2_ge_25
+      percent_2_ge_50 percent_2_ge_75 percent_2_ge_90
+      percent_2_ge_100 users github_users local_users
+      users_created_since_yesterday users_updated_since_yesterday
+      users_with_projects users_without_projects
+      users_with_multiple_projects users_with_passing_projects
+      users_with_silver_projects users_with_gold_projects
+      additional_rights_entries projects_with_additional_rights
+      users_with_additional_rights
+    ]
+    assert_equal expected_headers, contents.headers
+
     assert_equal 2, contents.size
     assert_equal '13', contents[0]['percent_ge_50']
     assert_equal '20', contents[0]['percent_ge_0']
     assert_equal '19', contents[1]['percent_ge_0']
   end
+  # rubocop:enable Metrics/BlockLength
 
   test 'should NOT be able to get new' do
     assert_raises AbstractController::ActionNotFound do

--- a/test/fixtures/project_stats.yml
+++ b/test/fixtures/project_stats.yml
@@ -9,6 +9,18 @@ one:
   percent_ge_75: 9
   percent_ge_90: 5
   percent_ge_100: 2
+  percent_1_ge_25: 2
+  percent_1_ge_50: 2
+  percent_1_ge_75: 2
+  percent_1_ge_90: 2
+  percent_1_ge_100: 2
+  percent_2_ge_25: 2
+  percent_2_ge_50: 1
+  percent_2_ge_75: 1
+  percent_2_ge_90: 1
+  percent_2_ge_100: 1
+  reminders_sent: 0
+  reactivated_after_reminder: 0
   created_since_yesterday: 2
   updated_since_yesterday: 1
 
@@ -20,5 +32,17 @@ two:
   percent_ge_75: 9
   percent_ge_90: 5
   percent_ge_100: 2
+  percent_1_ge_25: 2
+  percent_1_ge_50: 2
+  percent_1_ge_75: 2
+  percent_1_ge_90: 2
+  percent_1_ge_100: 2
+  percent_2_ge_25: 2
+  percent_2_ge_50: 1
+  percent_2_ge_75: 1
+  percent_2_ge_90: 1
+  percent_2_ge_100: 1
+  reminders_sent: 0
+  reactivated_after_reminder: 0
   created_since_yesterday: 4
   updated_since_yesterday: 0

--- a/test/mailers/report_mailer_test.rb
+++ b/test/mailers/report_mailer_test.rb
@@ -30,9 +30,16 @@ class ReportMailerTest < ActionMailer::TestCase
     # This is a quick sanity test, not an in-depth test.
     # Use 'example.org' per RFC 2606
     ENV['REPORT_MONTHLY_EMAIL'] = 'mytest@example.org'
+    awesome_projects = [
+      [
+        projects(:perfect_passing), projects(:perfect_silver),
+        projects(:perfect)
+      ], [projects(:perfect_silver), projects(:perfect)],
+      [projects(:perfect)]
+    ]
     email = ReportMailer
             .report_monthly_announcement(
-              [@perfect_project], '2015-02',
+              awesome_projects, '2015-02',
               project_stats(:one), project_stats(:two)
             )
             .deliver_now

--- a/test/models/project_stat_test.rb
+++ b/test/models/project_stat_test.rb
@@ -33,4 +33,30 @@ class ProjectStatTest < ActiveSupport::TestCase
   test 'count including fixtures' do
     assert_equal 3, ProjectStat.count
   end
+
+  test 'ProjectStat.percent_field_name() works correctly' do
+    assert_equal 'percent_ge_0', ProjectStat.percent_field_name(0, 0)
+    assert_equal 'percent_ge_90', ProjectStat.percent_field_name(0, 90)
+    assert_equal 'percent_1_ge_90', ProjectStat.percent_field_name(1, 90)
+    assert_equal 'percent_2_ge_100', ProjectStat.percent_field_name(2, 100)
+  end
+
+  test 'ProjectStat.percent_field_description() works correctly' do
+    assert_equal 'Total Projects', ProjectStat.percent_field_description(0, 0)
+    assert_equal 'Total Projects', ProjectStat.percent_field_description('0', 0)
+    assert_equal 'Passing Projects',
+                 ProjectStat.percent_field_description(0, 100)
+    assert_equal 'Passing Projects',
+                 ProjectStat.percent_field_description('0', 100)
+    assert_equal 'Silver Projects',
+                 ProjectStat.percent_field_description(1, 100)
+    assert_equal 'Gold Projects',
+                 ProjectStat.percent_field_description(2, 100)
+    assert_equal 'Passing Projects, 50%+ to Silver',
+                 ProjectStat.percent_field_description(1, 50)
+    assert_equal 'Silver Projects, 90%+ to Gold',
+                 ProjectStat.percent_field_description(2, 90)
+    assert_equal 'Silver Projects, 90%+ to Gold',
+                 ProjectStat.percent_field_description('2', 90)
+  end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -176,6 +176,8 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 'Unmet', @project_passing.achieve_silver_status
     assert_equal 'Met', @project_silver.achieve_passing_status
     assert_equal 'Unmet', @project_silver.achieve_silver_status
+    assert @project_silver.achieved_silver_at.blank?
+    assert @project_silver.first_achieved_silver_at.blank?
     Project.update_all_badge_percentages(Criteria.keys)
     assert_equal(
       'Unmet', Project.find(@unjustified_project.id).achieve_passing_status
@@ -186,8 +188,9 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal(
       'Unmet', Project.find(@project_passing.id).achieve_silver_status
     )
-    assert_equal 'Met', Project.find(@project_silver.id).achieve_passing_status
-    assert_equal 'Met', Project.find(@project_silver.id).achieve_silver_status
+    updated_project = Project.find(@project_silver.id)
+    assert_equal 'Met', updated_project.achieve_passing_status
+    assert_equal 'Met', updated_project.achieve_silver_status
   end
 
   test 'update_prereqs works correctly for level downgrades' do


### PR DESCRIPTION
In the monthly report, report projects that achieve
higher-level badges.

This was a classic "this will be an easy task" that turned
into more work than expected:
* We never recorded achieving
  higher-level badges, so we needed a data migration to
  add this information.
* I wanted the field names to be consistent, so we
  needed a method to convert level ids/numbers
  into field names.
* The previous step made it obvious that using
  Criteria.keys() as the way to find level IDs wasn't really
  sensible; that should be its own constant, and once that's done,
  modifying a few routines like update_prereqs() to use it seemed
  appropriate (the new version is clearer than the old one - at
  least Rubocop thinks so!).
  The whole thing should be clearer & thus less likely to have
  defects (it should be easier to add another level, too).
* The CSV statistics file generator missed some information,
  since we added new fields, and in general easily went wrong.
  Instead of manually adding fields, I rewrote the CSV template
  so that it automatically includes all stats.
  That completely future-proofs the whole thing; we may never
  need to modify it again.
* I had to temporarily disable Railroader again :-(
* A number of tests related to this needed to be modified.
  I added a number of extra tests to focus on the new
  parts I created.

This does have a change. It reports projects that achieve
a badge level in a month, even if they've lost it before and
the re-achieved it.  We want to encourage projects to get and
keep badges; if a project re-earns a badge they've lost, it
seems appropriate to congratulate them & note it.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>