### PR TITLE
Switch test env to CircleCI cimg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,11 @@
-version: 2
+version: 2.1
+# This CircleCI orb doesn't seem to work, so I gave up:
+# orbs:
+#   browser-tools: circleci/browser-tools@1.1.1
+# When I try to later run "browser-tools/install-browser-tools" or similar,
+# CircleCI reports that the file doesn't exist (which is true).
+# It's not clear *why* the file doesn't exist. So we instead force-install
+# a browser for testing below.
 jobs:
   build:
     working_directory: ~/coreinfrastructure/best-practices-badge
@@ -8,7 +15,7 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-    - image: drdavidawheeler/cii-bestpractices:2.7.2-buster
+    - image: drdavidawheeler/cii-bestpractices:2.7.2-browsers
       environment:
         PG_HOST: localhost
         PG_USER: ubuntu
@@ -20,19 +27,56 @@ jobs:
         POSTGRES_DB: circle_ruby_test
     steps:
     - checkout
+    - run: pwd
+    - run: ls -l
+    # This should install the orb, but it doesn't work.
+    # - run:
+    #     name: Install browser tools
+    #     command: browser-tools/install-browser-tools
+    #
+    # We instead manually force installation of Chrome using a code
+    # snippet from the browser tools. See:
+    # https://github.com/CircleCI-Public/browser-tools-orb/blob/master/src/commands/install-chrome.yml#L131
+    - run:
+        name: Install Chrome
+        command: |
+          SUDO='sudo'
+          CHROME_VERSION='latest'
+          if [[ "$CHROME_VERSION" == "latest" ]]; then
+            CHROME_URL="https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+          else
+            CHROME_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb"
+          fi
+          curl --silent --show-error --location --fail --retry 3 \
+            --output google-chrome.deb $CHROME_URL
+          $SUDO apt-get update
+          # The pipe will install any dependencies missing
+          $SUDO dpkg -i google-chrome.deb || $SUDO apt-get -fy install
+          rm -rf google-chrome.deb
+          $SUDO sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome"
+          which google-chrome
+          google-chrome --version
     # Prepare for artifact and test results
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # Force cleanup to make deterministic.
+    # See https://circleci.com/docs/2.0/caching
+    # - run: bundle clean --force
     # Dependencies
     # Restore the dependency cache
     - restore_cache:
         keys:
-        # Find a cache corresponding to this particular Gemfile.lock checksum
-        - v4-dep-{{ checksum "Gemfile.lock" }}
         # Find the most recently generated cache used
-        - v4-dep-
+        # Find a cache corresponding to this particular Gemfile.lock checksum
+        - v7-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - v7-dep-{{ arch }}-{{ .Branch }}-
+        - v7-dep-{{ arch }}-
+        # This was suggested, but it seems like a bad idea to me:
+        # - v7-dep-
+    # This would show what we restored
+    # - run: find ~/.rubygems || true
     - run:
         name: Update Rubygems
-        command: sudo gem update --system --silent
+        command: sudo gem update --system --silent --no-document
         environment:
           REALLY_GEM_UPDATE_SYSTEM: 1
     - run:
@@ -45,18 +89,29 @@ jobs:
         command: bundle --version
     - run:
         name: Install Bundle
+        # Note: --path=vendor/bundle removed, we don't need it.
         command: >
-          bundle check --path=vendor/bundle ||
-          bundle install --path=vendor/bundle --jobs=4 --retry=3
+          bundle check ||
+          bundle install --jobs=4 --retry=3
     - run:
        name: Update Chromedriver
        command: bundle exec rake update_chromedriver
+    # Here's how we could show more:
+    # - run: find ~/.rubygems || true
+    # - run: find ~/.bundle || true
+    # - run: find ~/.rbenv || true
+    # - run: find vendor/bundle || true
+    # - run: find ~ -name "*rack-timeout*" || true
     # Save dependency cache
     - save_cache:
-        key: v4-dep-{{ checksum "Gemfile.lock" }}
+        key: v7-dep-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
         paths:
-          - vendor/bundle
+          - ~/.rubygems
           - ~/.bundle
+          # Not used in current config; we include these just in case they
+          # get used later:
+          - ~/.rbenv/versions
+          - vendor/bundle
     - run:
         name: Configure database
         command: |

--- a/Gemfile
+++ b/Gemfile
@@ -48,14 +48,17 @@ gem 'omniauth-github', '1.4.0' # Authentication to GitHub (get project info)
 # Counter CVE-2015-9284 in omniauth.  Unfortunately, at the time of this
 # writing the omniauth folks STILL have not fixed it (!). There is a shim
 # by a third party that *does* fix it. I don't know the person who created
