### PR TITLE
Create Rails system test stub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,8 +125,8 @@ jobs:
         name: Check for whitespace issues.
         command: '[[ ! -s "$(git rev-parse --git-dir)/shallow" ]] || git fetch --unshallow'
     - run:
-        name:  Run test suite
-        command: bundle exec rake test
+        name:  Run test suite (both system and non-system tests)
+        command: bundle exec rails test:system test
     - run:
         name:  Run pronto GitHub
         command: >

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -40,6 +40,43 @@ modify something.  One way is to change some shared configuration values to be
 Another is to change some methods to take parameters, so that
 you can provide different parameters during testing.
 
+## System Tests
+
+We are in the process of replacing all uses of the class
+CapybaraFeatureTest (subclass of Capybara::Rails::TestCase)
+with the standard Rails system tests, which use the
+class ApplicationSystemTestCase (subclass of ActionDispatch::SystemTestCase).
+
+Warning! By default "rails test" (and thus rake) do *NOT* run system tests.
+You must run system tests via "rails test:system". To run *both*
+system and non-system tests, say "rails test:system test" (in that order).
+This commit modifies our CI pipeline so that it runs BOTH
+system and non-system tests. So for most people this detail will be quietly
+handled correctly. Rails 6.1 adds "rails test:all", so when we get
+to Rails 6.1 it will be easier to ask for all (normal) tests.
+
+Rails system tests normally interact with an actual browser.
+In some cases they can be configured to use the `rack_test` backend and
+merely simulate a browser; that is faster, but it doesn't support
+JavaScript and the tests are not as realistic.
+So here we'll discuss the normal, interacting with an actual browser.
+
+For basic information on how to create syystem tests, see the
+[Rails guide on testing (system testing section)](https://guides.rubyonrails.org/testing.html#system-testing).
+
+Here's how a Rails system test normally works, as explained in
+[Rails 6 System Tests, From Top to Bottom](https://avdi.codes/rails-6-system-tests-from-top-to-bottom/)
+
+* "A MiniTest test case, augmented with...
+* Capybara testing helpers, which start and stop an instance of your app,
+  and provide an English-like DSL on top of...
+* The selenium-webdriver gem, which provides a Ruby API for using the...
+* ... WebDriver protocol in order to interact with...
+* A WebDriver tool such as chromedriver or geckodriver, which…
+* Is automatically downloaded by the webdrivers gem.
+ The WebDriver tool automates...
+* A browser, such as Chrome."
+
 ## Features
 
 Features that don't need JavaScript should default to the headless rack-test driver, which is fastest. Features that need JavaScript should set `Capybara.current_driver = Capybara.javascript_driver` as described in this [blog post](http://www.rubytutorial.io/how-to-test-an-autocomplete-with-rails/). To debug features in a browser, preface the test with the driver in an environment variable, like:

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Copyright the CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+require 'test_helper'
+
+# Must run headless and disable sandbox, see:
+# https://medium.com/@john200Ok/running-rails-6-system-tests-using-chrome-headless-and-selenium-on-gitlab-ci-9b4de5cafcd0
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400] do |option|
+    option.add_argument('no-sandbox')
+  end
+end

--- a/test/system/examples_test.rb
+++ b/test/system/examples_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Copyright the CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+require 'application_system_test_case'
+
+# Brief example of system tests; this is used to see if we can
+# run system tests at all.
+class ExamplesTest < ApplicationSystemTestCase
+  test 'visiting the English home page' do
+    visit '/en'
+    assert_selector 'h2', text: 'CII Best Practices Badge Program'
+  end
+end


### PR DESCRIPTION
Implement the standard Rails system test via its conventional
configuration file test/application_system_test_case.rb
and create a first system test (test/system/examples_test.rb)
using this Rails system test framework.

This required various modifications to actually work.
In particular, modern Chrome *requires* disabling the sandbox for the
system tests to work, and we need to configure it to be headless.

Warning! By default "rails test" (and thus rake) do *NOT* run system tests.
You must run system tests via "rails test:system". To run *both*
system and non-system tests, say "rails test:system test" (in that order).
This commit modifies our CI pipeline so that it runs BOTH
system and non-system tests. So for most people this detail will be quietly
handled correctly. Rails 6.1 adds "rails test:all", so when we get
to Rails 6.1 it will be easier to ask for all (normal) tests.

Here's the background.  We currently implement system tests using
Capybara::Rails::TestCase, but this is not compatible with Rails 6.
To upgrade to Rails 6 we need to switch to the Rails system test
mechanisms (which didn't exist when we wrote our system tests). Our
first step, implemented in this commit, is to get Rails 6 system tests
working at all... which required some effort.

The next step is to convert, step by step, our existing system tests that
currently use class CapybaraFeatureTest (or its superclass
Capybara::Rails::TestCase) so that they use ApplicationSystemTestCase
instead. This step will almost certainly happen as a large set of
smaller steps to do that conversion.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>