### PR TITLE
Add pt_BR (Brazilian Portuguese)

### DIFF
--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -12,7 +12,7 @@ if Rails.env.development? || Rails.env.test?
   TranslationIO.configure do |config|
     config.api_key        = 'b6086a4661ba47d79ec771236e298211'
     config.source_locale  = 'en'
-    config.target_locales = %i[zh-CN es fr de ja ru sw]
+    config.target_locales = %i[zh-CN es fr de ja pt_BR ru sw]
 
     # Uncomment this if you don't want to use gettext
     config.disable_gettext = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
     de: German
     fr: French
     ja: Japanese
+    pt_BR: Brazilian Portuguese
     ru: Russian
     sw: Swahili
     zh-CN: Chinese (Simplified)


### PR DESCRIPTION
Add pt_BR (Brazilian Portuguese) as a translation target.
This does *not* allow selecting it from the run-time menu;
that will be a separate pull request once we have some
actual translated text.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>