### PR TITLE
Update Fastly purge_all

### DIFF
--- a/app/lib/fastly_rails.rb
+++ b/app/lib/fastly_rails.rb
@@ -59,7 +59,7 @@ class FastlyRails
   # rubocop:enable Metrics/MethodLength
 
   # rubocop:disable Metrics/MethodLength
-  def self.purge_all(key, force = false, base = FASTLY_BASE)
+  def self.purge_all(force = false, base = FASTLY_BASE)
     return if !force && (FASTLY_API_KEY.blank? || FASTLY_SERVICE_ID.blank?)
 
     begin
@@ -79,7 +79,7 @@ class FastlyRails
       # For example, this does NOT work:
       # rescue HTTParty::Error, Net::OpenTimeout, IOError => e
       Rails.logger.error do
-        "ERROR:: FAILED TO PURGE #{key} , #{e.class}: #{e}"
+        "ERROR:: FAILED TO PURGE_ALL, #{e.class}: #{e}"
       end
     end
   end

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -266,17 +266,24 @@ end
 
 # Tasks for Fastly including purging and testing the cache.
 namespace :fastly do
-  # Implement full purge of Fastly CDN cache.  Invoke using:
-  #   heroku run --app HEROKU_APP_HERE rake fastly:purge
+  # Implement purge_all (full purge) of Fastly CDN cache.  Invoke using:
+  #   heroku run --app HEROKU_APP_HERE -- rake fastly:purge
   # Run this if code changes will cause a change in badge level, since otherwise
   # the old badge levels will keep being displayed until the cache times out.
   # See: https://robots.thoughtbot.com/
   # a-guide-to-caching-your-rails-application-with-fastly
-  desc 'Purge Fastly cache (takes about 5s)'
-  task :purge do
-    puts 'Starting full purge of Fastly cache (typically takes about 5s)'
-    require Rails.root.join('config', 'initializers', 'fastly')
-    FastlyRails.client.get_service(ENV.fetch('FASTLY_SERVICE_ID')).purge_all
+  # This will cause a SIGNIFICANT temporary increase in activity, since
+  # it will completely empty the CDN cache.
+  # This requires environment variables to be set, specifically
+  # 'FASTLY_API_KEY' and 'FASTLY_SERVICE_ID'. See:
+  # https://developer.fastly.com/reference/api/purging/
+  # Basically, we'll do POST /service/service_id/purge_all
+  # Unfortunately we *cannot* do a soft purge, "Fastly-Soft-Purge: 1"
+  # on a purge-all, per the Fastly documentation.
+  desc 'Purge ALL of Fastly cache (takes about 5s)'
+  task :purge_all do
+    puts 'Starting purge ALL of Fastly cache (typically takes about 5s)'
+    FastlyRails.purge_all(ENV['FASTLY_API_KEY'])
     puts 'Cache purged'
   end
 

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -283,7 +283,7 @@ namespace :fastly do
   desc 'Purge ALL of Fastly cache (takes about 5s)'
   task :purge_all do
     puts 'Starting purge ALL of Fastly cache (typically takes about 5s)'
-    FastlyRails.purge_all(ENV['FASTLY_API_KEY'])
+    FastlyRails.purge_all
     puts 'Cache purged'
   end
 

--- a/test/unit/lib/fastly_rails_test.rb
+++ b/test/unit/lib/fastly_rails_test.rb
@@ -31,4 +31,12 @@ class FastlyRailsTest < ActiveSupport::TestCase
     # instead force a failure to connect so we can test its handling.
     FastlyRails.purge_by_key('foo', true, 'https://localhost:0/')
   end
+
+  test 'purge_all keeps working even if port fails' do
+    # *Force* use of the key, since we don't have one set.
+    # We set a nonsense localhost base  for this test.
+    # VCR can't record "failure to connect", so we'll
+    # instead force a failure to connect so we can test its handling.
+    FastlyRails.purge_all('foo', true, 'https://localhost:0/')
+  end
 end

--- a/test/unit/lib/fastly_rails_test.rb
+++ b/test/unit/lib/fastly_rails_test.rb
@@ -37,6 +37,6 @@ class FastlyRailsTest < ActiveSupport::TestCase
     # We set a nonsense localhost base  for this test.
     # VCR can't record "failure to connect", so we'll
     # instead force a failure to connect so we can test its handling.
-    FastlyRails.purge_all('foo', true, 'https://localhost:0/')
+    FastlyRails.purge_all(true, 'https://localhost:0/')
   end
 end


### PR DESCRIPTION
Update `rake fastly:purge_all` to work properly.

We previously had to remove the FastlyRails gem, but
never changed how to do a `purge_all`, so that rake command
no longer works.

This commit re-implements purge_all so that it works again
(and renames it from `purge` to `purge_all` to clarify that
is what it's doing). We must `purge_all` when, for example,
there's a change in how the badges are calculated (so that
recipients will see the new results).

Sadly, due to a limitation of Fastly's API,
we *cannot* do a soft purge, aka "Fastly-Soft-Purge: 1".
A soft purge would let the CDN distribute the cached value
if it couldn't contact the real server. Unfortunately,
Fastly doesn't support soft purges on full purges.

Beware: Do *not* run `purge_all` lightly on real systems.
It will temporarily increase server load, because it flushes
*EVERYTHING* that was cached on Fastly. As a result,
the server will have to provide the cached data.
But when you need it, you need it.

There's some rigging of the test (as we've done with other
Fastly method calls), because we don't want tests to
*actually* contact the Fastly service :-).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>