### PR TITLE
Use expires_in to show project_stats

### DIFF
--- a/app/controllers/project_stats_controller.rb
+++ b/app/controllers/project_stats_controller.rb
@@ -56,9 +56,15 @@ class ProjectStatsController < ApplicationController
   end
 
   # Set the cache (including the CDN) to be used for cache_time
+  # Sets HTTP header 'Cache-Control' to "max-age=#{seconds_left}, public"
   def cache_until_next_stat
     seconds_left = cache_time(Time.now.utc.seconds_since_midnight)
-    headers['Cache-Control'] = "max-age=#{seconds_left}"
+    # We can't just set Cache-Control directly like this:
+    # headers['Cache-Control'] = "max-age=#{seconds_left}"
+    # The problem is that Rails will quietly add 'private'
+    # to the value of Cache-Control value. An easy solution is to
+    # just use the built-in Rails mechanism for setting Cache-Control:
+    expires_in seconds_left, public: true
   end
 
   # These controllers often generate a lot of JSON. More info:

--- a/test/controllers/project_stats_controller_test.rb
+++ b/test/controllers/project_stats_controller_test.rb
@@ -154,6 +154,10 @@ class ProjectStatsControllerTest < ActionDispatch::IntegrationTest
     # Do *NOT* include "Accept" in the Vary heading.
     # Note: "Origin" will be added to the Vary headers outside this test.
     assert 'Accept-Encoding', @response.headers['Vary']
+    cache_control = @response.headers['Cache-Control']
+    assert_includes cache_control, 'max-age='
+    assert_includes cache_control, 'public'
+    assert_not_includes cache_control, 'private'
   end
 
   test 'Test /project_stats/nontrivial_projects.json' do


### PR DESCRIPTION
If we just set the HTTP header 'Cache-Control', Rails quietly
adds "private" which we do *NOT* want when showing project_stats.
So, switch to using Rails' expires_in, where we can easily set
public: true.

This should significantly optimize project_stats views, because it
allows the JSON files to be cached by the CDN (as was intended).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>