### PR TITLE
Remove x-xss-protection hardening criterion, fixes #1426

### DIFF
--- a/app/lib/hardened_sites_detective.rb
+++ b/app/lib/hardened_sites_detective.rb
@@ -14,10 +14,12 @@ class HardenedSitesDetective < Detective
   NOSNIFF = 'nosniff'
 
   # All of the security-hardening headers that need to be present to pass.
+  # They're listed in the same order as the criteria text.
   # Field names must be in lowercase here.
   CHECK =
     [
-      'content-security-policy', XCTO, 'x-frame-options', 'x-xss-protection'
+      'content-security-policy', 'strict-transport-security',
+      XCTO, 'x-frame-options'
     ].freeze
   MET =
     {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2799,14 +2799,15 @@ en:
           web), and download site (if separate) MUST include key
           hardening headers with nonpermissive values.
         details: >-
-          Note that GitHub is known to meet this. Sites such as
-          https://securityheaders.io/ can quickly check this.
-          The key hardening headers are: Content Security Policy
-          (CSP), HTTP Strict Transport Security (HSTS), X-Content-Type-Options
-          (as "nosniff"), X-Frame-Options, and X-XSS-Protection.
-          Static web sites with no ability to log in via the web pages
-          may omit the CSP and X-XSS-Protection HTTP hardening headers,
-          because in that situation those headers are less effective.
+          Note that GitHub and GitLab are known to meet this. Sites such as
+          https://securityheaders.com/ can quickly check this.
+          The key hardening headers are: Content Security Policy (CSP),
+          HTTP Strict Transport Security (HSTS), X-Content-Type-Options
+          (as "nosniff"), and X-Frame-Options.
+          Fully static web sites with no ability to log in via the web pages
+          could omit some hardening headers with less risk,
+          but there's no reliable way to detect such sites,
+          so we require these headers even if they are fully static sites.
       security_review:
         description: >-
           The project MUST have performed a security review within


### PR DESCRIPTION
This commit removes the X-XSS-Protection from the `hardened_sites`
criterion and its automated checker, and makes it clear that we
*always* check for the key hardening HTTP headers.

There are two problems. The first is that X-XSS-Protection has not
aged well. It's supposed to enable some heuristic protections. These
protections are largely unnecessary in modern browsers (CSP is
recommended instead), and it's increasingly obvious that this header
will never be standardized. Firefox won't add it, Edge has retired it.
Perhaps most importantly, securityheaders.io doesn't even report the
status of X-XSS-Protection, making it suddenly harder to see this
header value for a site... and also providing additional evidence that
X-XSS-Protection has outlived its purpose. Details here:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection

The second problem is that while some hardening headers aren't very helpful
on static sites, it's impractical to detect if a site is a static site or
not, and we very much do want to encourage use of hardening headers.
So I propose keeping the main criterion unchanged, but changing these details
to make it clear that we just require it for all sites.
We can't tell the difference in an automated way, it doesn't *hurt*
to have those extra protections, and if someone modifies a static site
to become dynamic the hardening protections will be in place.

While we are at it, we'll make other tweaks to this text:

- I checked, and GitLab-hosted project repos have the same
  protections. I confirmed this by viewing the Inkscape repo at
  https://gitlab.com/inkscape/inkscape . GitHub is a great service,
  but where possible I want to not imply that people must lock into any
  specific services.
- I think the text about static sites should be tweaked so that if
  headers are added/removed later it’ll still make sense,
  and also just to shorten it.
- The securityheaders.io site is now a redirect to securityheaders.com
  (it seems to be otherwise the same). As always, we mention this service as
  an easy way to get useful information (“such as”), we don’t mandate its use.

This also adds a check for Strict-Transport-Security. This was always
required for this criterion, now we directly check for it as part of our
automation.