### PR TITLE
Enable admin CLI search of email and name (for GDPR)

### DIFF
--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -162,6 +162,17 @@ This was implemented with:
 heroku config:set --app production-bestpractices TZ=:/usr/share/zoneinfo/UTC
 ~~~~
 
+## Searching user names and emails (for GDPR Requests)
+
+We have a simple ability for system admins to search for user names
+and user emails, primarily to support GDPR Requests.
+Use as follows
+
+~~~~
+heroku run --app production-bestpractices rake search_name -- 'NAME'
+heroku run --app production-bestpractices rake search_email -- 'EMAIL'
+~~~~
+
 ## Security
 
 See the separate


### PR DESCRIPTION
Add the ability for the BadgeApp admin to more easily search on
user email and user name. This is primarily so that we can easily
support GDPR requests, though it can have other uses.

The name search is relatively slow; instead of being indexed,
we look for internal matches while downcasing. But this is a
rare event that cannot be requested by unauthorized users,
so it doesn't matter. It's only *relatively* slow anyway; the
search happens entirely within the database.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>