### PR TITLE
Simplify translation of locale list

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -53,7 +53,13 @@
                 <li><a href="<%=
                   # TODO: This doesn't include the anchor.
                   force_locale_url(request.original_url, loc)
-                  %>"><%= t("locale_name.#{loc}") %></a>
+                  %>"><%= t("locale_name.#{loc}") %>
+                  <%=
+                    if loc != I18n.locale
+                      '// ' + t("locale_name.#{loc}", locale: loc)
+                    end
+                  %>
+                  (<%= loc %>)</a>
                 </li>
               <% end %>
             </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,14 +11,14 @@ en:
   feed_title: CII Best Practices BadgeApp Updated Projects
   project_name_unknown: "(Name unknown)"
   locale_name:
-    en: English (en)
-    es: Spanish / Español (es)
-    de: German / Deutsch (de)
-    fr: French / Français (fr)
-    ja: Japanese / 日本語 (ja)
-    ru: Russian / Русский (ru)
-    sw: Swahili / Kiswahili (sw)
-    zh-CN: Chinese (Simplified) / 简体中文 (zh-CN)
+    en: English
+    es: Spanish
+    de: German
+    fr: French
+    ja: Japanese
+    ru: Russian
+    sw: Swahili
+    zh-CN: Chinese (Simplified)
   layouts:
     cii_best_practices: CII Best Practices
     toggle_navigation: Toggle collapsible navigation

--- a/config/locales/translation.de.yml
+++ b/config/locales/translation.de.yml
@@ -18,13 +18,13 @@ de:
   feed_title: CII Best Practices BadgeApp Aktualisierte Projekte
   project_name_unknown: "(Name unbekannt)"
   locale_name:
-    en: Englisch / English (en)
-    de: Deutsch (de)
-    fr: Französisch / Français (fr)
-    ja: Japanisch / 日本語 (ja)
-    zh-CN: Chinesisch (vereinfacht) / 简体 中 文 (zh-CN)
-    ru: Russisch / Русский (ru)
-    es: Spanisch / Español (es)
+    en: Englisch
+    de: Deutsch
+    fr: Französisch
+    ja: Japanisch
+    zh-CN: Chinesisch (vereinfacht)
+    ru: Russisch
+    es: Spanisch
     sw:
   layouts:
     cii_best_practices: CII Best Practices

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -18,13 +18,13 @@ es:
   feed_title:
   project_name_unknown:
   locale_name:
-    en: Inglés / English (en)
-    de: Alemán / Deutsch (de)
-    fr: Francés / Français (fr)
-    ja: Japonés / 日本語 (ja)
-    ru: Ruso / Русский (ru)
-    zh-CN: Chino (Simplificado) / 简体中文 (zh-CN)
-    es: Español (es)
+    en: Inglés
+    de: Alemán
+    fr: Francés
+    ja: Japonés
+    ru: Ruso
+    zh-CN: Chino (Simplificado)
+    es: Español
     sw:
   layouts:
     cii_best_practices: CII Best Practices

--- a/config/locales/translation.fr.yml
+++ b/config/locales/translation.fr.yml
@@ -910,14 +910,14 @@ fr:
       obtenir le badge.\n\nMerci pour votre attention."
   project_name_unknown: "(Nom inconnu)"
   locale_name:
-    en: Anglais / English (en)
-    fr: Français (fr)
-    zh-CN: Chinois (simplifié) / 简体 中文 (zh-CN)
-    de: Allemand / Deutsch (de)
-    ja: Japonais / 日本語 (ja)
-    ru: Russe / Русский (ru)
-    es: Espagnol / Español (es)
-    sw: Swahili / Kiswahili (sw)
+    en: Anglais
+    fr: Français
+    zh-CN: Chinois (simplifié)
+    de: Allemand
+    ja: Japonais
+    ru: Russe
+    es: Espagnol
+    sw: Swahili
   criteria:
     '0':
       description_good:

--- a/config/locales/translation.ja.yml
+++ b/config/locales/translation.ja.yml
@@ -18,13 +18,13 @@ ja:
   feed_title: CIIベスト プラクティス バッジ更新プロジェクト
   project_name_unknown: "（名称不明）"
   locale_name:
