### PR TITLE
Gemfile: Break rails gem into selected dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,19 @@
 source 'https://rubygems.org'
 ruby File.open('.ruby-version', 'rb') { |f| f.read.chomp }
 
+# The action* gems are Rails portions. When you upgrade their versions, be
+# sure to upgrade them in sync, *including* railties.
+# Loading only what we use reduces memory use & attack surface.
+# gem 'actioncable' # Not used. Client/server comm channel.
+gem 'actionmailer', '5.2.4.4' # Rails. Send email.
+gem 'actionpack', '5.2.4.4' # Rails. MVC framework.
+gem 'actionview', '5.2.4.4' # Rails. View.
+gem 'activejob', '5.2.4.4' # Rails. Async jobs.
+gem 'activemodel', '5.2.4.4' # Rails. Model basics.
+gem 'activerecord', '5.2.4.4' # Rails. ORM and query system.
+# gem 'activestorage' # Not used. Attaches cloud files to ActiveRecord.
+gem 'activesupport', '5.2.4.4' # Rails. Underlying library.
+# gem 'activetext' # Not used. Text editor that fails to support markdown.
 gem 'attr_encrypted', '3.1.0' # Encrypt email addresses
 gem 'bcrypt', '3.1.15' # Security - for salted hashed interated passwords
 gem 'blind_index', '0.3.4' # Index encrypted email addresses
@@ -15,6 +28,7 @@ gem 'bootstrap-sass', '3.4.1'
 gem 'bootstrap-social-rails', '4.12.0'
 gem 'bootstrap-will_paginate', '1.0.0'
 gem 'bootstrap_form', '2.7.0'
+gem 'bundler' # Ensure it's available
 gem 'chartkick', '3.4.0' # Chart project_stats
 gem 'fastly-rails', '0.8.0'
 gem 'font-awesome-rails', '4.7.0.5'
@@ -48,12 +62,17 @@ gem 'puma', '4.3.6' # Faster webserver; recommended by Heroku
 gem 'rack-attack', '6.3.1' # Implement rate limiting
 gem 'rack-cors', '1.1.1' # Enable CORS so JavaScript clients can get JSON
 gem 'rack-headers_filter', '0.0.1' # Filter out "dangerous" headers
-gem 'rails', '5.2.4.4' # Our web framework
+# We no longer say: gem 'rails', '5.2.4.4' # Our web framework
+# but instead load only what we use (to reduce memory use and attack surface).
+# We load sprockets-rails, but its version number isn't kept in sync.
+# Note: Update the gem versions of action* and railties in sync.
+gem 'railties', '5.2.4.4' # Rails. Rails core, loads rest of Rails
 gem 'rails-i18n', '5.1.3' # Localizations for Rails built-ins
 gem 'redcarpet', '3.5.0' # Process markdown in form textareas (justifications)
 gem 'sass-rails', '5.1.0', require: false # For .scss files (CSS extension)
 gem 'scout_apm', '2.6.9' # Monitor for memory leaks
 gem 'secure_headers', '6.3.1' # Add hardening measures to HTTP headers
+gem 'sprockets-rails', '3.2.2' # Rails. Asset precompilation
 gem 'uglifier', '4.2.0', require: false # Minify JavaScript
 gem 'will-paginate-i18n', '0.1.15' # Provide will-paginate translations
 gem 'will_paginate', '3.3.0' # Paginate results (next/previous)
@@ -80,6 +99,7 @@ group :development, :test do
   gem 'rubocop-rails', '2.8.0', require: false # Rails-specific cops
   gem 'ruby-graphviz', '1.2.5' # This is used for bundle viz
   gem 'spring', '2.1.1' # Preloads app so console, rake, and tests run faster
