### PR TITLE
Remove gem fastly-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,10 @@ gem 'bootstrap-social-rails', '4.12.0'
 gem 'bootstrap_form', '2.7.0'
 gem 'bundler' # Ensure it's available
 gem 'chartkick', '3.4.0' # Chart project_stats
-gem 'fastly-rails', '0.8.0'
+# We no longger use "fastly-rails"; it doesn't support Rails 6+.
+# They recommend switching to the "fastly" gem (aka "fastly-ruby"),
+# but fastly-ruby is not designed to support multi-threading, so we
+# call the Fastly API directly instead.
 gem 'font-awesome-rails', '4.7.0.5'
 gem 'http_accept_language', '2.1.1' # Determine user's preferred locale
 gem 'httparty', '0.18.1' # HTTP convenience. rake fix_use_gravatar

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -587,14 +587,7 @@ class ProjectsController < ApplicationController
   # Purge data about this project from the CDN (if the CDN has any)
   def purge_cdn_project
     cdn_badge_key = @project.record_key
-    # If we can't authenticate to the CDN, complain but don't crash.
-    begin
-      FastlyRails.purge_by_key cdn_badge_key
-    rescue StandardError => e
-      Rails.logger.error do
-        "ERROR:: FAILED TO PURGE #{cdn_badge_key} , #{e.class}: #{e}"
-      end
-    end
+    FastlyRails.purge_by_key cdn_badge_key
   end
 
   # Maximum number of GitHub repos to retrieve when retrieving a list of

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -187,7 +187,7 @@ class UsersController < ApplicationController
     # The goal is to make it harder for adversaries to get leaked data.
     # We do this as HTTP headers, so it applies to anything (HTML, JSON, etc.)
     response.set_header('X-Robots-Tag', 'noindex')
-    response.set_header('Cache-Control', 'no-cache, no-store, must-revalidate')
+    response.set_header('Cache-Control', 'private, no-store, must-revalidate')
   end
 
   def user_params

--- a/app/lib/fastly_rails.rb
+++ b/app/lib/fastly_rails.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Copyright CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+# Enable Fastly support from Rails.
+# We once used the fastly-rails gem, but that doesn't support Rails 6.
+# The fastly (fastly-ruby) gem doesn't support threads (!).
+# So we'll just call the purge API directly, as recommended in:
+# https://github.com/fastly/fastly-ruby
+# See also:
+# https://developer.fastly.com/reference/api/purging/
+# https://developer.fastly.com/reference/api/auth/
+
+# We could require 'net/http', but that needs more code for HTTPS.
+
+class FastlyRails
+  include HTTParty
+
+  # Base of API. To create a "dead port" after .com append ":444" or some
+  # other unused port
+  # FASTLY_BASE = 'https://api.fastly.com'
+  FASTLY_BASE = 'https://api.fastly.com'
+  FASTLY_API_KEY = ENV['FASTLY_API_KEY'].to_s
+  FASTLY_OPTIONS = {
+    headers: { 'Fastly-Key': FASTLY_API_KEY },
+    timeout: 10 # seconds
+  }.freeze
+  FASTLY_SERVICE_ID = ENV['FASTLY_SERVICE_ID'].to_s
+
+  # Purge the CDN resources associated with this key
+  # Use "force" to force a post even when we have no key or service id
+  # (this is used for testing).
+  # We'll squelch exceptions, we'd rather keep going than fail if the
+  # cache fails.
+  # rubocop:disable Metrics/MethodLength
+  def self.purge_by_key(key, force = false, base = FASTLY_BASE)
+    return if !force && (FASTLY_API_KEY.blank? || FASTLY_SERVICE_ID.blank?)
+
+    begin
+      # We'll return the result, but normally that will be ignored.
+      HTTParty.post(
+        "#{base}/service/#{FASTLY_SERVICE_ID}/purge/#{key}",
+        FASTLY_OPTIONS
+      )
+    rescue StandardError => e
+      # I hate catching StandardError, ideally we'd be more specific.
+      # However, there doesn't seem to be a safe way to identify
+      # all network-based exceptions. See:
+      # https://stackoverflow.com/questions/5370697/
+      # what-s-the-best-way-to-handle-exceptions-from-nethttp
+      # For example, this does NOT work:
+      # rescue HTTParty::Error, Net::OpenTimeout, IOError => e
+      Rails.logger.error do
+        "ERROR:: FAILED TO PURGE #{key} , #{e.class}: #{e}"
+      end
+    end
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -6,4 +6,16 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  # table_key and record_key are used to compute CDN keys
+  # Based on:
+  # https://github.com/fastly/fastly-rails/blob/master/lib/fastly-rails/
+  # active_record/surrogate_key.rb
+  def table_key
+    self.class.table_name
+  end
+
+  def record_key
+    "#{table_key}/#{id}"
+  end
 end