-    en: 英語 / English (en)
-    de: ドイツ語 / Deutsch (de)
-    fr: フランス語 / Français (fr)
-    ja: 日本語 (ja)
-    zh-CN: 中国語 (簡体字) / 简体中文 (zh-CN)
-    ru: ロシア語 / Русский (ru)
-    es: スペイン語/スペイン語
+    en: 英語
+    de: ドイツ語
+    fr: フランス語
+    ja: 日本語
+    zh-CN: 中国語 (簡体字)
+    ru: ロシア語
+    es: スペイン語
     sw:
   layouts:
     cii_best_practices: CII ベスト プラクティス

--- a/config/locales/translation.ru.yml
+++ b/config/locales/translation.ru.yml
@@ -18,13 +18,13 @@ ru:
   feed_title: Значок "Передовая практика CII" - обновленные проекты
   project_name_unknown: "(Название неизвестно)"
   locale_name:
-    en: Английский / English (en)
-    de: Немецкий / Deutsch (de)
-    fr: Французский / Français (fr)
-    ja: Японский / 日本語 (ja)
-    ru: Русский (ru)
-    zh-CN: Китайский (упрощенный) / 简体 中文 (zh-CN)
-    es: Испанский / Español (es)
+    en: Английский
+    de: Немецкий
+    fr: Французский
+    ja: Японский
+    ru: Русский
+    zh-CN: "Китайский (упрощенный)"
+    es: Испанский
     sw:
   layouts:
     cii_best_practices: Передовая практика CII

--- a/config/locales/translation.sw.yml
+++ b/config/locales/translation.sw.yml
@@ -18,14 +18,14 @@ sw:
   feed_title:
   project_name_unknown:
   locale_name:
-    en: Kiingereza (en)
-    es: Kihispania / Español (es)
-    de: Kijerumani / Deutsch (de)
-    fr: Kifaransa / Français (fr)
-    ja: Kijapani / 日本語 (ja)
-    ru: Kirusi / Русский (ru)
-    sw: Swahili / Kiswahili (sw)
-    zh-CN: Kichina (Kilichorahisishwa) / 简体中文 (zh-CN)
+    en: Kiingereza
+    es: Kihispania
+    de: Kijerumani
+    fr: Kifaransa
+    ja: Kijapani
+    ru: Kirusi
+    sw: Kiswahili
+    zh-CN: Kichina (Kilichorahisishwa)
   layouts:
     cii_best_practices: Mazoea Bora ya CII
     toggle_navigation:

--- a/config/locales/translation.zh-CN.yml
+++ b/config/locales/translation.zh-CN.yml
@@ -577,14 +577,14 @@ zh-CN:
       感谢您的时间。
   project_name_unknown: "(未知名称)"
   locale_name:
-    en: 英文 / English (en）
-    fr: 法语 / Français (fr)
-    zh-CN: 中文（简体）/简体中文（zh-CN）
-    de: 德文 / Deutsch (de)
-    ja: 日语 / 日本語 (ja)
-    ru: 俄语 / Русский (ru)
-    es: 西班牙语/西班牙文 / Español (es)
-    sw: 斯瓦希里语/斯瓦希里语（瑞士）
+    en: 英文
+    fr: 法语
+    zh-CN: 中文（简体）
+    de: 德文
+    ja: 日语
+    ru: 俄语
+    es: 西班牙语/西班牙文
+    sw: 斯瓦希里语
   criteria:
     '0':
       description_good:


### PR DESCRIPTION
Modify how the locale list at the top is generated
to simplify its translation.

Originally we had exactly one string per line, reducing the
string-handling necessary to generate the locale list
(string handling always has some small performance overhead).
However, this approach required every translator to insert text from
other locales, and that is very error-prone.

This changes the locale list so that translators only need to
translate locales (language names) for their own locale.
The system will automatically extract the locale name in those
other locales and the system locale name. This is much
less error-prone. The locale list is cached, so avoiding the
extra string handling doesn't really save any performance either.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>