### PR TITLE
Do not display email address in user display

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -52,7 +52,7 @@
          user_email = @user.email_if_decryptable
     %>
       | <a href="mailto:<%= CGI::escape(user_email).html_safe %>"><%=
-        t('.send_email_to') + user_email.to_s %></a>
+        t('.send_email_to') %></a>
     <% end %>
     | <%= link_to Icon[:'fa-times-circle'] + t('.delete_link_name'),
                   @user, method: :delete,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,7 +294,7 @@ en:
       local_account: Custom (local) account
       is_admin: This user is a badge application administrator.
       as_admin: 'as an admin, you may also:'
-      send_email_to: 'Send email to:'
+      send_email_to: 'Send email'
       delete_link_name: Delete user account
       confirm_delete: Are you sure you want to delete this user?
     destroy:


### PR DESCRIPTION
Thanks to COVID-19, people often share screens with others.

This commit removes the screen display of email addresses on user display,
even to those authorized to see it. Instead, it just shows "Send email"
as the text. We continue to support a mailto: hyperlink.

No functionality is lost, this commit just reduces the risk of
unintentional disclosure via screen sharing.
Those who are authorized to see the email addresses can still
hover to see it, or click on the link to send an email, or
right-click to copy the email address.

We also still display the email address if a user is *editing* their
entry. But editing is a much rarer event, and we *have* to display
the email address then (so users can confirm it and/or edit it
to the correct value).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>