--- a/config/initializers/fastly.rb
+++ b/config/initializers/fastly.rb
@@ -11,31 +11,32 @@ require 'json'
 require 'ipaddr'
 
 # Download list of valid IP addresses from this (be SURE this is https!):
-iplist_uri = 'https://api.fastly.com/public-ip-list'
+# iplist_uri = 'https://api.fastly.com/public-ip-list'
 
 # Ensure that there's *a* value for valid_client_ips (nil=all allowed)
 Rails.configuration.valid_client_ips = nil
 
-if !ENV['FASTLY_API_KEY'] && !Rails.env.test?
-  Rails.logger.warn 'FASTLY_API_KEY is not set.'
+if !Rails.env.test?
+  Rails.logger.warn 'FASTLY_API_KEY not set.' unless ENV['FASTLY_API_KEY']
+  Rails.logger.warn 'FASTLY_SERVICE_ID not set.' unless ENV['FASTLY_SERVICE_ID']
 end
 
-FastlyRails.configure do |c|
-  c.api_key = ENV['FASTLY_API_KEY'] # Fastly api key, required for it to work
-  c.max_age = 86_400 # time in seconds, optional, default 2592000 (30 days)
-  c.service_id = ENV['FASTLY_SERVICE_ID'] # The Fastly service, required
-  c.purging_enabled = !Rails.env.development? && !Rails.env.test? &&
-                      ENV['FASTLY_API_KEY']
-end
-
-if ENV['FASTLY_CLIENT_IP_REQUIRED']
-  # Set up list of valid IP addresses, assumes iplist_uri is accessible.
-  # Note: Ruby's HTTP.get *does* check for invalid certs, e.g., it
-  # will error out if given 'https://wrong.host.badssl.com/' (*yay*).
-  # Don't call log, may not be ready yet
-  # Rails.logger.info 'Getting Fastly public IPs'
-  iplist_text = Net::HTTP.get(URI(iplist_uri))
-  iplist_json = JSON.parse(iplist_text)
-  iplist_ips = iplist_json['addresses'].map { |i| IPAddr.new(i) }
-  Rails.configuration.valid_client_ips = iplist_ips
-end
+# FastlyRails.configure do |c|
+#   c.api_key = ENV['FASTLY_API_KEY'] # Fastly api key, required for it to work
+#   c.max_age = 86_400 # time in seconds, optional, default 2592000 (30 days)
+#   c.service_id = ENV['FASTLY_SERVICE_ID'] # The Fastly service, required
+#   c.purging_enabled = !Rails.env.development? && !Rails.env.test? &&
+#                       ENV['FASTLY_API_KEY']
+# end
+#
+# if ENV['FASTLY_CLIENT_IP_REQUIRED']
+#   # Set up list of valid IP addresses, assumes iplist_uri is accessible.
+#   # Note: Ruby's HTTP.get *does* check for invalid certs, e.g., it
+#   # will error out if given 'https://wrong.host.badssl.com/' (*yay*).
+#   # Don't call log, may not be ready yet
+#   # Rails.logger.info 'Getting Fastly public IPs'
+#   iplist_text = Net::HTTP.get(URI(iplist_uri))
+#   iplist_json = JSON.parse(iplist_text)
+#   iplist_ips = iplist_json['addresses'].map { |i| IPAddr.new(i) }
+#   Rails.configuration.valid_client_ips = iplist_ips
+# end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -96,7 +96,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes @response.body, '@example.com'
     # We also want to make sure we don't cache this
     assert_equal 'noindex', @response.headers['X-Robots-Tag']
-    assert_equal 'no-cache, no-store',
+    assert_equal 'private, must-revalidate, no-store',
                  @response.headers['Cache-Control']
   end
 
@@ -116,7 +116,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_not_includes @response.body, '%40example.com'
     assert_not_includes @response.body, '@example.com'
-    assert_equal 'no-cache, no-store',
+    assert_equal 'private, must-revalidate, no-store',
                  @response.headers['Cache-Control']
   end
 
@@ -125,7 +125,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get "/en/users/#{@user.id}.json"
     assert_response :success
     assert_not_includes @response.body, 'example.com'
