### PR TITLE
Purge badge image last from CDN

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -504,8 +504,8 @@ class ProjectsController < ApplicationController
     cdn_json_key = @project.record_key + '/json'
     # If we can't authenticate to the CDN, complain but don't crash.
     begin
-      FastlyRails.purge_by_key cdn_badge_key
       FastlyRails.purge_by_key cdn_json_key
+      FastlyRails.purge_by_key cdn_badge_key
     rescue StandardError => e
       Rails.logger.error "FAILED TO PURGE #{cdn_badge_key} , #{e.class}: #{e}"
     end


### PR DESCRIPTION
Purge the badge image *last* from the CDN.

In a race condition the badge image is the most likely to be
requested, so by requesting it last we reduce the time a
race condition can occur (and thus reduce the likelihood of it).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>