### PR TITLE
Switch test env to CircleCI cimg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.1
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.1
+  browser-tools: circleci/browser-tools@1.1.1
 jobs:
   build:
     working_directory: ~/coreinfrastructure/best-practices-badge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,9 +88,9 @@ jobs:
     - save_cache:
         key: v4-dep-{{ echo `checksum "Gemfile.lock")`+`cat .ruby-version` }}
         paths:
-          # vendor/bundle removed
+          - vendor/bundle
           - ~/.bundle
-          - {{ dirname "$(bundle info --path rake)" }}
+          - ~/.rbenv
     - run:
         name: Configure database
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,10 @@ jobs:
         - v4-dep-{{ arch }}-{{ .Branch }}-
         - v4-dep-{{ arch }}-
         # - v4-dep-
+    # DEBUG: Show what we restored
+    - run: find vendor/bundle
+    - run: find .bundle
+    - run: find ~/.rbenv
     - run:
         name: Update Rubygems
         command: sudo gem update --system --silent --no-document

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,17 +56,22 @@ jobs:
           google-chrome --version
     # Prepare for artifact and test results
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # Force cleanup to make deterministic.
+    # See https://circleci.com/docs/2.0/caching
+    - run bundle clean --force
     # Dependencies
     # Restore the dependency cache
     - restore_cache:
         keys:
-        # Find a cache corresponding to this particular Gemfile.lock checksum
-        - v4-dep-{{ checksum "Gemfile.lock" }}
         # Find the most recently generated cache used
-        - v4-dep-
+        # Find a cache corresponding to this particular Gemfile.lock checksum
+        - v4-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - v4-dep-{{ arch }}-{{ .Branch }}-
+        - v4-dep-{{ arch }}-
+        # - v4-dep-
     - run:
         name: Update Rubygems
-        command: sudo gem update --system --silent
+        command: sudo gem update --system --silent --no-document
         environment:
           REALLY_GEM_UPDATE_SYSTEM: 1
     - run:
@@ -88,11 +93,11 @@ jobs:
        command: bundle exec rake update_chromedriver
     # Save dependency cache
     - save_cache:
-        key: v4-dep-{{ checksum "Gemfile.lock" }}
+        key: v4-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
         paths:
           - vendor/bundle
           - ~/.bundle
-          - ~/.rbenv
+          - ~/.rbenv/versions
     - run:
         name: Configure database
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
     # Force cleanup to make deterministic.
     # See https://circleci.com/docs/2.0/caching
-    - run bundle clean --force
+    - run: bundle clean --force
     # Dependencies
     # Restore the dependency cache
     - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
     - restore_cache:
         keys:
         # Find a cache corresponding to this particular Gemfile.lock checksum
-        - v4-dep-{{ checksum "Gemfile.lock" }}
+        - v4-dep-{{ echo `checksum "Gemfile.lock")`+`cat .ruby-version` }}
         # Find the most recently generated cache used
         - v4-dep-
     - run:
@@ -77,18 +77,20 @@ jobs:
         command: bundle --version
     - run:
         name: Install Bundle
+        # Note: --path=vendor/bundle removed, we don't need it.
         command: >
-          bundle check --path=vendor/bundle ||
-          bundle install --path=vendor/bundle --jobs=4 --retry=3
+          bundle check ||
+          bundle install --jobs=4 --retry=3
     - run:
        name: Update Chromedriver
        command: bundle exec rake update_chromedriver
     # Save dependency cache
     - save_cache:
-        key: v4-dep-{{ checksum "Gemfile.lock" }}
+        key: v4-dep-{{ echo `checksum "Gemfile.lock")`+`cat .ruby-version` }}
         paths:
-          - vendor/bundle
+          # vendor/bundle removed
           - ~/.bundle
+          - {{ dirname "$(bundle info --path rake)" }}
     - run:
         name: Configure database
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ version: 2.1
 #   browser-tools: circleci/browser-tools@1.1.1
 # When I try to later run "browser-tools/install-browser-tools" or similar,
 # CircleCI reports that the file doesn't exist (which is true).
