### PR TITLE
Mention US export control law; fixes #1513

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -743,6 +743,16 @@ en:
       some_not_crypto_html: >-
         Note that some software does not need to use cryptographic
         mechanisms.
+        If your project produces software that (1) includes,
+        activates, or enables encryption functionality, and
+        (2) might be released from the United States (US) to outside
+        the US or to a non-US-citizen, you may be legally required
+        to take a few extra steps.
+        Typically this just involves sending an email.
+        For more information, see the encryption section of
+        <a href="https://www.linuxfoundation.org/wp-content/uploads/2020/07/UnderstandingOpenSourceTechnologyandUSExportControls_Whitepaper_070220.pdf"
+        ><i>Understanding Open Source Technology &amp;
+        US Export Controls</i></a>.
       dont_use_crypto: >-
         Press here if the software produced by the project does
         not use cryptographic mechanisms

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -749,8 +749,8 @@ en:
         the US or to a non-US-citizen, you may be legally required
         to take a few extra steps.
         Typically this just involves sending an email.
-        For more information, see the encryption section of
-        <a href="https://www.linuxfoundation.org/wp-content/uploads/2020/07/UnderstandingOpenSourceTechnologyandUSExportControls_Whitepaper_070220.pdf"
+        For more information, see the encryption section of <a
+        href="https://www.linuxfoundation.org/resources/publications/understanding-us-export-controls-with-os-projects/"
         ><i>Understanding Open Source Technology &amp;
         US Export Controls</i></a>.
       dont_use_crypto: >-


### PR DESCRIPTION
US export control law has some quirky requirements about
encryption that are easy to comply with, but have potentially
harsh penalties for non-compliance. Mention them in the crypto
section, since many developers won't know about this legal requirement,
as a way to help out the developers.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>