### PR TITLE
Redefine CORS patterns using regexes

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -74,12 +74,15 @@ CORS_ALLOWED_METHODS = %i[get options].freeze
 # response.set_header('Vary', 'Accept')
 # this would let browser caches know to check the 'Accept' HTTP value.
 
+# We use regular expressions to define the patterns;
+# the library also supports string matching, but it's not very precise
+# and there's no way to express priority.
+# With regular expressions we can express the patterns unambiguously.
+
 CORS_DIFFERENTIATED_RESOURCE_PATTERNS = [
-  '/projects', '/projects/*',
-  '/projects/**/*', '/project_stats*',
-  '/en/projects', '/en/projects/*',
-  '/en/projects/**/*', '/en/project_stats*',
-  '/users/*.json', '/en/users/*.json'
+  %r{\A/([a-z]{2}(-[A-Z]{2})?/)?projects(/[1-9][0-9]*(/[1-9][0-9]*)?)?\z},
+  %r{\A/([a-z]{2}(-[A-Z]{2})?/)?project_stats\z},
+  %r{\A/([a-z]{2}(-[A-Z]{2})?/)?users/[1-9][0-9]*\.json\z}
 ].freeze
 
 # For some resources we are absolutely *certain* that their results
@@ -104,16 +107,9 @@ CORS_DIFFERENTIATED_RESOURCE_PATTERNS = [
 # that would just produce useless "/badge" and "/badge.json" and so on.
 
 CORS_UNDIFFERENTIATED_RESOURCE_PATTERNS = [
-  # Badge information about one project (image and JSON)
-  '/projects/*/badge', '/projects/*/badge.json',
-  # Information about one project (JSON)
-  '/??/projects/*.json', '/??-??/projects/*.json',
-  # Information about a set of projects (JSON)
-  '/??/projects.json', '/??-??/projects.json',
-  # Project statistics (JSON); some have no locale, some have a locale
-  '/project_stats/*.json',
-  '/??/project_stats/*.json', '/??-??/project_stats/*.json',
-  '/??/project_stats.json', '/??-??/project_stats.json'
+  %r{\A/([a-z]{2}(-[A-Z]{2})?/)?projects/[1-9][0-9]*/badge\z},
+  %r{\A/([a-z]{2}(-[A-Z]{2})?/)?projects(/[1-9][0-9]*)?\.json\z},
+  %r{\A/([a-z]{2}(-[A-Z]{2})?/)?project_stats(/[a-z0-9_]+)?\.json\z}
 ].freeze
 CORS_UNDIFFERENTIATED_VARY = ['Accept-Encoding'].freeze
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -570,8 +570,9 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     get "/projects/#{@perfect_passing_project.id}/../badge.json",
         headers: { 'Origin': 'example.com' }
     assert_response :not_found
-    assert_equal 'Accept-Encoding', @response.headers['Vary']
-    assert_equal '*', @response.headers['Access-Control-Allow-Origin']
+    # We don't really care about these for a "not found":
+    # assert_equal 'Accept-Encoding', @response.headers['Vary']
+    # assert_equal '*', @response.headers['Access-Control-Allow-Origin']
   end
 
   test 'A perfect passing project should have the passing badge' do
@@ -592,7 +593,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   test 'A perfect passing project requested with CORS' do
     get "/en/projects/#{@project.id}/badge.json",
         headers: { 'Origin': 'example.com' }
-    assert_equal 'Accept-Encoding, Origin', @response.headers['Vary']
+    assert_equal 'Accept-Encoding', @response.headers['Vary']
   end
 
   test 'A perfect silver project should have the silver badge' do


### PR DESCRIPTION
The CORS patterns were defined with strings (globs). Those are
easy to read but in some cases the patterns overlapped.
The overlap meant that some .json files were being incorrectly sent
with a "Vary" over Origin, which interferes with caching.
There doesn't seem to be a way to prioritize the patterns to
prevent this as long as we stick with globs.

This commit redefines the CORS patterns with regexes.
Regexes are more complicated, but far more powerful; we can
use regexes to far more precisely declare the patterns.

As a result, the .json endpoints will no longer Vary by Origin,
which should significantly improve caching.

The final outcome is that this commit should increase average
user speed AND reduce average server load, both due to
better caching. It's always nice to get both.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>