### PR TITLE
Rename "master" branch to "main"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
         path: test/html_reports
     - store_artifacts:
         path: /tmp/circleci-test-results
-  deploy-master:
+  deploy-main:
     docker:
       - image: buildpack-deps:bionic
     environment:
@@ -225,12 +225,12 @@ workflows:
   build-deploy:
     jobs:
       - build
-      - deploy-master:
+      - deploy-main:
           requires:
             - build
           filters:
             branches:
-              only: master
+              only: main
       - deploy-staging:
           requires:
             - build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1043,4 +1043,5 @@ you can switch by doing the following:
 git branch -m master main
 git fetch origin
 git branch -u origin/main main
+git remote set-head origin -a
 ~~~~

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,9 @@ Here's help on how to make contributions, divided into the following sections:
 * criteria changes,
 * code changes,
 * how to check proposed changes before submitting them,
-* reuse (supply chain for third-party components, including updating them), and
-* keeping up with external changes.
+* reuse (supply chain for third-party components, including updating them),
+* keeping up with external changes, and
+* handling the rename of the "master" branch to "main".
 
 ## General information
 
@@ -55,7 +56,7 @@ For more about how to create a pull request, see
 <https://help.github.com/articles/using-pull-requests/>.
 
 We recommend creating different branches for different (logical)
-changes, and creating a pull request when you're done into the master branch.
+changes, and creating a pull request when you're done into the main branch.
 See the GitHub documentation on
 [creating branches](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/)
 and
@@ -1017,7 +1018,7 @@ it can be checked in as a new commit.
 ## Keeping up with external changes
 
 The installer adds a git remote named 'upstream'.
-Running 'git pull upstream master' will pull the current version from
+Running 'git pull upstream main' will pull the current version from
 upstream, enabling you to sync with upstream.
 
 You can reset this, if something has happened to it, using:
@@ -1031,3 +1032,15 @@ If the version of Ruby has changed (in the Gemfile),
 use the 'Ruby itself can be updated' instructions.
 If gems have been added or their versions changed, run
 "bundle install" to install the new ones.
+
+## Renaming "master" to "main"
+
+We have renamed our "master" branch to "main".
+If you have a copy of our code that uses a "master" branch,
+you can switch by doing the following:
+
+~~~~sh
+git branch -m master main
+git fetch origin
+git branch -u origin/main main
+~~~~

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -225,16 +225,16 @@ task :bundle_viz do
   sh 'bundle viz --version --requirements --format svg'
 end
 
-desc 'Deploy current origin/master to staging'
+desc 'Deploy current origin/main to staging'
 task deploy_staging: :production_to_staging do
   sh 'git checkout staging && git pull && ' \
-     'git merge --ff-only origin/master && git push && git checkout master'
+     'git merge --ff-only origin/main && git push && git checkout main'
 end
 
 desc 'Deploy current origin/staging to production'
 task :deploy_production do
   sh 'git checkout production && git pull && ' \
-     'git merge --ff-only origin/staging && git push && git checkout master'
+     'git merge --ff-only origin/staging && git push && git checkout main'
 end
 
 rule '.html' => '.md' do |t|
@@ -323,9 +323,9 @@ task :pull_production_alternative do
      '           -d development db/latest.dump'
 end
 
-desc 'Copy active master database into development (requires access privs)'
-task :pull_master do
-  puts 'Getting master database'
+desc 'Copy active main database into development (requires access privs)'
+task :pull_main do
+  puts 'Getting main database'
   Rake::Task['drop_database'].reenable
   Rake::Task['drop_database'].invoke
   sh 'heroku pg:pull DATABASE_URL development --app master-bestpractices'
@@ -338,8 +338,8 @@ end
 # unnecessarily.  If you want the current active database, you can
 # force a backup with:
 # heroku pg:backups:capture --app production-bestpractices
-desc 'Copy production database backup to master, overwriting master database'
-task :production_to_master do
+desc 'Copy production database backup to main stage, overwriting main database'
+task :production_to_main do
   sh 'heroku pg:backups:restore $(heroku pg:backups:public-url ' \
      '--app production-bestpractices) DATABASE_URL --app master-bestpractices'
   sh 'heroku run:detached bundle exec rake db:migrate ' \
@@ -448,12 +448,12 @@ def normalize_yaml(path)
   end
 end
 
-desc "Ensure you're on master branch"
-task :ensure_master do
-  raise StandardError, 'Must be on master branch to proceed' unless
-    `git rev-parse --abbrev-ref HEAD` == "master\n"
+desc "Ensure you're on the main branch"
+task :ensure_main do
+  raise StandardError, 'Must be on main branch to proceed' unless
+    `git rev-parse --abbrev-ref HEAD` == "main\n"
 
-  puts 'On master branch, proceeding...'
+  puts 'On main branch, proceeding...'
 end
 
 desc 'Reformat en.yml'
@@ -488,7 +488,7 @@ end
 # We save and restore the en version around the sync to resolve.
 # Ths task only runs in development, since the gem is only loaded then.
 if Rails.env.development?
-  Rake::Task['translation:sync'].enhance %w[ensure_master backup_en] do
+  Rake::Task['translation:sync'].enhance %w[ensure_main backup_en] do
     at_exit do
       Rake::Task['restore_en'].invoke
       Rake::Task['fix_localizations'].invoke
@@ -751,11 +751,11 @@ task :test_dev_install do
   puts 'Updating test-dev-install branch'
   sh <<-TEST_BRANCH_SHELL
     git checkout test-dev-install
-    git merge --no-commit master
+    git merge --no-commit main
     git checkout HEAD circle.yml
-    git commit -a -s -m "Merge master into test-dev-install"
+    git commit -a -s -m "Merge main into test-dev-install"
     git push origin test-dev-install
-    git checkout master
+    git checkout main
   TEST_BRANCH_SHELL
 end
 


### PR DESCRIPTION
Rename the "master" branch to "main" in git.

This does *not* change the Heroku app name. That is *much*
more complicated because renaming that requires new certificates,
as well as modifications of settings in Scout APM, Heroku, and
several Heroku plugins at least, it will require new DNS entries
and a re-authentication with SendGrid, and possibly other changes
that we aren't sure we understand.

It is less risky to try to do this rename in stages, so that's
what we're doing.  In addition, the Heroku name is a lot less visible.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>