+# It's not clear *why* the file doesn't exist. So we instead force-install
+# a browser for testing below.
 jobs:
   build:
     working_directory: ~/coreinfrastructure/best-practices-badge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # orbs:
 #   browser-tools: circleci/browser-tools@1.1.1
 # When I try to later run "browser-tools/install-browser-tools" or similar,
-# CircleCI simply reports that the file doesn't exist (which is true).
+# CircleCI reports that the file doesn't exist (which is true).
 jobs:
   build:
     working_directory: ~/coreinfrastructure/best-practices-badge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ jobs:
         POSTGRES_USER: ubuntu
         POSTGRES_DB: circle_ruby_test
     steps:
+    - run: pwd
+    - run: ls -l
     - run:
         name: Install browser tools
         command: browser-tools/install-browser-tools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 version: 2.1
+# orbs don't seem to actually do anything, so I gave up:
 # orbs:
 #   browser-tools: circleci/browser-tools@1.1.1
 jobs:
@@ -24,9 +25,32 @@ jobs:
     - checkout
     - run: pwd
     - run: ls -l
+    # This should install the orb, but it doesn't work.
     # - run:
     #     name: Install browser tools
     #     command: browser-tools/install-browser-tools
+    #
+    #
+    # https://github.com/CircleCI-Public/browser-tools-orb/blob/master/src/commands/install-chrome.yml#L131
+    - run:
+        name: Install Chrome
+        command: |
+          SUDO=''
+          CHROME_VERSION='latest'
+          if [[ "$CHROME_VERSION" == "latest" ]]; then
+            CHROME_URL="https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+          else
+            CHROME_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb"
+          fi
+          curl --silent --show-error --location --fail --retry 3 \
+            --output google-chrome.deb $CHROME_URL
+          $SUDO apt-get update
+          # The pipe will install any dependencies missing
+          $SUDO dpkg -i google-chrome.deb || $SUDO apt-get -fy install
+          rm -rf google-chrome.deb
+          $SUDO sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome"
+          which google-chrome
+          google-chrome --version
     # Prepare for artifact and test results
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
     # Dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,9 @@ jobs:
         - v4-dep-{{ arch }}-
         # - v4-dep-
     # DEBUG: Show what we restored
-    - run: find ~/.rbenv
-    - run: find .bundle
+    - run: find .bundle || true
+    - run: find ~/.rbenv || true
+    - run: find vendor/bundle || true
     - run:
         name: Update Rubygems
         command: sudo gem update --system --silent --no-document
@@ -96,6 +97,10 @@ jobs:
     - run:
        name: Update Chromedriver
        command: bundle exec rake update_chromedriver
+    # DEBUG
+    - run: find .bundle || true
+    - run: find ~/.rbenv || true
+    - run: find vendor/bundle || true
     # Save dependency cache
     - save_cache:
         key: v4-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
     - restore_cache:
         keys:
         # Find a cache corresponding to this particular Gemfile.lock checksum
-        - v4-dep-{{ echo `checksum "Gemfile.lock")`+`cat .ruby-version` }}
+        - v4-dep-{{ echo `checksum "Gemfile.lock"`+`cat .ruby-version` }}
         # Find the most recently generated cache used
         - v4-dep-
     - run:
@@ -86,7 +86,7 @@ jobs:
        command: bundle exec rake update_chromedriver
     # Save dependency cache
     - save_cache:
-        key: v4-dep-{{ echo `checksum "Gemfile.lock")`+`cat .ruby-version` }}
+        key: v4-dep-{{ echo `checksum "Gemfile.lock"`+`cat .ruby-version` }}
         paths:
           - vendor/bundle
           - ~/.bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 version: 2.1
-# orbs don't seem to actually do anything, so I gave up:
+# This CircleCI orb doesn't seem to work, so I gave up:
 # orbs:
 #   browser-tools: circleci/browser-tools@1.1.1
 jobs:
@@ -30,7 +30,8 @@ jobs:
     #     name: Install browser tools
     #     command: browser-tools/install-browser-tools
     #
