### PR TITLE
Make app router validations pickier

### DIFF
--- a/app/controllers/badge_static_controller.rb
+++ b/app/controllers/badge_static_controller.rb
@@ -17,23 +17,26 @@ class BadgeStaticController < ApplicationController
   def show
     # Show the badge static display given a value.
     # "Value" must be 0..99, passing, silver, or gold
-    # TODO: have a way to show "no such project"
+    # TODO: have a way to show "no such value"
     value = params[:value]
     begin
-      value = Integer(value, 10)
-    rescue ArgumentError # not an integer
+      value = Integer(value, 10) # Switch to integer type if it is
+    rescue ArgumentError # not an integer - don't change "value"
     end
-    if Badge.valid?(value)
-      set_surrogate_key_header "/badge_percent/#{value}"
-      send_data Badge[value],
-                type: 'image/svg+xml', disposition: 'inline'
-    else
-      # Value isn't valid, return a 404
-      render(
-        template: 'static_pages/error_404',
-        formats: [:html], layout: false, status: :not_found # 404
-      )
-    end
+
+    # Defensive programming: check if it's valid before displaying it.
+    # The router should prevent invalid values from reaching here.
+    return unless Badge.valid?(value)
+
+    set_surrogate_key_header "/badge_percent/#{value}"
+    send_data Badge[value],
+              type: 'image/svg+xml', disposition: 'inline'
+    # Our application router now prevents invalid values. Before we did that,
+    # we had an "else" clause that sent a 404 by doing this:
+    # render(
+    #   template: 'static_pages/error_404',
+    #   formats: [:html], layout: false, status: :not_found # 404
+    # )
   end
   # rubocop:enable Metrics/MethodLength
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,10 @@ LEGAL_LOCALE = /(?:#{I18n.available_locales.join("|")})/.freeze
 VALID_CRITERIA_LEVEL = /[0-2]/.freeze
 
 # Confirm that number-only id is provided
-VALID_ID = /[1-9][0-9]+/.freeze
+VALID_ID = /[1-9][0-9]*/.freeze
+
+# Valid values for static badge display
+VALID_STATIC_VALUE = /0|[1-9]{1,2}|passing|silver|gold/.freeze
 
 Rails.application.routes.draw do
   # First, handle routing of special cases.
@@ -45,6 +48,7 @@ Rails.application.routes.draw do
   # Beware: This route produces a result unconnected to a project's status.
   # Do NOT use this route on a project's README.md page!
   get '/badge_static/:value' => 'badge_static#show',
+      constraints: { value: VALID_STATIC_VALUE },
       defaults: { format: 'svg' }
 
   # These routes never use locales, so that the cache is shared across locales.
@@ -120,7 +124,7 @@ Rails.application.routes.draw do
     get 'feed' => 'projects#feed', defaults: { format: 'atom' }
     get 'reminders' => 'projects#reminders_summary'
 
-    resources :projects do
+    resources :projects, constraints: { id: VALID_ID } do
       member do
         get 'delete_form' => 'projects#delete_form'
         get '' => 'projects#show_json',

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -173,6 +173,11 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Accept-Encoding, Origin', @response.headers['Vary']
   end
 
+  test 'should NOT show project if invalid id given' do
+    get "/en/projects/#{@project.id}junk"
+    assert_response :missing
+  end
+
   # DEPRECATED CAPABILITY. We eventually want to require people to use
   # "/en/projects/:id.json" if they want JSON. However, as long as this
   # capability exists, we should test that it works. We also want to test


### PR DESCRIPTION
Add various validations to the router so it's pickier about
what it accepts. In particular, IDs must be positive integers.
Before we quietly converted IDs that *started* as integers
as integers, but we have attackers creatively adding garbage
after the ID to try to trigger attacks. We know of no way for
that to actually *work* as an attack on our system, but it's
better to validate input and reject anything that doesn't meet
our strict criteria. We do that in other places; now we'll make
these pickier as well.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>