### PR TITLE
Add ability to control cache size

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,9 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
-  config.cache_store = :memory_store, { size: 64.megabytes }
+  config.cache_store =
+    :memory_store,
+    { size: (ENV['RAILS_CACHE_SIZE'] || '128').to_i.megabytes }
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,7 +21,9 @@ Rails.application.configure do
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
-  config.cache_store = :memory_store, { size: 64.megabytes }
+  config.cache_store =
+    :memory_store,
+    { size: (ENV['RAILS_CACHE_SIZE'] || '128').to_i.megabytes }
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
   # Add `rack-cache` to your Gemfile before enabling this.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -4,6 +4,7 @@
 # CII Best Practices badge contributors
 # SPDX-License-Identifier: MIT
 
+# rubocop:disable Metrics/BlockLength
 Rails.application.configure do
   # Settings specified here will take precedence over those in
   # config/application.rb.
@@ -27,7 +28,9 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
-  config.cache_store = :memory_store, { size: 64.megabytes }
+  config.cache_store =
+    :memory_store,
+    { size: (ENV['RAILS_CACHE_SIZE'] || '128').to_i.megabytes }
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
@@ -85,3 +88,4 @@ Rails.application.configure do
     # Bullet.slack = { webhook_url: 'http://some.slack.url', foo: 'bar' }
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Add the ability to set the environment variable RAILS_CACHE_SIZE
to control the cache size in Mebibytes (default 128 Mebibytes;
the old default was 64 Mebibytes). Warning: the Rails ".megabytes"
actually means Mebibytes.

I tried merging this into a single initializer, but that caused
test failures. I believe the problem is that that initializing the
cache is especially order-dependent (which makes sense, because it
affects so many other things). I'm sure I could track that down,
but trying to eliminate the duplication of a single simple line
isn't worth the trouble (especially since it was already duplicated).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>