### PR TITLE
Extend default FAIL2BAN pattern for % or &.

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -194,16 +194,22 @@ class Rack::Attack
   # so we have more time to deal with other things.
   # "/admin" is a common admin URL. "/wp-" handles attacks on WordPress.
   # "/cgi" includes "cgi-bin", a standard prefix for old-school CGI programs.
-  # (?:...) is a non-capturing regexp group - we don't need to capture it.
+  # The pattern near the end that finishes with [%&] is to catch
+  # various naive attacks that append nonsense encoded characters after
+  # project IDs; we see a lot of these in the wild.
+  # (?:...) is a non-capturing regexp group - we don't need to capture this.
   FAIL2BAN_PATH = Regexp.compile(
     ENV['FAIL2BAN_PATH'] ||
-    '^/(?:admin|backup|cgi|command|common|config|' \
+    '\A/(?:admin|backup|cgi|command|common|config|' \
     'data|dbadmin|dump|error_message|install|joomla|' \
     'muieblackcat|myadmin|mysql|onvif|options|' \
     'phpadmin|phpmanager|phpmyadmin|phpMyAdmin|PHPMYADMIN|' \
     'scripts|setup|sqladmin|sql-admin|submitticket|' \
     'temp|upload|w00tw00t|webadmin|' \
-    'wootwoot|WootWoot|WooTWooT|wp-|xmlrpc)'
+    'wootwoot|WootWoot|WooTWooT|wp-|xmlrpc|' \
+    '(?:[a-z]{2}(?:-[A-Z]{2})?/)?' \
+    'projects(?:/[1-9][0-9]*(?:/[1-9][0-9]*)?)?(?:\.json)?[%&]' \
+    ')'
   )
   # FAIL2BAN_QUERY = Regexp.compile(ENV['FAIL2BAN_QUERY'] || '\/etc\/passwd')
   Rack::Attack.blocklist('fail2ban pentesters') do |req|


### PR DESCRIPTION
We're getting a lot of attacks of the form
/:locale/projects/:id followed by a % or & and then nonsense.
These are *legal* URLs (per the URL spec), but there's
no reason to send paths with that pattern to our site;
they simply seem to be attacks. They're naive attacks and
seem unlikely to break into the system, but since we can
detect them as attacks, let's tweak our default FAIL2BAN
pattern to counter them. This reduces the time we waste
responding to them, and might also prevent a real attack
(they might later randomly find a *working* attack, but if
we've already temporarily banned them it would be ignored).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>