### PR TITLE
Cache badge on CDN in JSON (in addition to SVG)

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -163,19 +163,22 @@ class ProjectsController < ApplicationController
     'id, name, updated_at, tiered_percentage, ' \
     'badge_percentage_0, badge_percentage_1, badge_percentage_2'
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def badge
     # Don't use "set_project", but instead specifically find the project
-    # ourselves.  That way, we can select *only* the fields we need
+    # ourselves.  That way, we select *only* the fields we need
     # (there are very few!).  By selecting only what we actually use, we
     # greatly reduce the number of objects created by ActiveRecord, which is
     # important because this common request is supposed to be quick.
     # Note: If the "find" fails this will raise an exception, which
     # will eventually lead (correctly) to a failure report.
     @project = Project.select(BADGE_PROJECT_FIELDS).find(params[:id])
+
+    # Tell CDN the surrogate key so we can quickly erase them later
+    set_surrogate_key_header @project.record_key + '/badge'
+
     respond_to do |format|
       format.svg do
-        set_surrogate_key_header @project.record_key + '/badge'
         send_data Badge[value_for_badge],
                   type: 'image/svg+xml', disposition: 'inline'
       end
@@ -184,7 +187,7 @@ class ProjectsController < ApplicationController
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   # GET /projects/new
   def new

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 
-# Copyright 2015-2017, the Linux Foundation, IDA, and the
+# Copyright the Linux Foundation, IDA, and the
 # CII Best Practices badge contributors
 # SPDX-License-Identifier: MIT
 
 # Allow client-side JavaScript of other systems to make GET requests,
 # but *only* get requests, from us.  We do *not* share credentials.
+
+# Typically CORS users will request the JSON files, e.g., by using
+# using the suffix ".json" on the resource. We do allow requests to
+# some non-JSON resources, in case it's useful.
+
+# There are some complications in the interaction of CORS and the
+# HTTP Heading 'Vary'.  For more information, see:
+# https://www.fastly.com/blog/best-practices-using-vary-header
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
 
 # It should be fine to allow "GET" and "OPTIONS" on any request,
 # since we require credentials for anything non-public.  However,
@@ -13,34 +22,24 @@
 # of caution.  We allow "/" just to make testing easy.
 # It's really "GET" that we want to allow, but we allow OPTIONS
 # in case a web browser decides to make a pre-flight request.
-# Typically CORS users will request the JSON files, e.g., by using
-# using the suffix ".json" on the resource.
 
 CORS_ALLOWED_METHODS = %i[get options].freeze
-CORS_RESOURCE_PATTERNS = [
-  '/projects', '/projects.json', '/projects/*',
-  '/projects/**/*', '/project_stats*',
-  '/en/projects', '/en/projects.json', '/en/projects/*',
-  '/en/projects/**/*', '/en/project_stats*',
-  '/users/*.json', '/en/users/*.json'
-].freeze
 
-# We use the default CORS 'Vary' setting 'Accept-Encoding, Origin':
+# Many resources we allow CORS requests for *might* differ depending on
+# who is asking. In these cases were use the default CORS value for
+# the HTTP Header 'Vary', which is 'Accept-Encoding, Origin':
 # * 'Accept-Encoding' is necessary because different browsers accept
 # different compression algorithms. Fastly normalizes this when we pass
 # it through Fastly, so this doesn't have a negative impact.
-# * 'Origin' is necessary for security. In some cases we vary the output
+# * 'Origin' is often necessary for security. In some cases we vary the output
 # depending on rights of the requestor. The browser would cache that.
 # If JavaScript from another origin then requested the same data, and
 # the 'Origin' was not included, the browser might return the cached
 # result (even though the origin might not have the same rights).
-# This does mean that on the CDN we have separate cache entries for
-# different origins, but that seems like a reasonable price to pay
-# to ensure that it's secure. In the long term it'd be good to remove
-# 'Origin' for /projects/NUMBER/badge(.:format), but we need to do that
-# carefully to ensure that we don't leak confidential data via CORS.
 #
