### PR TITLE
Provide locale-less CSV/JSON project stats

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -199,17 +199,19 @@ class ApplicationController < ActionController::Base
     I18n.default_locale
   end
 
+  # Special case: If the requested format is JSON or CSV, don't bother
+  # redirecting, because JSON and CSV are normally the same in any locale.
+  DO_NOT_REDIRECT_LOCALE = %w[json csv].freeze
+
   # If locale is not provided in the URL, redirect to best option.
   # NOTE: This is intentionally skipped by some calls, e.g., session create.
   # See <http://guides.rubyonrails.org/i18n.html>.
   def redir_missing_locale
     explicit_locale = params[:locale]
     return if explicit_locale.present?
-    #
-    # Special case: If the requested format is JSON, don't bother
-    # redirecting, because JSON is the same in any locale.
-    #
-    return if params[:format] == 'json'
+
+    # Don't bother redirecting some formats
+    return if DO_NOT_REDIRECT_LOCALE.include?(params[:format])
 
     #
     # No locale, determine the best locale and redirect.

--- a/app/views/project_stats/index.html.erb
+++ b/app/views/project_stats/index.html.erb
@@ -116,6 +116,8 @@
 <br>
 <%= t '.raw_data' %>
 <ul>
-<li><%= link_to t('.json_format'), project_stats_path(format: :json) %>
-<li><%= link_to t('.csv_format'), project_stats_path(format: :csv) %>.
+<li><%=
+  link_to t('.json_format'), project_stats_path(format: :json, locale: nil) %>
+<li><%=
+  link_to t('.csv_format'), project_stats_path(format: :csv, locale: nil) %>.
 </ul>


### PR DESCRIPTION
Provide the link to the CSV and JSON project stats
*without* a locale, and allow CSV to skip locale redirects
(like JSON already does). This means that we can can
have our CDN cache those values regardless of locale...
reducing the likelihood of doing it, and increasing speed
of response in cases where more than one person sent the
request (even if those users use different locales).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>