-    #
+    # We instead manually force installation of Chrome using a code
+    # snippet from the browser tools. See:
     # https://github.com/CircleCI-Public/browser-tools-orb/blob/master/src/commands/install-chrome.yml#L131
     - run:
         name: Install Chrome

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
     - run:
        name: Update Chromedriver
        command: bundle exec rake update_chromedriver
-    # DEBUG
+    # DEBUG - check
     - run: find ~/.rubygems || true
     - run: find ~/.bundle || true
     - run: find ~/.rbenv || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2.1
 # This CircleCI orb doesn't seem to work, so I gave up:
 # orbs:
 #   browser-tools: circleci/browser-tools@1.1.1
+# When I try to later run "browser-tools/install-browser-tools" or similar,
+# CircleCI simply reports that the file doesn't exist (which is true).
 jobs:
   build:
     working_directory: ~/coreinfrastructure/best-practices-badge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
     - run:
         name: Install Chrome
         command: |
-          SUDO=''
+          SUDO='sudo'
           CHROME_VERSION='latest'
           if [[ "$CHROME_VERSION" == "latest" ]]; then
             CHROME_URL="https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
-orbs:
-  browser-tools: circleci/browser-tools@1.1.1
+# orbs:
+#   browser-tools: circleci/browser-tools@1.1.1
 jobs:
   build:
     working_directory: ~/coreinfrastructure/best-practices-badge
@@ -24,9 +24,9 @@ jobs:
     - checkout
     - run: pwd
     - run: ls -l
-    - run:
-        name: Install browser tools
-        command: browser-tools/install-browser-tools
+    # - run:
+    #     name: Install browser tools
+    #     command: browser-tools/install-browser-tools
     # Prepare for artifact and test results
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
     # Dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
     # Force cleanup to make deterministic.
     # See https://circleci.com/docs/2.0/caching
-    - run: bundle clean --force
+    # - run: bundle clean --force
     # Dependencies
     # Restore the dependency cache
     - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,16 +67,16 @@ jobs:
         keys:
         # Find the most recently generated cache used
         # Find a cache corresponding to this particular Gemfile.lock checksum
-        - v6-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-        - v6-dep-{{ arch }}-{{ .Branch }}-
-        - v6-dep-{{ arch }}-
+        - v7-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - v7-dep-{{ arch }}-{{ .Branch }}-
+        - v7-dep-{{ arch }}-
         # This was suggested, but it seems like a bad idea to me:
-        # - v6-dep-
+        # - v7-dep-
     # DEBUG: Show what we restored
-    - run: find .bundle || true
+    - run: find ~/.rubygems || true
+    - run: find ~/.bundle || true
     - run: find ~/.rbenv || true
     - run: find vendor/bundle || true
-    - run: find .rubygems || true
     - run:
         name: Update Rubygems
         command: sudo gem update --system --silent --no-document
@@ -100,19 +100,21 @@ jobs:
        name: Update Chromedriver
        command: bundle exec rake update_chromedriver
     # DEBUG
-    - run: find .bundle || true
+    - run: find ~/.rubygems || true
+    - run: find ~/.bundle || true
     - run: find ~/.rbenv || true
     - run: find vendor/bundle || true
-    - run: find .rubygems || true
     - run: find ~ -name "*rack-timeout*" || true
     # Save dependency cache
     - save_cache:
-        key: v6-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        key: v7-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
         paths:
-          - vendor/bundle
-          - ~/.bundle
-          - ~/.rbenv/versions
           - ~/.rubygems
+          - ~/.bundle
+          # Not used in current config; we include these just in case they
+          # get used later:
+          - ~/.rbenv/versions
+          - vendor/bundle
     - run:
         name: Configure database
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-    - image: drdavidawheeler/cii-bestpractices:2.7.2-buster
+    - image: drdavidawheeler/cii-bestpractices:2.7.2-browsers
       environment:
         PG_HOST: localhost
         PG_USER: ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ jobs:
         - v5-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
         - v5-dep-{{ arch }}-{{ .Branch }}-
         - v5-dep-{{ arch }}-
