### PR TITLE
Remove gem database_cleaner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,6 @@ group :development, :test do
   gem 'awesome_print', '1.8.0' # Pretty print Ruby objects
   gem 'bullet', '6.1.3' # Avoid n+1 queries
   gem 'bundler-audit', '0.7.0.1'
-  gem 'database_cleaner', '1.8.5' # Cleans up database between tests
   gem 'dotenv-rails', '2.7.6'
   gem 'eslintrb', '2.1.0'
   gem 'json', '2.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,6 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    database_cleaner (1.8.5)
     docile (1.3.5)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -478,7 +477,6 @@ DEPENDENCIES
   capybara-slow_finder_errors (= 0.1.5)
   chartkick (= 3.4.0)
   codecov (= 0.4.3)
-  database_cleaner (= 1.8.5)
   dotenv-rails (= 2.7.6)
   eslintrb (= 2.1.0)
   font-awesome-rails (= 4.7.0.7)

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -944,8 +944,36 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'sanity test of reminders' do
+    # The test framework does not reliably reset the test values for the
+    # late_project (we don't know why). So in this test we manually force the
+    # correct test values so our test will work reliably.
+    # This makes the test reliable (I've re-run "rails test:all" 177 times after doing this),
+    # and doing this lets us remove the gem "database_cleaner" (which shouldn't be necessary).
+    # We generally want to minimize dependencies, so adding a few lines to set up a test
+    # is a good trade-off.
+
+    # Here are debug statements if you want to investigate this again:
+    # projects_to_remind = Project.projects_to_remind
+    # projects_to_remind_ids = projects_to_remind.map(&:id) # Return a list
+    # puts('')
+    # puts('Expect: project name=Pathfinder OS id=980190962 badge_percentage_0=0 '
+    #      'last_reminder_at= lost_passing_at= updated_at=2000-01-01 00:00:00 UTC')
+    # p = projects_to_remind.first
+    # p = Project.find_by(id: 980190962)
+    # puts("Sanity: project name=#{p.name} id=#{p.id} badge_percentage_0=#{p.badge_percentage_0} '
+    #      "last_reminder_at=#{p.last_reminder_at} lost_passing_at=#{p.lost_passing_at} "
+    #      "updated_at=#{p.updated_at}")
+    # byebug if projects_to_remind_ids.size == 0
+
+    # Manually force the correct test values so our test will work reliably.
+    late_project = Project.find_by(name: 'Pathfinder OS')
+    late_project.last_reminder_at = nil
+    late_project.lost_passing_at = nil
+    late_project.save!(touch: false)
+
     result = ProjectsController.send :send_reminders
     assert_equal 1, result.size
+    assert_equal late_project.id, result[0]
   end
 
   # This is a unit test of a private method in ProjectsController.

--- a/test/system/github_login_test.rb
+++ b/test/system/github_login_test.rb
@@ -9,8 +9,6 @@ require 'application_system_test_case'
 class GithubLoginTest < ApplicationSystemTestCase
   # rubocop:disable Metrics/BlockLength
   test 'Can sign up with GitHub' do
-    DatabaseCleaner.clean
-    DatabaseCleaner.start
     configure_omniauth_mock unless ENV['GITHUB_PASSWORD']
 
     VCR.use_cassette('github_login', allow_playback_repeats: true) do

--- a/test/system/github_project_test.rb
+++ b/test/system/github_project_test.rb
@@ -9,11 +9,6 @@ require 'application_system_test_case'
 class GithubProjectTest < ApplicationSystemTestCase
   # rubocop:disable Metrics/BlockLength
   test 'Can Create new project via GitHub login' do
-    # Clean up database here and restart DatabaseCleaner.
-    # This solves a transient issue if test restarts without running
-    # teardown meaning the database is dirty after restart.
-    DatabaseCleaner.clean
-    DatabaseCleaner.start
     configure_omniauth_mock('github_project') unless ENV['GITHUB_PASSWORD']
 
     VCR.use_cassette('github_project', allow_playback_repeats: true) do

--- a/test/system/github_user_test.rb
+++ b/test/system/github_user_test.rb
@@ -8,11 +8,6 @@ require 'application_system_test_case'
 
 class GithubUserTest < ApplicationSystemTestCase
   test 'GitHub user has correct edit rights' do
-    # Clean up database here and restart DatabaseCleaner.
-    # This solves a transient issue if test restarts without running
-    # teardown meaning the database is dirty after restart.
-    DatabaseCleaner.clean
-    DatabaseCleaner.start
     configure_omniauth_mock
 
     visit '/en'
@@ -37,11 +32,6 @@ class GithubUserTest < ApplicationSystemTestCase
 
   # This is a regression test for problems seen by @yannickmoy in Issue #798
   test 'Alternate locale has link to GitHub Login' do
-    # Clean up database here and restart DatabaseCleaner.
-    # This solves a transient issue if test restarts without running
-    # teardown meaning the database is dirty after restart.
-    DatabaseCleaner.clean
-    DatabaseCleaner.start
     configure_omniauth_mock
 
     visit '/fr/signup'

--- a/test/unit/lib/rake_task_test.rb
+++ b/test/unit/lib/rake_task_test.rb
@@ -5,23 +5,8 @@
 # SPDX-License-Identifier: MIT
 
 require 'test_helper'
-require 'database_cleaner'
-DatabaseCleaner.strategy = :transaction
 
 class RakeTaskTest < ActiveSupport::TestCase
-  # When using DatabaseCleaner, transactional fixtures must be off.
-  self.use_transactional_tests = false
-
-  setup do
-    # Start DatabaseCleaner before each test.
-    DatabaseCleaner.start
-  end
-
-  teardown do
-    # Clean up the database with DatabaseCleaner after each test.
-    DatabaseCleaner.clean
-  end
-
   test 'regression test for rake reminders' do
     assert_equal 1, Project.projects_to_remind.size
     result = system 'rake reminders >/dev/null'


### PR DESCRIPTION
Remove the gem database_cleaner, as we should not need it any more.

In general this works. However, this currently produces a
flapping test that sometimes, but inconsistently, produces this error:

Running tests with run options --seed 46922:

Failure:
ProjectsControllerTest#test_sanity_test_of_reminders [/home/dwheeler/best-practices-badge/test/controllers/projects_controller_test.rb:948]
Minitest::Assertion: Expected: 1
  Actual: 0

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>