### PR TITLE
Log JSON requests without .json suffix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,10 @@
 
 require 'ipaddr'
 
+# rubocop:disable Metrics/ClassLength
 class ApplicationController < ActionController::Base
   include Pagy::Backend
 
-  # Record the original session value in "original_session".
   # That way we tell if the session value has changed, and potentially
   # omit it if it has not changed.
   before_action :record_original_session
@@ -46,6 +46,20 @@ class ApplicationController < ActionController::Base
   # Use the new HTTP security header, "permissions policy", to disable things
   # we don't need.
   before_action :add_http_permissions_policy
+
+  def log_json_without_suffix(request)
+    logger.warn 'JSON request without json path extension, ' \
+      "url=#{request&.url}"
+  end
+
+  # Warn about a JSON request without a .json suffix.
+  # E.g., because someone used the Accept: header to specially request it
+  before_action :json_without_suffix
+  def json_without_suffix
+    weird = request.format.to_s == 'application/json' &&
+            request.path !~ /.json\z/
+    log_json_without_suffix(request) if weird
+  end
 
   # Record user_id, e.g., so it can be recorded in logs
   # https://github.com/roidrage/lograge/issues/23
@@ -286,3 +300,4 @@ class ApplicationController < ActionController::Base
 
   include SessionsHelper
 end
+# rubocop:enable Metrics/ClassLength

--- a/test/controllers/project_stats_controller_test.rb
+++ b/test/controllers/project_stats_controller_test.rb
@@ -164,6 +164,22 @@ class ProjectStatsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 4, contents.length
   end
 
+  # This doesn't affect the HTTP Accept header for some reason,
+  # so this is commented out & we use a unit test.
+  # test 'Test Warning /en/project_stats using accept to get JSON' do
+  #   get '/project_stats',
+  #       headers: { 'Accept': 'application/json' }
+  #   follow_redirect!
+  #   contents = JSON.parse(@response.body)
+  #   assert_equal 4, contents.length
+  # end
+
+  test 'Test special JSON logger' do
+    app = ApplicationController.new
+    # Make sure we can run log_json_without_suffix
+    app.log_json_without_suffix(nil)
+  end
+
   test 'Test /fr/project_stats/activity_30.json' do
     get activity_30_project_stats_path(format: :json, locale: 'fr')
     contents = JSON.parse(@response.body)


### PR DESCRIPTION
We want *stop* listening to the "Accept" header, but is anyone using it?
This logs anything interpreted as a JSON request but has a .json
extension, to help detect those using an obsolete request.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>