### PR TITLE
Add ability to show autofill entries

### DIFF
--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -25,6 +25,7 @@ class CriteriaController < ApplicationController
   def set_params
     @details = boolean_param(:details, false)
     @rationale = boolean_param(:rationale, false)
+    @autofill = boolean_param(:autofill, false)
   end
 
   # Convert user-provided parameter "name" into true/false.

--- a/app/views/criteria/_one_level.html.erb
+++ b/app/views/criteria/_one_level.html.erb
@@ -57,6 +57,13 @@
     <dd><%= raw criterion_data['rationale'] %></dd>
   </dl>
 <%       end -%>
+<%       if (autofill && (I18n.locale == :en) &&
+             criterion_data.key?('autofill')) -%>
+  <dl>
+    <dt><i>Autofill:</i></dt><dt> </dt>
+    <dd><%= raw criterion_data['autofill'] %></dd>
+  </dl>
+<%       end -%>
 <%     end -%>
 </ul>
 <%   end -%>

--- a/app/views/criteria/index.html.erb
+++ b/app/views/criteria/index.html.erb
@@ -10,6 +10,7 @@
             {
               criteria_level: criteria_level,
               details: @details, rationale: @rationale,
+              autofill: @autofill,
               bare_key: false
             } -%>
 <% end %>

--- a/app/views/criteria/show.html.erb
+++ b/app/views/criteria/show.html.erb
@@ -1,4 +1,4 @@
-<% cache [locale, @criteria_level, @details, @rationale] do -%>
+<% cache [locale, @criteria_level, @details, @rationale, @autofill] do -%>
 <div class="row">
 <div class="col-xs-12">
 <h1><%= t("criteria_overall.beginning_header_#{@criteria_level}") %></h1>
@@ -9,6 +9,7 @@
             {
               criteria_level: @criteria_level,
               details: @details, rationale: @rationale,
+              autofill: @autofill,
               bare_key: true # True for "show"
             } -%>
 </div>

--- a/doc/criteria-header.markdown
+++ b/doc/criteria-header.markdown
@@ -20,6 +20,15 @@ criteria</a>, and the
 This change makes it easier to see the real criteria in any language,
 as well as hide or reveal the details and rationale.
 
+You can also add a "?" and some `&`-separated parameters:
+
+* `details=true` : Show criterion details (clarifications)
+* `rationale=true` : Show the criterion rationale
+  (why this criterion is included in the set of criteria).
+  This option only applies to the English locale.
+* `autofill=true` : Show ideas for how to automatically determine this.
+  This option only applies to the English locale.
+
 For now, we've kept the old criteria text below, so you're not
 surprised by this change.
 

--- a/doc/criteria.md
+++ b/doc/criteria.md
@@ -20,6 +20,15 @@ criteria</a>, and the
 This change makes it easier to see the real criteria in any language,
 as well as hide or reveal the details and rationale.
 
+You can also add a "?" and some `&`-separated parameters:
+
+* `details=true` : Show criterion details (clarifications)
+* `rationale=true` : Show the criterion rationale
+  (why this criterion is included in the set of criteria).
+  This option only applies to the English locale.
+* `autofill=true` : Show ideas for how to automatically determine this.
+  This option only applies to the English locale.
+
 For now, we've kept the old criteria text below, so you're not
 surprised by this change.
 

--- a/test/controllers/criteria_controller_test.rb
+++ b/test/controllers/criteria_controller_test.rb
@@ -21,6 +21,31 @@ class CriteriaControllerTest < ActionDispatch::IntegrationTest
     assert_includes @response.body, 'MUST achieve a silver level badge'
     assert_includes @response.body,
                     'MUST document its code review requirements'
+    assert_includes @response.body, 'Passing'
+    assert_includes @response.body, 'Silver'
+    assert_includes @response.body, 'Gold'
+    assert_not_includes @response.body, 'Details:'
+    assert_not_includes @response.body, 'Rationale:'
+    assert_not_includes @response.body, 'Autofill:'
+  end
+
+  test 'Get criteria set in English with extra information' do
+    get '/en/criteria?details=true&rationale=true&autofill=true'
+    assert_response :success
+    assert_includes @response.body, 'Basics'
+    assert_includes @response.body, 'Basic project website content'
+    assert_includes @response.body,
+                    'MUST succinctly describe what the software does'
+    assert_includes @response.body, 'MUST achieve a passing level badge'
+    assert_includes @response.body, 'MUST achieve a silver level badge'
+    assert_includes @response.body,
+                    'MUST document its code review requirements'
+    assert_includes @response.body, 'Passing'
+    assert_includes @response.body, 'Silver'
+    assert_includes @response.body, 'Gold'
+    assert_includes @response.body, 'Details:'
+    assert_includes @response.body, 'Rationale:'
+    assert_includes @response.body, 'Autofill:'
   end
 
   test 'Get passing criteria set in English with details and rationale' do
@@ -32,6 +57,19 @@ class CriteriaControllerTest < ActionDispatch::IntegrationTest
                     'MUST succinctly describe what the software does'
     assert_includes @response.body, 'Details:'
     assert_includes @response.body, 'Rationale:'
+    assert_not_includes @response.body, 'Autofill:'
+  end
+
+  test 'Get passing criteria set in English with details and autofill' do
+    get '/en/criteria/0?details=true&autofill=true'
+    assert_response :success
+    assert_includes @response.body, 'Basics'
+    assert_includes @response.body, 'Basic project website content'
+    assert_includes @response.body,
+                    'MUST succinctly describe what the software does'
+    assert_includes @response.body, 'Details:'
+    assert_not_includes @response.body, 'Rationale:'
+    assert_includes @response.body, 'Autofill:'
   end
 
   test 'Get one criteria set, passing, in English' do
@@ -42,6 +80,7 @@ class CriteriaControllerTest < ActionDispatch::IntegrationTest
                     'MUST succinctly describe what the software does'
     assert_not_includes @response.body, 'Details:'
     assert_not_includes @response.body, 'Rationale:'
+    assert_not_includes @response.body, 'Autofill:'
     assert_not_includes @response.body, 'MUST achieve a passing level badge'
     assert_not_includes @response.body, 'MUST achieve a silver level badge'
   end


### PR DESCRIPTION
Add `autofill=true` as an option to /criteria displays, so that
this information is much easier to retrieve.
This is in support of OpenSSF discussions.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>