+        # This was suggested, but it seems like a bad idea to me:
         # - v5-dep-
     # DEBUG: Show what we restored
     - run: find .bundle || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,8 @@ jobs:
         - v4-dep-{{ arch }}-
         # - v4-dep-
     # DEBUG: Show what we restored
-    - run: find vendor/bundle
-    - run: find .bundle
     - run: find ~/.rbenv
+    - run: find .bundle
     - run:
         name: Update Rubygems
         command: sudo gem update --system --silent --no-document

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2
+orbs:
+  browser-tools: circleci/browser-tools@1.1
 jobs:
   build:
     working_directory: ~/coreinfrastructure/best-practices-badge
@@ -19,6 +21,9 @@ jobs:
         POSTGRES_USER: ubuntu
         POSTGRES_DB: circle_ruby_test
     steps:
+    - run:
+        name: Install browser tools
+        command: browser-tools/install-browser-tools
     - checkout
     # Prepare for artifact and test results
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
     - restore_cache:
         keys:
         # Find a cache corresponding to this particular Gemfile.lock checksum
-        - v4-dep-{{ echo `checksum "Gemfile.lock"`+`cat .ruby-version` }}
+        - v4-dep-{{ checksum "Gemfile.lock" }}
         # Find the most recently generated cache used
         - v4-dep-
     - run:
@@ -86,7 +86,7 @@ jobs:
        command: bundle exec rake update_chromedriver
     # Save dependency cache
     - save_cache:
-        key: v4-dep-{{ echo `checksum "Gemfile.lock"`+`cat .ruby-version` }}
+        key: v4-dep-{{ checksum "Gemfile.lock" }}
         paths:
           - vendor/bundle
           - ~/.bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,10 +67,10 @@ jobs:
         keys:
         # Find the most recently generated cache used
         # Find a cache corresponding to this particular Gemfile.lock checksum
-        - v4-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-        - v4-dep-{{ arch }}-{{ .Branch }}-
-        - v4-dep-{{ arch }}-
-        # - v4-dep-
+        - v5-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - v5-dep-{{ arch }}-{{ .Branch }}-
+        - v5-dep-{{ arch }}-
+        # - v5-dep-
     # DEBUG: Show what we restored
     - run: find .bundle || true
     - run: find ~/.rbenv || true
@@ -103,7 +103,7 @@ jobs:
     - run: find vendor/bundle || true
     # Save dependency cache
     - save_cache:
-        key: v4-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        key: v5-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
         paths:
           - vendor/bundle
           - ~/.bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
     - run: find .bundle || true
     - run: find ~/.rbenv || true
     - run: find vendor/bundle || true
+    - run: find ~ -name "*rack-timeout*" || true
     # Save dependency cache
     - save_cache:
         key: v5-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,12 @@ jobs:
         POSTGRES_USER: ubuntu
         POSTGRES_DB: circle_ruby_test
     steps:
+    - checkout
     - run: pwd
     - run: ls -l
     - run:
         name: Install browser tools
         command: browser-tools/install-browser-tools
-    - checkout
     # Prepare for artifact and test results
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
     # Dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,15 +67,16 @@ jobs:
         keys:
         # Find the most recently generated cache used
         # Find a cache corresponding to this particular Gemfile.lock checksum
-        - v5-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-        - v5-dep-{{ arch }}-{{ .Branch }}-
-        - v5-dep-{{ arch }}-
+        - v6-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - v6-dep-{{ arch }}-{{ .Branch }}-
+        - v6-dep-{{ arch }}-
         # This was suggested, but it seems like a bad idea to me:
-        # - v5-dep-
+        # - v6-dep-
     # DEBUG: Show what we restored
     - run: find .bundle || true
     - run: find ~/.rbenv || true
     - run: find vendor/bundle || true
+    - run: find .rubygems || true
     - run:
         name: Update Rubygems
         command: sudo gem update --system --silent --no-document
@@ -102,14 +103,16 @@ jobs:
     - run: find .bundle || true
     - run: find ~/.rbenv || true
     - run: find vendor/bundle || true
