### PR TITLE
*Actually* Update URL for SPDX license identifiers page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2673,7 +2673,7 @@ en:
           The project MUST include a license statement in each
           source file. This MAY be done by including the following
           inside a comment near the beginning of each file: <a
-          href="https://spdx.org/using-spdx#identifiers"><tt>SPDX-License-Identifier:
+          href="https://spdx.dev/ids/#how"><tt>SPDX-License-Identifier:
           [SPDX license expression for project]</tt></a>.
         details: >-
           This MAY also be done by including a statement in natural


### PR DESCRIPTION
This *actually* updates the URL for the per-file SPDX license
expression page.  Commit 15a670ccd633b5ffb68d7963639bb5c79f82fe3b
from Steve Winslow tried to do that, but it only modified other.md,u
and did *not* modify the file used when displaying the form.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>