### PR TITLE
Improve error log reporting

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -590,7 +590,9 @@ class ProjectsController < ApplicationController
       FastlyRails.purge_by_key cdn_json_key
       FastlyRails.purge_by_key cdn_badge_key
     rescue StandardError => e
-      Rails.logger.error "FAILED TO PURGE #{cdn_badge_key} , #{e.class}: #{e}"
+      Rails.logger.error do
+        "ERROR:: FAILED TO PURGE #{cdn_badge_key} , #{e.class}: #{e}"
+      end
     end
   end
 

--- a/app/lib/chief.rb
+++ b/app/lib/chief.rb
@@ -94,10 +94,11 @@ class Chief
   end
 
   def log_detective_failure(source, e, detective, proposal, data)
-    Rails.logger.error(
+    Rails.logger.error do
+      'ERROR:: ' \
       "In method #{source}, exception #{e} on #{detective.class.name}, " \
       "current_proposal= #{proposal}, current_data= #{data}"
-    )
+    end
   end
 
   # Invoke one "Detective", which will


### PR DESCRIPTION
Modify error logging:

* Add an "ERROR:: " term to make it easier to search for error reports.
* Switch to a block, so that logging strings are only computed
  when needed. Currently this won't matter, but it might in the future.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>