### PR TITLE
Send CDN purge early, as well as late

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -183,6 +183,8 @@ class ProjectsController < ApplicationController
   # rubocop:disable Metrics/PerceivedComplexity
   def update
     if repo_url_change_allowed?
+      # Send CDN purge early, to give it time to distribute purge request
+      purge_cdn_project
       old_badge_level = @project.badge_level
       project_params.each do |key, user_value| # mass assign
         @project[key] = user_value
@@ -202,6 +204,7 @@ class ProjectsController < ApplicationController
         update_additional_rights
         if @project.save
           successful_update(format, old_badge_level, @criteria_level)
+          # Also send CDN purge last, to increase likelihood of being purged
           purge_cdn_project
         else
           format.html { render :edit, criteria_level: @criteria_level }


### PR DESCRIPTION
Send CDN purge early to counter potential delays within the CDN.

When the project is about to be edited, send the CDN a purge request
early as well as late. This increases the likelihood that a purge
will complete before a request is sent if it takes significant time
for the CDN to distribute that information through its internal network.

We continue to send the purge request late, so that if the CDN manages
to get in a request after the early purge but before the change occurs,
the CDN will throw it away.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>