### PR TITLE
Minor tweak: use .ids in projects_controller

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -395,7 +395,7 @@ class ProjectsController < ApplicationController
     )
                 .deliver_now
     # To simplify certain tests, return list of project ids newly passing
-    projects[0].map(&:id)
+    projects[0].ids
   end
   # rubocop:enable Metrics/MethodLength
   private_class_method :send_monthly_announcement


### PR DESCRIPTION
Use .ids instead of .map(&:id) to get a list of ids.
It's clearer *and* more efficient.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>