### PR TITLE
If there's only 1 page, don't show page navigation

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -49,5 +49,5 @@
 <br>
 <br>
   <%= render 'table', projects: @projects, locale: locale %>
-  <%== pagy_bootstrap_nav(@pagy) %>
+  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,6 +20,6 @@
     </li>
   <% end %>
 </ul>
-<%== pagy_bootstrap_nav(@pagy) %>
+<%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
 
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,7 +22,7 @@
     <br><br>
     <h2><%= t '.projects_owned' %></h2>
     <%= render 'projects/table', projects: @projects %>
-    <%== pagy_bootstrap_nav(@pagy) %>
+    <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
   <% end %>
 
   <% if @projects_additional_rights.present? %>


### PR DESCRIPTION
If there's only one page of results, omit the page navigation
material. It just adds clutter without purpose in that case.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>