### PR TITLE
Refer to the *website* for the criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
+This file documents some notable changes.
+However, because this software is primarily intended for a single site,
+we have not worked at keeping it up to date.
 
 This Change Log format is suggested by
 <https://github.com/olivierlacan/keep-a-changelog/blob/master/CHANGELOG.md>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,6 @@ The "doc/" directory has information you may find helpful, for example:
 -   [implementation.md](doc/implementation.md) provies implementation details
 -   [background.md](doc/background.md) provides background info on criteria
 
-You can see the entire set of "passing" criteria in the generated file
-[criteria.md](doc/criteria.md).
-The documentation for higher-level badge criteria is in
-[other.md](doc/other.md).
 If you want *change* the criteria, see below.
 
 The [INSTALL.md](doc/INSTALL.md) file explains how to install the program

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ There is also a
 [mailing list](https://lists.coreinfrastructure.org/mailman/listinfo/cii-badges)
 for general discussion.
 
-* Badging **[Criteria](./doc/criteria.md)** for the "passing" level
-* **[Other criteria for higher-level badges](./doc/other.md)**
+* Badging **[Criteria for the passing level](https://bestpractices.coreinfrastructure.org/criteria/0)**
+* **[Criteria for all badging levels](https://bestpractices.coreinfrastructure.org/criteria)**
 * Information on how to **[contribute](./CONTRIBUTING.md)**
   (including how to report vulnerabilities)
 * [Up-for-grabs](https://github.com/coreinfrastructure/best-practices-badge/labels/up-for-grabs)
@@ -53,8 +53,7 @@ for general discussion.
 
 ## Summary of Best Practices Criteria "passing" level
 
-This is a summary of the passing criteria, with requirements in bold
-(for details, see the [full list of criteria](doc/criteria.md)):
+This is a summary of the passing criteria, with requirements in bold:
 
 * **Have a [stable website](doc/criteria.md#homepage_url)**, which says:
   - **[what it does](doc/criteria.md#description_good)**

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,15 +131,16 @@ en:
         following best practices and as a result are more likely
         to produce higher-quality secure software.
       p2_html: >-
-        More information on the CII Best Practices Badging program,
-        including background and <a href='https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/criteria.md'>criteria</a>,
-        is <a href='https://github.com/coreinfrastructure/best-practices-badge'>available
+        You can easily see just the <a href="/en/criteria/0">criteria for the
+        passing badge</a>.
+        More information on the CII Best Practices Badging program is
+        <a href='https://github.com/coreinfrastructure/best-practices-badge'>available
         on GitHub</a>. <a href="/en/project_stats">Project statistics</a>
         and <a href="/en/criteria_stats">criteria statistics</a> are available.
         The <a href="/en/projects">projects page</a> shows participating
         projects and supports queries (e.g., you can see <a href="/en/projects?gteq=100">projects
         that have a passing badge</a>). You can also see <a href='/en/projects/1/0'>an
-        example (where we try to get our own badge)</a>.
+        example (where we try to earn our own badge)</a>.
       p3_html: >-
         <em>Privacy and legal issues</em>: Please see our <a href="https://www.linuxfoundation.org/privacy">privacy
         policy</a>,

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -397,8 +397,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -387,8 +387,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/background.md
+++ b/doc/background.md
@@ -1751,8 +1751,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/criteria-footer.markdown
+++ b/doc/criteria-footer.markdown
@@ -128,8 +128,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/criteria.md
+++ b/doc/criteria.md
@@ -585,8 +585,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -481,8 +481,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/governance.md
+++ b/doc/governance.md
@@ -100,8 +100,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -1289,8 +1289,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/other.md
+++ b/doc/other.md
@@ -1702,8 +1702,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -136,8 +136,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -52,8 +52,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/security.md
+++ b/doc/security.md
@@ -3140,8 +3140,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -190,8 +190,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 

--- a/doc/vetting.md
+++ b/doc/vetting.md
@@ -115,8 +115,8 @@ Project participation and interface:
 
 Criteria:
 
-* [criteria.md](criteria.md) - Criteria for "passing" badge
-* [other.md](other.md) - Criteria for other badges (silver and gold)
+* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
+* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
 
 Development processes and security:
 


### PR DESCRIPTION
This changes many documents and the website front page
so that users are directed to /criteria to see the
actual criteria, instead of the static markdown files.

This does *NOT* change all the specialized README links to
specific criteria; the plan is to do that later.
Let's get the main links updated first :-).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>