-    assert_equal 'no-cache, no-store',
+    assert_equal 'private, must-revalidate, no-store',
                  @response.headers['Cache-Control']
     json_response = JSON.parse(@response.body)
     assert_equal @user.id, json_response['id']
@@ -144,7 +144,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get "/en/users/#{@user.id}"
     assert_response :success
     assert_includes @response.body, 'mailto:melissa%40example.com'
-    assert_equal 'no-cache, no-store',
+    assert_equal 'private, must-revalidate, no-store',
                  @response.headers['Cache-Control']
   end
 
@@ -153,7 +153,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get "/en/users/#{@user.id}"
     assert_response :success
     assert_includes @response.body, 'mailto:melissa%40example.com'
-    assert_equal 'no-cache, no-store',
+    assert_equal 'private, must-revalidate, no-store',
                  @response.headers['Cache-Control']
   end
 
@@ -164,7 +164,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get "/en/users/#{@user.id}?format=json"
     assert_response :success
     assert_includes @response.body, 'melissa@example.com'
-    assert_equal 'no-cache, no-store',
+    assert_equal 'private, must-revalidate, no-store',
                  @response.headers['Cache-Control']
   end
 

--- a/test/features/login_test.rb
+++ b/test/features/login_test.rb
@@ -15,18 +15,19 @@ class LoginTest < CapybaraFeatureTest
   X = /result_symbol_x/.freeze
 
   setup do
-    FastlyRails.configure do |c|
-      c.purging_enabled = true
-    end
+    # FastlyRails is no longer in use.
+    # FastlyRails.configure do |c|
+    #   c.purging_enabled = true
+    # end
     @user = users(:test_user)
     @project = projects(:one)
   end
 
-  teardown do
-    FastlyRails.configure do |c|
-      c.purging_enabled = false
-    end
-  end
+  # teardown do
+  #   FastlyRails.configure do |c|
+  #     c.purging_enabled = false
+  #   end
+  # end
 
   # Test this with larger integration, to increase confidence that
   # we really do reject correct local usernames with wrong passwords

--- a/test/unit/lib/fastly_rails_test.rb
+++ b/test/unit/lib/fastly_rails_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Copyright 2015-2017, the Linux Foundation, IDA, and the
+# CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+require 'test_helper'
+
+class FastlyRailsTest < ActiveSupport::TestCase
+  setup do
+  end
+
+  # Test that the system will keep running even if a bad key is given.
+  # We don't test for a "good" key because we don't want to accidentally
+  # include a valid Fastly key in the test data
+  test 'purge_by_key fails on bad key' do
+    VCR.use_cassette('fastly_no_key') do
+      # *Force* use of the key
+      FastlyRails.purge_by_key('foo', true)
+    end
+  end
+
+  # Test that the system will keep running even if the CDN (Fastly)
+  # port is dead. We created this cassette by modifying
+  # app/lib/fastly_rails.rb to try to access a useless port, then edited
+  # the cassette fastly_deadport to remove the port number.
+  test 'purge_by_key keeps working even if port fails' do
+    # *Force* use of the key, since we don't have one set.
+    # We set a nonsense localhost base  for this test.
+    # VCR can't record "failure to connect", so we'll
+    # instead force a failure to connect so we can test its handling.
+    FastlyRails.purge_by_key('foo', true, 'https://localhost:0/')
+  end
+end

--- a/test/vcr_cassettes/fastly_no_key.yml
+++ b/test/vcr_cassettes/fastly_no_key.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.fastly.com//service//purge/foo
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Fastly-Key:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Connection:
+      - keep-alive
+      Status:
+      - 404 Not Found
+      Fastly-Ratelimit-Remaining:
+      - '999'
+      Fastly-Ratelimit-Reset:
+      - '1609815600'
+      Accept-Ranges:
+      - bytes
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Date:
+      - Tue, 05 Jan 2021 02:08:55 GMT
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-wdc5548-WDC
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1609812535.267807,VS0,VE56
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Tue, 05 Jan 2021 02:08:55 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
The gem "fastly-rails" does not work on Rails 6, so we
must eliminate it to upgrade to Rails 6.

They recommend switching to the "fastly" gem (aka "fastly-ruby"),
but fastly-ruby is not designed to support multi-threading (WHAT?!).
The only workable solution I could find was to modify our code
to directly call the Fastly API instead.

This turned out to be more complicated than expected, and
frankly was a big pain. However, this is a blocker to upgrading
Rails, and the version of Rails we use is no longer supported,
so this needed to be done.

We need to test this on the *real* system to ensure that it really works.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>