### PR TITLE
Switch gems from will_paginate pagy, fixes #1480

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'bcrypt', '3.1.15' # Security - for salted hashed interated passwords
 gem 'blind_index', '0.3.4' # Index encrypted email addresses
 gem 'bootstrap-sass', '3.4.1'
 gem 'bootstrap-social-rails', '4.12.0'
-gem 'bootstrap-will_paginate', '1.0.0'
 gem 'bootstrap_form', '2.7.0'
 gem 'chartkick', '3.4.0' # Chart project_stats
 gem 'fastly-rails', '0.8.0'
@@ -40,6 +39,7 @@ gem 'omniauth-github', '1.4.0' # Authentication to GitHub (get project info)
 gem 'omniauth-rails_csrf_protection',
     git: 'https://github.com/cookpad/omniauth-rails_csrf_protection.git',
     ref: 'b33ff2e57f7c0530da76da6b4b358218f1e7f230'
+gem 'pagy', '3.8.3' # Paginate some views
 gem 'paleta', '0.3.0' # Color manipulation, used for badges
 gem 'paper_trail', '10.3.1' # Record previous versions of project data
 gem 'pg', '1.2.3' # PostgreSQL database, used for data storage
@@ -55,8 +55,6 @@ gem 'sass-rails', '5.1.0', require: false # For .scss files (CSS extension)
 gem 'scout_apm', '2.6.9' # Monitor for memory leaks
 gem 'secure_headers', '6.3.1' # Add hardening measures to HTTP headers
 gem 'uglifier', '4.2.0', require: false # Minify JavaScript
-gem 'will-paginate-i18n', '0.1.15' # Provide will-paginate translations
-gem 'will_paginate', '3.3.0' # Paginate results (next/previous)
 
 group :development, :test do
   gem 'awesome_print', '1.8.0' # Pretty print Ruby objects

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,8 +72,6 @@ GEM
       sassc (>= 2.0.0)
     bootstrap-social-rails (4.12.0)
       railties (>= 3.1)
-    bootstrap-will_paginate (1.0.0)
-      will_paginate
     bootstrap_form (2.7.0)
     builder (3.2.4)
     bullet (6.1.0)
@@ -251,6 +249,7 @@ GEM
     omniauth-oauth2 (1.7.0)
       oauth2 (~> 1.4)
       omniauth (~> 1.9)
+    pagy (3.8.3)
     paleta (0.3.0)
     paper_trail (10.3.1)
       activerecord (>= 4.2)
@@ -446,8 +445,6 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    will-paginate-i18n (0.1.15)
-    will_paginate (3.3.0)
     with_env (1.1.0)
     xml-simple (1.1.5)
     xpath (3.2.0)
@@ -465,7 +462,6 @@ DEPENDENCIES
   bootsnap (= 1.4.8)
   bootstrap-sass (= 3.4.1)
   bootstrap-social-rails (= 4.12.0)
-  bootstrap-will_paginate (= 1.0.0)
   bootstrap_form (= 2.7.0)
   bullet (= 6.1.0)
   bundler-audit (= 0.7.0.1)
@@ -495,6 +491,7 @@ DEPENDENCIES
   octokit (= 4.18.0)
   omniauth-github (= 1.4.0)
   omniauth-rails_csrf_protection!
+  pagy (= 3.8.3)
   paleta (= 0.3.0)
   paper_trail (= 10.3.1)
   pg (= 1.2.3)
@@ -531,8 +528,6 @@ DEPENDENCIES
   web-console (= 3.7.0)
   webdrivers (= 4.4.1)
   webmock (= 3.8.3)
-  will-paginate-i18n (= 0.1.15)
-  will_paginate (= 3.3.0)
   yaml-lint (= 0.0.10)
 
 RUBY VERSION

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@
 require 'ipaddr'
 
 class ApplicationController < ActionController::Base
+  include Pagy::Backend
+
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -669,15 +669,18 @@ class ProjectsController < ApplicationController
 
   # Subset to only the rows and fields we need
   def select_data_subset
-    # We want to know the *total* count, even if we're paging,
-    # so retrive this information separately
-    @count = @projects.count
     # If we're supplying html (common case), select only needed fields
     format = request&.format&.symbol
     if !format || format == :html
       @projects = @projects.select(HTML_INDEX_FIELDS)
     end