-# this shim, but I reviewed the code and it looks okay.  I could do this:
-# gem 'omniauth-rails_csrf_protection', '0.1.2' # Counter CVE-2015-9284
-# But to provide a stronger guarantee that what I reviewed is what will
-# be loaded, I'm specifying a specific hash reference.  That's no
-# guarantee, but it does make attacks harder to perform.
-gem 'omniauth-rails_csrf_protection',
-    git: 'https://github.com/cookpad/omniauth-rails_csrf_protection.git',
-    ref: 'b33ff2e57f7c0530da76da6b4b358218f1e7f230'
+# this shim, but I reviewed the code and it looks okay.
+# At one time I did this:
+# gem 'omniauth-rails_csrf_protection',
+#    git: 'https://github.com/cookpad/omniauth-rails_csrf_protection.git',
+#    ref: 'b33ff2e57f7c0530da76da6b4b358218f1e7f230'
+# to provide a stronger guarantee that what I reviewed is what will
+# be loaded, by specifying a specific hash reference.
+# However, using a git reference busts CI pipeline caching, slowing down
+# all testing, and over time we've become more comfortable that this is
+# the "standard way to resolve this issue".
+gem 'omniauth-rails_csrf_protection', '0.1.2' # Counter CVE-2015-9284
 gem 'pagy', '3.10.0' # Paginate some views
 gem 'paleta', '0.3.0' # Color manipulation, used for badges
 gem 'paper_trail', '10.3.1' # Record previous versions of project data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/cookpad/omniauth-rails_csrf_protection.git
-  revision: b33ff2e57f7c0530da76da6b4b358218f1e7f230
-  ref: b33ff2e57f7c0530da76da6b4b358218f1e7f230
-  specs:
-    omniauth-rails_csrf_protection (0.1.2)
-      actionpack (>= 4.2)
-      omniauth (>= 1.3.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -251,6 +242,9 @@ GEM
     omniauth-oauth2 (1.7.0)
       oauth2 (~> 1.4)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     pagy (3.10.0)
     paleta (0.3.0)
     paper_trail (10.3.1)
@@ -503,7 +497,7 @@ DEPENDENCIES
   minitest-retry (= 0.2.1)
   octokit (= 4.18.0)
   omniauth-github (= 1.4.0)
-  omniauth-rails_csrf_protection!
+  omniauth-rails_csrf_protection (= 0.1.2)
   pagy (= 3.10.0)
   paleta (= 0.3.0)
   paper_trail (= 10.3.1)

--- a/dockerfiles/2.7.2-browsers/Dockerfile
+++ b/dockerfiles/2.7.2-browsers/Dockerfile
@@ -1,0 +1,10 @@
+# "cimg" are newer CircleCI images, built on Ubuntu, supposed to be
+# faster and more deterministic.
+# See https://hub.docker.com/r/cimg/ruby
+
+FROM cimg/ruby:2.7.2-browsers
+
+# skip installing gem documentation
+RUN sudo apt-get update && sudo apt-get install -y cmake
+
+USER circleci


### PR DESCRIPTION
CircleCI is now promoting the use of a new set of starting
images in the "cimg" space, designating the ones we used
as "legacy". The newer "cimg" images are built on Ubuntu,
and are supposed to be faster and more deterministic.
See <https://hub.docker.com/r/cimg/ruby>.

This commit:
- creates a new Dockerfile for a special image
  that builds on this newer "cimg" format
  `dockerfiles/2.7.2-browsers/Dockerfile` that
  adds what we need (e.g., cmake).
- Switches to using this newer "cimg" format on CircleCI
  for testing and building.

This was *incredibly* painful to achieve, and took *much*
longer than it should have taken.

CircleCI strongerly recommends using the browser-tools orb.
However, I never got that to work in spite of endless tweaking.
I ended up creating a special task to install a browser (Chrome).

The result was *very* slow because the cache wasn't caching anything.
This setup ends up putting Ruby gems in ~/.rubygems, which is
not what I would have expected. Once the cache was reconfigured,
it works as expected. As always, changes to Gemfile.lock require
rebuilding gems (and thus takes extra time), but many changes don't
change Gemfile.lock, so caching is very much worth doing.

I had to change how gem omniauth-rails_csrf_protection was installed,
so it could be properly cached, but that is worth it.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>