### PR TITLE
Add non-badge-image rate limit, fixes #1475

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -69,7 +69,7 @@ class Rack::Attack
   # Path for a badge image. Note that this does NOT vary by locale.
   BADGE_REGEX_PATH = Regexp.compile('^/projects/[1-9][0-9]*/badge$')
 
-  # Throttle all requests other than badge images by IP (default 15/15sec)
+  # Throttle all requests other than badge images by IP (default 31/15sec)
   # Everything other than badge image requests should be made at a reasonable
   # rate slower than badge images, so enforce a slower rate.
   # We define a non-badge requests as anything either requesting JSON or
@@ -79,10 +79,12 @@ class Rack::Attack
   # requested much more often anyway (e.g., ~30 at time via /projects).
   # As noted above, this limit does NOT apply to static files (like images)
   # in production, as they are served separately.
+  # The default is chosen to allow someone to query a single /projects page
+  # of 30 projects along with JSON requests for data about every project.
   unless Rails.env.test?
     throttle(
       'nonbadge_req/ip',
-      limit: (ENV['NONBADGE_RATE_REQ_IP_LIMIT'] || '15').to_i,
+      limit: (ENV['NONBADGE_RATE_REQ_IP_LIMIT'] || '31').to_i,
       period: (ENV['NONBADGE_RATE_REQ_IP_PERIOD'] || '15').to_i
     ) do |req|
       if req.env['HTTP_ACCEPT']&.include?('application/json') ||

--- a/doc/api.md
+++ b/doc/api.md
@@ -16,6 +16,9 @@ a pointer to a sample analysis program,
 how to query, how to download the database,
 and then various kinds of more specialized information.
 
+All BadgeApp requests are rate-limited. At the time of this writing,
+if you keep requests at 1 request/second or less you'll be fine.
+
 ## Quickstart
 
 Like any RESTful API, use an HTTP verb (like GET) on a resource.

--- a/doc/api.md
+++ b/doc/api.md
@@ -17,7 +17,9 @@ how to query, how to download the database,
 and then various kinds of more specialized information.
 
 All BadgeApp requests are rate-limited. At the time of this writing,
-if you keep requests at 1 request/second or less you'll be fine.
+if you keep requests at 1 request/second or less for anything other than
+badge images you'll be fine. Badge image rates can be much higher
+(those are specially optimized).
 
 ## Quickstart
 
@@ -159,6 +161,18 @@ might request.
     The link uses as=entry; this will show the specific project entry
     if there is exactly one, and otherwise will show the project list of
     matches.
+
+    All BadgeApp requests are rate-limited, and requests other than badge
+    images have smaller rate limits. So while you can embed this query when
+    describing a single project, you can't really have a page
+    full of these queries (such as the img src above using a /projects query).
+    If you want to show a large number of CII badges images all at once,
+    it's better to use the query interface to find its corresponding
+    numeric project id (e.g., at the server). Then just use the numeric
+    project id reference instead, e.g., generate this instead (where you
+    found NUMBER earlier):
+
+    <img src="https://bestpractices.coreinfrastructure.org/projects/NUMBER/badge" alt="CII N/A">
 
 ## Tiered percentage in CII Best Practices Badge
 

--- a/doc/best-practices.py
+++ b/doc/best-practices.py
@@ -12,7 +12,7 @@
 # CII Best Practices badge contributors
 # SPDX-License-Identifier: MIT
 
-import os, sys, re, json, urllib
+import os, sys, re, json, time, urllib
 from urllib.request import urlopen
 
 # File for storing cached value
@@ -34,6 +34,7 @@ def retrieve_data():
             break
         retrieved_dataset += page_data
         page_number += 1
+        time.sleep(1) # Add delay to avoid hitting rate limits
     return retrieved_dataset
 
 # Load JSON data (from a file if possible, else it's retrieved and saved)


### PR DESCRIPTION
Add a separate rate limit for anything other than badge images
that is significantly lower than the "any request" rate limit.

Some badly-behaved crawlers/spiders/scrapers abuse the website
and request "everything at once".  We can handle badge images requests
more easily (they're fast and the CDN handles most of the load),
and we *expect* many badge image requests. However, we don't expect
other requests quite as much. Making too many of those requests can
result in denial of service, and the system burden also makes it harder
to serve others in a timely way.

By adding a separate rate limit, and one that triggers much more quickly
(before we even hit the number of active threads), we quickly halt
any unintentional overload and we quickly signal to crawlers that
they need to be patient.

This also modifies the sample "load data" program so that it will
stay within the rate limits.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>