### PR TITLE
Fix: max_age should be max-age

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,7 +73,7 @@ class ApplicationController < ActionController::Base
   ].max
 
   BADGE_CACHE_SURROGATE_CONTROL =
-    "max_age=#{BADGE_CACHE_MAX_AGE}, stale-if-error=#{BADGE_CACHE_STALE_AGE}"
+    "max-age=#{BADGE_CACHE_MAX_AGE}, stale-if-error=#{BADGE_CACHE_STALE_AGE}"
 
   # Set the cache control headers
   # More info:


### PR DESCRIPTION
Our caching wasn't working well because we set
max_age but that should have been max-age.

Fixed.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>