### PR TITLE
Add Brakeman GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.
+
+      # Run Brakeman. See https://github.com/devmasx/brakeman-linter-action
+      - name: Brakeman linter
+        uses: devmasx/brakeman-linter-action@v1.0.0
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Create a .github/workflows/main.yml file and use it to
call Brakeman to do static analysis

Almost all of our CI pipeline runs on CircleCI.
However, GitHub actions provides a convenient way to run Brakeman,
a static analysis tool for Ruby on Rails applications.
There's no reason we can't use both, and I want to quicky
re-add Brakeman. We can move Brakeman to CircleCI later if
that's important.

This uses our credential, but note that we do NOT check in
the credential into version control (that would be bad!).
That does raise the question of whether not we trust the tool
and the GitHub action shim to call it.
GitHub themselves use Rails, so while I don't know devmasx
personally, I think GitHub's vetting is adequate for us to trust it.

Brakeman's license allows us to use it, but it is no longer OSS.
However, since we're not bringing the Brakeman code into our code,
and we don't *depend* on Brakeman to execute correctly for our code
to execute correctly, I think it's okay. I still intend to also get
Railroader integrated, but there's no reason we can't have both,
and I really want to get a static tool re-integrated. We temporarily
disabled Brakeman & I keep forgetting about this. Let's get a static
analysis tool integrated *now*, and later improve things.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>