### PR TITLE
Add a new /badge_static/:value route

### DIFF
--- a/app/controllers/badge_static_controller.rb
+++ b/app/controllers/badge_static_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Copyright the Linux Foundation and the
+# CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+class BadgeStaticController < ApplicationController
+  # Show a *static* badge view, independent of any project's status
+
+  # The 'show' action is special and does NOT take a locale.
+  skip_before_action :redir_missing_locale, only: :show
+
+  # Cache this using the CDN
+  before_action :set_cache_control_headers, only: %i[show]
+
+  # rubocop:disable Metrics/MethodLength
+  def show
+    # Show the badge static display given a value.
+    # "Value" must be 0..99, passing, silver, or gold
+    # TODO: have a way to show "no such project"
+    value = params[:value]
+    begin
+      value = Integer(value, 10)
+    rescue ArgumentError # not an integer
+    end
+    if Badge.valid?(value)
+      set_surrogate_key_header "/badge_percent/#{value}"
+      send_data Badge[value],
+                type: 'image/svg+xml', disposition: 'inline'
+    else
+      # Value isn't valid, return a 404
+      render(
+        template: '/static_pages/error_404.html.erb',
+        layout: false, status: :not_found # 404
+      )
+    end
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -176,7 +176,7 @@ class ProjectsController < ApplicationController
     respond_to do |format|
       format.svg do
         set_surrogate_key_header @project.record_key + '/badge'
-        send_data Badge[value_for_badge],
+        send_data Badge[@project.badge_value],
                   type: 'image/svg+xml', disposition: 'inline'
       end
       format.json do
@@ -788,15 +788,6 @@ class ProjectsController < ApplicationController
     return url if url.nil?
 
     url.gsub(%r{\/+\z}, '')
-  end
-
-  # This needs to be modified each time you add a new badge level
-  # This method gives the percentage value to be passed to the Badge model
-  # when getting the svg badge for a project
-  def value_for_badge
-    return @project.badge_percentage_0 if @project.badge_level == 'in_progress'
-
-    @project.badge_level
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/helpers/badge_static_helper.rb
+++ b/app/helpers/badge_static_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Copyright the Linux Foundation and the
+# CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+module BadgeStaticHelper
+end

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -4,11 +4,16 @@
 # CII Best Practices badge contributors
 # SPDX-License-Identifier: MIT
 
+require 'set'
+
 class Badge
   ACCEPTABLE_PERCENTAGES = (0..99).to_a.freeze
   ACCEPTABLE_LEVELS = %w[passing silver gold].freeze
 
-  ACCEPTABLE_INPUTS = (ACCEPTABLE_PERCENTAGES + ACCEPTABLE_LEVELS).freeze
+  # Make this a set so we can quickly determine if an input is "valid?"
+  ACCEPTABLE_INPUTS = (
+    ACCEPTABLE_PERCENTAGES + ACCEPTABLE_LEVELS
+  ).to_set.freeze
 
   WHITE_TEXT_SPECS = {
     color: 'fill="#000" ', shadow: 'fill="#fefefe" fill-opacity=".7"'
@@ -49,8 +54,10 @@ class Badge
     # Class methods
     include Enumerable
 
+    # Create Badge static values as we need them.
     def [](level)
-      valid? level
+      raise ArgumentError unless valid?(level)
+
       @badges ||= {}
       @badges[level] ||= new(level)
     end
@@ -71,13 +78,14 @@ class Badge
     end
 
     def valid?(level)
-      raise ArgumentError unless level.in? ACCEPTABLE_INPUTS
+      ACCEPTABLE_INPUTS.include?(level)
     end
   end
 
   # Instance methods
   def initialize(level)
-    self.class.valid? level
+    raise ArgumentError unless self.class.valid?(level)
+
     @svg = create_svg(level)
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -301,6 +301,15 @@ class Project < ApplicationRecord
     }
   end
 