-    @projects = @projects.includes(:user).paginate(page: params[:page])
+    @pagy, @projects = pagy(@projects.includes(:user))
+    # We want to know the *total* count, even if we're paging.
+    # Pagy has to figure that out anyway, so instead of doing this:
+    # # @count = @projects.count
+    # we will extract it from pagy.
+    @count = @pagy.count
+    @pagy_locale = I18n.locale.to_s # Pagy requires a string version
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,17 +21,21 @@ class UsersController < ApplicationController
   end
 
   def index
-    @users = User.all.paginate(page: params[:page])
+    @pagy, @users = pagy(User.all)
+    @pagy_locale = I18n.locale.to_s # Pagy requires a string version
   end
 
   # rubocop: disable Metrics/MethodLength, Metrics/AbcSize
   def show
     @user = User.find(params[:id])
     respond_to :html, :json
+    # Paginate the list of user-owned projects.
     # Use "select_needed" to minimize the fields we extract
-    @projects = select_needed(@user.projects).paginate(page: params[:page])
-    # Don't bother paginating, we typically don't have that many and the
-    # interface would be confusing.
+    @pagy, @projects = pagy(select_needed(@user.projects))
+    @pagy_locale = I18n.locale.to_s # Pagy requires a string version
+
+    # Don't bother paginating the projects wtih additional rights,
+    # we practically never have that many and the interface would be confusing.
     @projects_additional_rights =
       select_needed(Project.includes(:user).joins(:additional_rights)
         .where('additional_rights.user_id = ?', @user.id))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,4 +5,5 @@
 # SPDX-License-Identifier: MIT
 
 module ApplicationHelper
+  include Pagy::Frontend
 end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -49,5 +49,5 @@
 <br>
 <br>
   <%= render 'table', projects: @projects, locale: locale %>
-  <%= will_paginate @projects %>
+  <%== pagy_bootstrap_nav(@pagy) %>
 </div>

