### PR TITLE
Ignore HTTP 'Accept' parameter

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -52,7 +52,7 @@ Rails.application.config.action_dispatch.ignore_accept_header = true
 CORS_ALLOWED_METHODS = %i[get options].freeze
 
 # Many resources we allow CORS requests for *might* differ depending on
-# who is asking. In these cases were use the default CORS value for
+# who is asking. In these cases we use the default CORS value for
 # the HTTP Header 'Vary', which is 'Accept-Encoding, Origin':
 # * 'Accept-Encoding' is necessary because different browsers accept
 # different compression algorithms. Fastly normalizes this when we pass
@@ -75,9 +75,9 @@ CORS_ALLOWED_METHODS = %i[get options].freeze
 # this would let browser caches know to check the 'Accept' HTTP value.
 
 CORS_DIFFERENTIATED_RESOURCE_PATTERNS = [
-  '/projects', '/projects.json', '/projects/*',
+  '/projects', '/projects/*',
   '/projects/**/*', '/project_stats*',
-  '/en/projects', '/en/projects.json', '/en/projects/*',
+  '/en/projects', '/en/projects/*',
   '/en/projects/**/*', '/en/project_stats*',
   '/users/*.json', '/en/users/*.json'
 ].freeze
@@ -92,7 +92,7 @@ CORS_DIFFERENTIATED_RESOURCE_PATTERNS = [
 # across all users. By omitting "Origin" for these, we significantly
 # optimize use because any Origin will share the same CDN cache entry.
 #
-# Note: we don't need to include 'Accept' in the HTTP Header 'Vary' for
+# Note: we do not include 'Accept' in the HTTP Header 'Vary' for
 # /projects/:id/badge(.:format) resource because we *always* ignored
 # the HTTP 'Accept' heading for selecting its data format (due to
 # the way it gets routed). This is the most important case
@@ -101,11 +101,19 @@ CORS_DIFFERENTIATED_RESOURCE_PATTERNS = [
 #
 # Note: This cannot be exploited to be misinterpreted as something else.
 # The "*" does not match an embedded "/". Even if an attacker used "..",
-# that would just produce the useless "/badge" and "/badge.json".
+# that would just produce useless "/badge" and "/badge.json" and so on.
 
 CORS_UNDIFFERENTIATED_RESOURCE_PATTERNS = [
+  # Badge information about one project (image and JSON)
   '/projects/*/badge', '/projects/*/badge.json',
-  '/project_stats/*.json', '/*/project_stats/*.json', '/project_stats.json'
+  # Information about one project (JSON)
+  '/??/projects/*.json', '/??-??/projects/*.json',
+  # Information about a set of projects (JSON)
+  '/??/projects.json', '/??-??/projects.json',
+  # Project statistics (JSON); some have no locale, some have a locale
+  '/project_stats/*.json',
+  '/??/project_stats/*.json', '/??-??/project_stats/*.json',
+  '/??/project_stats.json', '/??-??/project_stats.json'
 ].freeze
 CORS_UNDIFFERENTIATED_VARY = ['Accept-Encoding'].freeze
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -41,17 +41,13 @@ and ".svg") to the URL before the parameters (if any).
 When using "." + format, the format name must be all lowercase.
 
 WARNING: Do *not* use the HTTP header "Accept" to select a format;
-doing that is *deprecated*. Instead, please use the URL itself to request
+that *no longer works* (it was previously deprecated).
+Instead, please use the URL itself to request
 the format (e.g., use a URL with ".json" if you want JSON format).
-We currently support using the HTTP header Accept (such as "Accept:
-application/json") to select a format in several cases.
-However, the problem is that this
-interferes with caching. Caches normally just use the URL to determine
+At one time we allowed this, but that interferes with CDN caching.
+Caches normally just use the URL to determine
 what to cache, and caches work much less well if they have to use other
-parameters to examine the cache. There are also various problems in practice.
-The "Accept" HTTP header is ignored in badge requests of the form
-`/projects/:id/badge(.:format)` , and we expect that to be eventually
-true for all other resources as well.
+parameters to examine the cache.
 
 A GET just retrieves information, and since most information is public,
 in most cases you don't need to log in for a GET.

--- a/test/controllers/project_stats_controller_test.rb
+++ b/test/controllers/project_stats_controller_test.rb
@@ -21,6 +21,9 @@ class ProjectStatsControllerTest < ActionDispatch::IntegrationTest
     )
     # This isn't normally shown:
     assert_not @response.body.include?('Percentage of projects earning badges')
+    # Do *NOT* include "Accept" in the Vary heading.
+    # Note: "Origin" will be added to the Vary headers outside this test.
+    assert 'Accept-Encoding', @response.headers['Vary']
   end
 
   test 'should get index as admin' do
@@ -71,6 +74,9 @@ class ProjectStatsControllerTest < ActionDispatch::IntegrationTest
     assert_equal '13', contents[0]['percent_ge_50']
     assert_equal '20', contents[0]['percent_ge_0']
     assert_equal '19', contents[1]['percent_ge_0']
+
+    # Do *NOT* include "Accept" in the Vary heading.
+    assert 'Accept-Encoding', @response.headers['Vary']
   end
   # rubocop:enable Metrics/BlockLength
 
@@ -79,6 +85,8 @@ class ProjectStatsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     # Check if we can parse it.
     _contents = JSON.parse(@response.body)
+    # Do *NOT* include "Accept" in the Vary heading.
+    assert 'Accept-Encoding', @response.headers['Vary']
   end
 
   test 'should NOT be able to get new' do
@@ -143,6 +151,9 @@ class ProjectStatsControllerTest < ActionDispatch::IntegrationTest
     get total_projects_project_stats_path(format: :json, locale: nil)
     contents = JSON.parse(@response.body)
     assert 20, contents['2013-05-19 17:44:18 UTC']
+    # Do *NOT* include "Accept" in the Vary heading.
+    # Note: "Origin" will be added to the Vary headers outside this test.
+    assert 'Accept-Encoding', @response.headers['Vary']
   end
 
   test 'Test /project_stats/nontrivial_projects.json' do


### PR DESCRIPTION
Ignore the HTTP 'Accept' parameter when serving pages.
Instead, to choose a different format, use a different URL.
Our API documentation had previously deprecated the 'Accept'
parameter; this commit actually eliminates the deprecated mechanism.

We do *not* want to use the HTTP Accept header to decide what format to send,
because that interferes with using the CDN. Without this setting,
Rails will produce different values (in some cases) depending on the
HTTP "Accept" value, and thus will generate "Vary: Accept" (correctly).
However, since different browsers will have
different Accept header values, this Vary: Accept will mean that
different browsers will not share a CDN cached value.

By setting ignore_accept_user, users *must* use the URL to request a
non-default format. In compensation, this setting
speeds average response time & reduces server load by better using the CDN.

This commit primarily changes one setting:

> Rails.application.config.action_dispatch.ignore_accept_header = true

However, it modifies tests & documentation, as well as
changing some JSON access settings for project statistics.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>