-# We do not include 'Accept' in the default CORS setting.
+# This does mean different origins cannot share any caches.
+#
+# We do not include 'Accept' in the default Vary setting in CORS.
 # In theory we should include 'Accept' sometimes, because for several
 # resources the format we return varies depending on the 'Accept'
 # HTTP header (e.g., if it is application/json we'll sometimes return a
@@ -54,23 +53,55 @@ CORS_RESOURCE_PATTERNS = [
 # those cases the controllers would need to add this:
 # response.set_header('Vary', 'Accept')
 # this would let browser caches know to check the 'Accept' HTTP value.
+
+CORS_DIFFERENTIATED_RESOURCE_PATTERNS = [
+  '/projects', '/projects.json', '/projects/*',
+  '/projects/**/*', '/project_stats*',
+  '/en/projects', '/en/projects.json', '/en/projects/*',
+  '/en/projects/**/*', '/en/project_stats*',
+  '/users/*.json', '/en/users/*.json'
+].freeze
+
+# For some resources we are absolutely *certain* that their results
+# are undifferentiated, no matter who requests it or what its origin is.
+# This is, in particular, true for /projects/:id/badges(.json).
+# In this case Vary only includes Accept-Encoding, and *not* an Origin.
+# Out of an abundance of caution we only include resources if we are
+# *certain* about this. It's true for badges (SVG/JSON), and that's the
+# important case because we want to ensure that the CDN can share them
+# across all users. By omitting "Origin" for these, we significantly
+# optimize use because any Origin will share the same CDN cache entry.
 #
-# Note that we don't need to consider the HTTP 'Accept' value for the
-# /projects/:id/badge(.:format) because in that case we already *always*
-# ignore the HTTP 'Accept' heading for selecting the data format (due to
-# the way it gets routed), and that's the most important case (because that
-# CDN cache is shared globally).
+# Note: we don't need to include 'Accept' in the HTTP Header 'Vary' for
+# /projects/:id/badge(.:format) resource because we *always* ignored
+# the HTTP 'Accept' heading for selecting its data format (due to
+# the way it gets routed). This is the most important case
+# (because the CDN cache is shared globally); the fewer things we can
+# put in 'Vary' for this important (highly optimized) case, the better.
 #
-# For more information, see:
-# https://www.fastly.com/blog/best-practices-using-vary-header
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
+# Note: This cannot be exploited to be misinterpreted as something else.
+# The "*" does not match an embedded "/". Even if an attacker used "..",
+# that would just produce the useless "/badge" and "/badge.json".
+
+CORS_UNDIFFERENTIATED_RESOURCE_PATTERNS = [
+  '/projects/*/badge', '/projects/*/badge.json'
+].freeze
+CORS_UNDIFFERENTIATED_VARY = ['Accept-Encoding'].freeze
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins '*'
     # "credentials" is false (not sent) by default.
-    CORS_RESOURCE_PATTERNS.each do |resource_pattern|
-      # We could add the parameter vary: ARRAY_OF_STRINGS to modify Vary.
+
+    # 'Vary' is does NOT include Origin - same result must always occur
+    # We must add these rules first so they have higher priority.
+    CORS_UNDIFFERENTIATED_RESOURCE_PATTERNS.each do |resource_pattern|
+      resource resource_pattern, headers: :any, methods: CORS_ALLOWED_METHODS,
+               vary: CORS_UNDIFFERENTIATED_VARY
+    end
+
+    # 'Vary' is the default, includes Origin.
+    CORS_DIFFERENTIATED_RESOURCE_PATTERNS.each do |resource_pattern|
       resource resource_pattern, headers: :any, methods: CORS_ALLOWED_METHODS
     end
   end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -93,8 +93,9 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     origins '*'
     # "credentials" is false (not sent) by default.
 
-    # 'Vary' is does NOT include Origin - same result must always occur
-    # We must add these rules first so they have higher priority.
+    # 'Vary' does NOT include the Origin in undifferentiated resources.
+    # In these cases the same result must always occur.
+    # These undifferentiated rules must be first so they have higher priority.
     CORS_UNDIFFERENTIATED_RESOURCE_PATTERNS.each do |resource_pattern|
       resource resource_pattern, headers: :any, methods: CORS_ALLOWED_METHODS,
                vary: CORS_UNDIFFERENTIATED_VARY

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -25,11 +25,52 @@ CORS_RESOURCE_PATTERNS = [
   '/users/*.json', '/en/users/*.json'
 ].freeze
 
+# We use the default CORS 'Vary' setting 'Accept-Encoding, Origin':
+# * 'Accept-Encoding' is necessary because different browsers accept
+# different compression algorithms. Fastly normalizes this when we pass
+# it through Fastly, so this doesn't have a negative impact.
+# * 'Origin' is necessary for security. In some cases we vary the output
+# depending on rights of the requestor. The browser would cache that.
+# If JavaScript from another origin then requested the same data, and
+# the 'Origin' was not included, the browser might return the cached
+# result (even though the origin might not have the same rights).
+# This does mean that on the CDN we have separate cache entries for
+# different origins, but that seems like a reasonable price to pay
+# to ensure that it's secure. In the long term it'd be good to remove
+# 'Origin' for /projects/NUMBER/badge(.:format), but we need to do that
+# carefully to ensure that we don't leak confidential data via CORS.
+#
+# We do not include 'Accept' in the default CORS setting.
+# In theory we should include 'Accept' sometimes, because for several
+# resources the format we return varies depending on the 'Accept'
+# HTTP header (e.g., if it is application/json we'll sometimes return a
+# JSON format). However, we're *deprecating* using the HTTP header 'Accept'
+# to select the data format.
+#
+# We instead want people to use different URLs for different
+# output formats. This behaves *much* better with various caching systems
+# in the web ecosystem. If we wanted to seriously support using 'Accept'
+# for "ambiguous" URLs (which could return more than one format) then in
+# those cases the controllers would need to add this:
+# response.set_header('Vary', 'Accept')
+# this would let browser caches know to check the 'Accept' HTTP value.
+#
+# Note that we don't need to consider the HTTP 'Accept' value for the
+# /projects/:id/badge(.:format) because in that case we already *always*
+# ignore the HTTP 'Accept' heading for selecting the data format (due to
+# the way it gets routed), and that's the most important case (because that
+# CDN cache is shared globally).
+#
+# For more information, see:
+# https://www.fastly.com/blog/best-practices-using-vary-header
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
+
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins '*'
     # "credentials" is false (not sent) by default.
     CORS_RESOURCE_PATTERNS.each do |resource_pattern|
+      # We could add the parameter vary: ARRAY_OF_STRINGS to modify Vary.
       resource resource_pattern, headers: :any, methods: CORS_ALLOWED_METHODS
     end
   end


### PR DESCRIPTION
We need to add rate limits to counter overeager spidering tools
*without* impacting legitimate users. Some users (e.g., dashboards)
want to provides lots of data about project status.
We already use our CDN (Fastly) to cache the badge SVG.

This commit *also* caches the badge JSON data on our CDN.
That will let us support many more requests for badge JSON data.

The actual code change is tiny, but this adds many comments.
I had to do quite a bit a research about caches and CORS to
gain confidence that this wouldn't have some subtle problem in practice.

In the process, I discovered that our support for the
HTTP header 'Accept:' looks nice in theory, but in practice
creates complications. So I documented that we want people to use
different URLs with different suffixes to request different formats.
This is easy to understand and the app has always supported this.
We can remove support for 'Accept:' after it's been formally deprecated
for a while.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>