### PR TITLE
Make percentage <100% if level incomplete

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -613,8 +613,12 @@ class Project < ApplicationRecord
 
   def to_percentage(portion, total)
     return 0 if portion.zero?
+    return 100 if portion >= total
 
-    ((portion * 100.0) / total).round
+    # Give percentage, but only up to 99% (so "100%" always means "complete")
+    # The tertiary operator is clearer & faster than using [...].min
+    result = ((portion * 100.0) / total).round
+    result > 99 ? 99 : result
   end
 
   # Update achieved_..._at & lost_..._at fields given level as number


### PR DESCRIPTION
This commit caps the "percentage" value to
99 at most if the level is not 100% complete.

This is a defensive programming measure.
We round percentages, so this will only a problem once
(N-1)/N >= 0.995, that is, number of items in a level N>=200,
and we don't want that many questions in a level.
Still, I feel better being *certain* it cannot cause problems.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>