+    - run: find .rubygems || true
     - run: find ~ -name "*rack-timeout*" || true
     # Save dependency cache
     - save_cache:
-        key: v5-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        key: v6-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
         paths:
           - vendor/bundle
           - ~/.bundle
           - ~/.rbenv/versions
+          - ~/.rubygems
     - run:
         name: Configure database
         command: |

--- a/Gemfile
+++ b/Gemfile
@@ -48,14 +48,17 @@ gem 'omniauth-github', '1.4.0' # Authentication to GitHub (get project info)
 # Counter CVE-2015-9284 in omniauth.  Unfortunately, at the time of this
 # writing the omniauth folks STILL have not fixed it (!). There is a shim
 # by a third party that *does* fix it. I don't know the person who created
-# this shim, but I reviewed the code and it looks okay.  I could do this:
-# gem 'omniauth-rails_csrf_protection', '0.1.2' # Counter CVE-2015-9284
-# But to provide a stronger guarantee that what I reviewed is what will
-# be loaded, I'm specifying a specific hash reference.  That's no
-# guarantee, but it does make attacks harder to perform.
-gem 'omniauth-rails_csrf_protection',
-    git: 'https://github.com/cookpad/omniauth-rails_csrf_protection.git',
-    ref: 'b33ff2e57f7c0530da76da6b4b358218f1e7f230'
+# this shim, but I reviewed the code and it looks okay.
+# At one time I did this:
+# gem 'omniauth-rails_csrf_protection',
+#    git: 'https://github.com/cookpad/omniauth-rails_csrf_protection.git',
+#    ref: 'b33ff2e57f7c0530da76da6b4b358218f1e7f230'
+# to provide a stronger guarantee that what I reviewed is what will
+# be loaded, by specifying a specific hash reference.
+# However, using a git reference busts CI pipeline caching, slowing down
+# all testing, and over time we've become more comfortable that this is
+# the "standard way to resolve this issue".
+gem 'omniauth-rails_csrf_protection', '0.1.2' # Counter CVE-2015-9284
 gem 'pagy', '3.10.0' # Paginate some views
 gem 'paleta', '0.3.0' # Color manipulation, used for badges
 gem 'paper_trail', '10.3.1' # Record previous versions of project data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/cookpad/omniauth-rails_csrf_protection.git
-  revision: b33ff2e57f7c0530da76da6b4b358218f1e7f230
-  ref: b33ff2e57f7c0530da76da6b4b358218f1e7f230
-  specs:
-    omniauth-rails_csrf_protection (0.1.2)
-      actionpack (>= 4.2)
-      omniauth (>= 1.3.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -251,6 +242,9 @@ GEM
     omniauth-oauth2 (1.7.0)
       oauth2 (~> 1.4)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     pagy (3.10.0)
     paleta (0.3.0)
     paper_trail (10.3.1)
@@ -503,7 +497,7 @@ DEPENDENCIES
   minitest-retry (= 0.2.1)
   octokit (= 4.18.0)
   omniauth-github (= 1.4.0)
-  omniauth-rails_csrf_protection!
+  omniauth-rails_csrf_protection (= 0.1.2)
   pagy (= 3.10.0)
   paleta (= 0.3.0)
   paper_trail (= 10.3.1)

--- a/dockerfiles/2.7.2-browsers/Dockerfile
+++ b/dockerfiles/2.7.2-browsers/Dockerfile
@@ -1,0 +1,10 @@
+# "cimg" are newer CircleCI images, built on Ubuntu, supposed to be
+# faster and more deterministic.
+# See https://hub.docker.com/r/cimg/ruby
+
+FROM cimg/ruby:2.7.2-browsers
+
+# skip installing gem documentation
+RUN sudo apt-get update && sudo apt-get install -y cmake
+
+USER circleci


### PR DESCRIPTION
CircleCI is now promoting the use of a new set of starting
images in the "cimg" space, designating the ones we used
as "legacy".

This commit switches to using this newer "cimg" format
as our starting image, then adds what we need.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>