+  # Do NOT upgrade to vcr 6.*, as that is not OSS:
   gem 'vcr', '5.0.0' # Record network responses for later test reuse
   gem 'yaml-lint', '0.0.10' # Check YAML file syntax
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,6 +458,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionmailer (= 5.2.4.4)
+  actionpack (= 5.2.4.4)
+  actionview (= 5.2.4.4)
+  activejob (= 5.2.4.4)
+  activemodel (= 5.2.4.4)
+  activerecord (= 5.2.4.4)
+  activesupport (= 5.2.4.4)
   attr_encrypted (= 3.1.0)
   awesome_print (= 1.8.0)
   bcrypt (= 3.1.15)
@@ -468,6 +475,7 @@ DEPENDENCIES
   bootstrap-will_paginate (= 1.0.0)
   bootstrap_form (= 2.7.0)
   bullet (= 6.1.0)
+  bundler
   bundler-audit (= 0.7.0.1)
   capybara-selenium (= 0.0.6)
   capybara-slow_finder_errors (= 0.1.5)
@@ -509,10 +517,10 @@ DEPENDENCIES
   rack-cors (= 1.1.1)
   rack-headers_filter (= 0.0.1)
   rack-timeout (= 0.6.0)
-  rails (= 5.2.4.4)
   rails-controller-testing (= 1.0.4)
   rails-i18n (= 5.1.3)
   rails_12factor (= 0.0.3)
+  railties (= 5.2.4.4)
   redcarpet (= 3.5.0)
   rubocop (= 0.91.1)
   rubocop-performance (= 1.8.0)
@@ -524,6 +532,7 @@ DEPENDENCIES
   selenium-webdriver (= 3.142.7)
   simplecov (= 0.19.0)
   spring (= 2.1.1)
+  sprockets-rails (= 3.2.2)
   traceroute (= 0.8.1)
   translation (= 1.22)
   uglifier (= 4.2.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,9 @@
 
 require_relative 'boot'
 
+# This loads all Rails libraries that are *present*. However,
+# note that our Gemfile only includes the Rails gems we actually use
+# (to reduce memory use and attack surface).
 require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
Modify the Gemfile so we *only* load the Rails gems we use.
This reduces our memory use and attack surface.

Previously in our Gemfile we just used this construct to load Rails:

> gem 'rails', '5.2.4.4' # Our web framework

However, that brings in some Rails gems that we never use.

Bringing in unused gems can be a problem.
[Rails issue #36963, "Rails 6.0.0 performance regression because of ActionText::Engine hook"](https://github.com/rails/rails/issues/36963)
discusses a serious problem when using Rails 6 - ActionText
takes a lot more memory (so much that many people have reverted
an upgrade). We don't plan to use ActionText anyway;
it fails to support markdown.
ActionText builds on Trix, and we have requested markdown suport
([Trix issue #626](https://github.com/basecamp/trix/issues/626))
and someone has developed a pull request for some markdown support
([Trix pull request #737](https://github.com/basecamp/trix/pull/737)).
But those patches have yet to be accepted, and it's not clear this
functionality will ever get added. Without that functionality,
ActionText is not useful for many people (not just us).
So we'd have a lot of pain (wasted memory) with no benefit (we can't
use ActionText anyway).

The StackOverflow discussion
[Rails 5.2.4: How to reduce RAM use?](https://stackoverflow.com/questions/59340237/rails-5-2-4-how-to-reduce-ram-use)
noted several ways to reduce RAM use, including:

> Another thing you can do is to only load the rails modules you
> actually use. On your config/application.rb file you'll see a
> line like this require 'rails/all' that loads all rails features
> https://github.com/rails/rails/blob/master/railties/lib/rails/all.rb
> You can change that line to only import the features you want, like if
> you don't use action_cable or active_job you can just import the rest.

However, while we *could* modify `config/application.rb`, it seems
much cleaner to list in the Gemfile *only* the gems we use.
Then we *know* we never loaded anything else.

A minor negative to this approach is that when we update our Gemfile we
have to update all these gem versions in sync. Since they're released
as a unit, it's possible that different rails gems won't work properly
together if they use different versions. This commit adds
comments to the Gemfile to specifically counter that potential problem.
As a result, I think that risk is very low.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>