### PR TITLE
Omit session cookie if empty

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -73,6 +73,9 @@ class ProjectsController < ApplicationController
     if validated_url != request.original_url
       redirect_to validated_url
     else
+      # Omit useless empty session cookie for performance
+      request.session_options[:skip] = true if session.empty?
+
       retrieve_projects
       if params[:as] == 'badge' # Redirect to badge view
         # We redirect, instead of responding directly with the answer, because
@@ -132,6 +135,9 @@ class ProjectsController < ApplicationController
   # GET /projects/1
   # rubocop:disable Metrics/MethodLength
   def show
+    # Omit useless empty session cookie for performance
+    request.session_options[:skip] = true if session.empty?
+
     # Fix malformed queries of form "/en/projects/188?criteria_level,2"
     # These produce parsed.query_values of {"criteria_level,2"=>nil}
     # They end up as weird special keys, so this is the easy way to detect them
@@ -177,6 +183,9 @@ class ProjectsController < ApplicationController
 
     # Tell CDN the surrogate key so we can quickly erase it later
     set_surrogate_key_header @project.record_key
+
+    # Never send session cookie
+    request.session_options[:skip] = true
 
     respond_to do |format|
       format.svg do

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -133,7 +133,7 @@ class ProjectsController < ApplicationController
   # rubocop:disable Metrics/MethodLength
 
   # GET /projects/1
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def show
     # Omit useless empty session cookie for performance
     request.session_options[:skip] = true if session.empty?
@@ -155,7 +155,7 @@ class ProjectsController < ApplicationController
                   status: :moved_permanently
     end
   end
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   # GET /projects/1.json
   def show_json

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -17,7 +17,10 @@ class StaticPagesController < ApplicationController
   skip_before_action :redir_missing_locale,
                      only: %i[robots error_404 google_verifier]
 
-  def home; end
+  def home
+    # Omit useless empty session cookie for performance
+    request.session_options[:skip] = true if session.empty?
+  end
 
   def criteria_stats; end
 

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -225,6 +225,7 @@ module SessionsHelper
     return unless logged_in? && session_expired
 
     reset_session
+    # Set "current_user" to invalid value (session hash is not empty)
     session[:current_user] = nil
     redirect_to login_path
   end

--- a/test/vcr_cassettes/fastly_no_key.yml
+++ b/test/vcr_cassettes/fastly_no_key.yml
@@ -53,4 +53,53 @@ http_interactions:
       string: ''
     http_version: 
   recorded_at: Tue, 05 Jan 2021 02:08:55 GMT
+- request:
+    method: post
+    uri: https://api.fastly.com/service//purge/foo
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Fastly-Key:
+      - ''
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '68'
+      Server:
+      - Varnish
+      Retry-After:
+      - '0'
+      Content-Type:
+      - application/json
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 06 Jan 2021 02:13:48 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-wdc5579-WDC
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"msg":"Record not found", "detail": "Cannot find service ''(null)''"}'
+    http_version: 
+  recorded_at: Wed, 06 Jan 2021 02:13:48 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
By default Rails *always* sets a session cookie, even if it's empty.
That interferes with many cache optimizations and is generally
unfriendly. I tried to set an after filter to disable this, but that
happens at the wrong time. There's an ugly hack that worked on
Rails 3 but doesn't any more.

So let's disable sending empty session cookies for a few especially
popular pages at least.  Some discussion here:
https://stackoverflow.com/questions/5435494/rails-3-disabling-session-cookies

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>