### PR TITLE
Remove FOSSA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1/badge)](https://bestpractices.coreinfrastructure.org/projects/1)
 [![CircleCI Build Status](https://circleci.com/gh/coreinfrastructure/best-practices-badge.svg?&style=shield&circle-token=ca450ac150523030464677a1aa7f3cacfb8b3472)](https://app.circleci.com/pipelines/github/coreinfrastructure/best-practices-badge)
 [![codecov](https://codecov.io/gh/coreinfrastructure/best-practices-badge/branch/master/graph/badge.svg)](https://codecov.io/gh/coreinfrastructure/best-practices-badge)
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fcoreinfrastructure%2Fbest-practices-badge.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fcoreinfrastructure%2Fbest-practices-badge?ref=badge_shield)
 [![License](https://img.shields.io/:license-mit-blue.svg)](https://badges.mit-license.org)
 
 This project identifies best practices for


### PR DESCRIPTION
I like the idea of using two different licensing check tools, including
the one done by FOSSA (fossa.io).  However, the actual FOSSA service
is causing us problems.  It's incorrectly giving a failing report because
it can't find some licenses. By itself that'd be fine if we could
override its false results; no tool can be perfect.  However, although I
can log in to their service, I can't seem to override the false positives.

Licensing is important, but we *already* use a tool
(license_finder) to analyze our licenses to help us meet them all.
We don't *need* to use multiple tools, especially one that has caused
problems. The license_finder tool provides lots of information, and
provides a clear way to override incorrect results while documenting
every override (including why the result is incorrect).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>