+  # Return the badge value: 0..99 (the percent) if in progress,
+  # else it returns 'passing', 'silver', or 'gold'.
+  # This needs to be modified each time you add a new badge level
+  def badge_value
+    return badge_percentage_0 if badge_level == 'in_progress'
+
+    badge_level
+  end
+
   # Flash a message to update static_analysis if the user is updating
   # for the first time since we added met_justification_required that
   # criterion

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,8 +26,8 @@ Rails.application.routes.draw do
   get '/robots.txt' => 'static_pages#robots',
       defaults: { format: 'text' }, as: :robots
 
-  # The /projects/NUMBER/badge image route needs speed and never depends
-  # on the locale. Perhaps most importantly, badge images need to have
+  # The /projects/NUMBER/badge image route needs speed and never uses a
+  # locale. Perhaps most importantly, badge images need to have
   # a single canonical name so that the CDN caches will work correctly.
   # If we use a single canonical name for a badge image, we can then
   # change or invalidate a single CDN cache to update a badge image.
@@ -36,6 +36,12 @@ Rails.application.routes.draw do
   # Therefore, instead of redirecting the badge image to a locale if
   # one is not listed, we do *NOT* support locale URLs in this case.
   get '/projects/:id/badge' => 'projects#badge',
+      defaults: { format: 'svg' }
+
+  # The /badge_static/:value route needs speed and never uses a locale.
+  # Beware: This route produces a result unconnected to a project's status.
+  # Do NOT use this route on a project's README.md page!
+  get '/badge_static/:value' => 'badge_static#show',
       defaults: { format: 'svg' }
 
   # Weird special case: for David A. Wheeler to get log issues from Google,

--- a/test/controllers/badge_static_controller_test.rb
+++ b/test/controllers/badge_static_controller_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Copyright the Linux Foundation and the
+# CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+require 'test_helper'
+
+class BadgeStaticControllerTest < ActionDispatch::IntegrationTest
+  test 'get badge static image for 0' do
+    get '/badge_static/0'
+    assert_response :success
+    assert_includes @response.body, '<svg xmlns='
+    assert_includes @response.body, 'in progress 0%'
+    assert_not_includes @response.body, 'gold'
+  end
+
+  test 'get badge static image for 99' do
+    get '/badge_static/99'
+    assert_response :success
+    assert_includes @response.body, '<svg xmlns='
+    assert_includes @response.body, 'in progress 99%'
+    assert_not_includes @response.body, 'gold'
+  end
+
+  test 'get badge static image for passing' do
+    get '/badge_static/passing'
+    assert_response :success
+    assert_includes @response.body, '<svg xmlns='
+    assert_includes @response.body, 'passing'
+    assert_not_includes @response.body, 'gold'
+  end
+
+  test 'get badge static image for silver' do
+    get '/badge_static/silver'
+    assert_response :success
+    assert_includes @response.body, '<svg xmlns='
+    assert_includes @response.body, 'silver'
+    assert_not_includes @response.body, 'gold'
+  end
+
+  test 'get badge static image for gold' do
+    get '/badge_static/gold'
+    assert_response :success
+    assert_includes @response.body, '<svg xmlns='
+    assert_includes @response.body, 'gold'
+    assert_not_includes @response.body, 'silver'
+    assert_not_includes @response.body, 'passing'
+  end
+
+  test 'cannot get badge static image for bad value' do
+    get '/badge_static/0q'
+    assert_response :not_found
+    assert_includes @response.body, 'Sorry, '
+    assert_not_includes @response.body, '0q'
+  end
+end


### PR DESCRIPTION
Add a new /badge_static/:value route; this serves *static* SVG
badge images given just "value". Value can be 0..99, passing,
silver, or gold. This will be cached by the CDN (Fastly).

This is the first step in implementing some countermeasures against
CDN race conditions. The plan is to use this to
serve /:locale/projects/:number badge entries. That way, if the
badge entry has just changed, but the CDN hasn't caught up yet, the
user who just change the project data will nevertheless
see the *current* status of the project.
We could also do this with the /projects display.

We still want projects, on their README, to use the
/projects/:number/badge URL when displaying badges, because that
will automatically adjust as the project's badge status changes.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>