--- a/app/views/static_pages/robots.text.erb
+++ b/app/views/static_pages/robots.text.erb
@@ -84,6 +84,9 @@ Disallow: /*?*sort_direction=
 # This rule covers q=, pq=, lteq=, and gteq=:
 Disallow: /*?*q=
 #
+# Don't crawl JavaScript pagy pseudo-pages (real pages are fine to crawl)
+Disallow: *__pagy_page__
+#
 # Don't crawl "edit" pages. They require login, so attempting to crawl them
 # wastes everyone's time.  They should all end in "/edit", but
 # sometimes they end in "edit" instead - disallow them either way.

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,6 +20,6 @@
     </li>
   <% end %>
 </ul>
-<%= will_paginate @users %>
+<%== pagy_bootstrap_nav(@pagy) %>
 
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,7 +22,7 @@
     <br><br>
     <h2><%= t '.projects_owned' %></h2>
     <%= render 'projects/table', projects: @projects %>
-    <%= will_paginate @projects %>
+    <%== pagy_bootstrap_nav(@pagy) %>
   <% end %>
 
   <% if @projects_additional_rights.present? %>

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -22,7 +22,7 @@
 # user accounts in that locale. See: app/views/static_pages/robots.text.erb
 #
 # The order here is English (the source language in this case), followed
-# by the locales in English name order.  That's an arbitrary order.
+# by the locales in English name order. Pagy initialization requires en first.
 # This has the useful side-effect that Chinese is listed early, next to
 # a Romance language, so it will be *immediately* obvious to users when
 # they see the list that it is for locale selection.

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (3.8.3)
+# Customize only what you really need and notice that Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+# Extras
+# See https://ddnexus.github.io/pagy/extras
+
+# Backend Extras
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/extras/array
+# require 'pagy/extras/array'
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::VARS[:cycle] = false    # default
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
+# require 'pagy/extras/elasticsearch_rails'
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/extras/searchkick
+# require 'pagy/extras/searchkick'
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
+# See https://ddnexus.github.io/pagy/extras/foundation
+# require 'pagy/extras/foundation'
+
+# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
+# See https://ddnexus.github.io/pagy/extras/materialize
+# require 'pagy/extras/materialize'
+
+# Navs extra: Add nav_js and combo_nav_js javascript helpers
+# Notice: the other frontend extras add their own framework-styled versions,
+# so require this extra only if you need the unstyled version
+# See https://ddnexus.github.io/pagy/extras/navs
+# require 'pagy/extras/navs'
+
+# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
+# See https://ddnexus.github.io/pagy/extras/semantic
+# require 'pagy/extras/semantic'
+
+# UIkit extra: Add nav helper and templates for UIkit pagination
+# See https://ddnexus.github.io/pagy/extras/uikit
+# require 'pagy/extras/uikit'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/extras/navs#steps
+# Pagy::VARS[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+
+# Feature Extras
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See http://ddnexus.github.io/pagy/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::VARS[:headers] = { page: 'Current-Page', items: 'Page-Items', count: 'Total-Count', pages: 'Total-Pages' }     # default
+
+# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
+# See https://ddnexus.github.io/pagy/extras/support
+# require 'pagy/extras/support'
+
+# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/extras/items
+# require 'pagy/extras/items'
+# Pagy::VARS[:items_param] = :items    # default
+# Pagy::VARS[:max_items]   = 100       # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::VARS[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/extras/metadata
+# you must require the shared internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/shared'
+# require 'pagy/extras/metadata'
+# For performance reason, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::VARS[:metadata] = [:scaffold_url, :count, :page, :prev, :next, :last]    # example
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/extras/trim
+# require 'pagy/extras/trim'
+require 'pagy/extras/trim'
+
+# Pagy Variables
+# See https://ddnexus.github.io/pagy/api/pagy#variables
+# All the Pagy::VARS are set for all the Pagy instances but can be overridden
+# per instance by just passing them to Pagy.new or the #pagy controller method
+
+# Instance variables
+# See https://ddnexus.github.io/pagy/api/pagy#instance-variables
+# Pagy::VARS[:items] = 20                                   # default
+Pagy::VARS[:items] = 30
+
+# Other Variables
+# See https://ddnexus.github.io/pagy/api/pagy#other-variables
+# Pagy::VARS[:size]       = [1,4,4,1]                       # default
+# Pagy::VARS[:page_param] = :page                           # default
+# Pagy::VARS[:params]     = {}                              # default
+# Pagy::VARS[:anchor]     = '#anchor'                       # example
+# Pagy::VARS[:link_extra] = 'data-remote="true"'            # example
+Pagy::VARS[:size] = [2, 4, 4, 2]
+
+# Rails
+
+# Rails: extras assets path required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
+# See https://ddnexus.github.io/pagy/extras#javascript
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/api/frontend#i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({locale: 'de'},
+#                 {locale: 'en'},
+#                 {locale: 'es'})
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({locale: 'en'},
+#                 {locale: 'es', filepath: 'path/to/pagy-es.yml'},
+#                 {locale: 'xyz',  # not built-in
+#                  filepath: 'path/to/pagy-xyz.yml',
+#                  pluralize: lambda{|count| ... } )
+
+# Load pagy locales for all the locales we use, preferring speed.
+# This presumes that 'en' is listed first in I18n.available_locales (true).
+# This also presumes that pagy's internal translations includes all our locales
+# (this is currently true).
+PAGY_LOCALES = I18n.available_locales.map { |lang| { locale: lang.to_s } }.freeze
+Pagy::I18n.load(*PAGY_LOCALES)
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/extras/i18n
+# require 'pagy/extras/i18n'
+
+# Default i18n key
+# Pagy::VARS[:i18n_key] = 'pagy.item_name'   # default


### PR DESCRIPTION
This commit changes how we paginate project lists when they're being
displayed. This switches from the will_paginate gem to the pagy gem
to speed view generation, use less memory, and use less code.

The will_paginate gem works, but the article
["Speeding Up Your Ruby on Rails App" by Daniel Lempesis](https://medium.com/@daniellempesis/speeding-up-your-ruby-on-rails-app-4c37ec71b126)
noted that while this was common, the
[pagy gem](https://github.com/ddnexus/pagy) was a significantly
better option. It's much faster and uses significantly less memory.
It's also just cleaner (in my opinion).
Although pagy works differently, switching looked pretty easy, and it was.

The tweak to the robots.txt file isn't strictly necessary, since that's
only needed if we use the JavaScript versions. But it would be easy to
switch to the JavaScript versions and forget to tweak the robots.txt
file, so this commit modifies the robots.txt file pre-emptively.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>