### PR TITLE
Fix test fixture project percentages

### DIFF
--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -19,11 +19,16 @@ one:
   repo_url: https://www.nasa.gov/pathfinder
   created_at: '2000-01-01'
   updated_at: '2000-01-01'
-  badge_percentage_0: 0
+  # Precalculated
+  badge_percentage_0: 1
   badge_percentage_1: 0
   badge_percentage_2: 0
   tiered_percentage: 0
+  # Criterion 'static_analysis' is 'met_justification_required'.
+  # Thus, even though it's claimed to be "Met", that will NOT count
+  # when we calculate the passing percentage.
   static_analysis_status: Met
+  maintained_status: Met
 
 two:
   user: test_user_melissa
@@ -32,10 +37,12 @@ two:
   homepage_url: https://www.nasa.gov
   license: MIT
   repo_url: https://github.com/ciitest/test-repo
-  badge_percentage_0: 0
+  # Precalculated
+  badge_percentage_0: 1
   badge_percentage_1: 0
   badge_percentage_2: 0
   tiered_percentage: 0
+  maintained_status: Met
 
 no_repo:
   user: test_user
@@ -44,10 +51,12 @@ no_repo:
   homepage_url: https://www.nasa.gov
   license: MIT
   repo_url: ''
-  badge_percentage_0: 0
+  # Precalculated
+  badge_percentage_0: 1
   badge_percentage_1: 0
   badge_percentage_2: 0
   tiered_percentage: 0
+  maintained_status: Met
 
 # TODO: Generate list of status fields from central location.
 # No justifications means failing status.
@@ -58,10 +67,10 @@ perfect_unjustified:
   homepage_url: https://www.example.org
   repo_url: https://github.com/ciitest2/test-repo
   license: MIT
-  badge_percentage_0: 86
-  badge_percentage_1: 0
-  badge_percentage_2: 5
-  tiered_percentage: 86
+  badge_percentage_0: 87
+  badge_percentage_1: 2
+  badge_percentage_2: 4
+  tiered_percentage: 87
 <% Criteria['0'].keys.each do |criterion| %>
   <%= criterion.to_s + '_status' %>: Met
 <% end %>
@@ -71,6 +80,8 @@ perfect_unjustified:
   test_most_status: Unmet
   crypto_certificate_verification_status: Unmet
   build_reproducible_status: '?'
+  bus_factor_status: 'Met'
+  bus_factor_justification: 'See https://github.com/ciitest2/test-repo'
 
 # TODO: Generate list of status fields from central location.
 perfect_passing:
@@ -83,7 +94,7 @@ perfect_passing:
   license: MIT
   badge_percentage_0: 100
   badge_percentage_1: 13
-  badge_percentage_2: 23
+  badge_percentage_2: 22
   tiered_percentage: 113
   achieved_passing_at: 2015-02-15T12:00:00
 <% Criteria['0'].keys.each do |criterion| %>
@@ -102,8 +113,8 @@ perfect_silver:
   license: MIT
   badge_percentage_0: 100
   badge_percentage_1: 100
-  badge_percentage_2: 41
-  tiered_percentage: 241
+  badge_percentage_2: 39
+  tiered_percentage: 239
   achieved_passing_at: 2015-02-15T12:00:00
 <% (Criteria['0'].keys + Criteria['1'].keys).each do |criterion| %>
   <%= criterion.to_s + '_status' %>: Met

--- a/test/integration/recalc_test.rb
+++ b/test/integration/recalc_test.rb
@@ -10,7 +10,7 @@ class RecalcTest < ActionDispatch::IntegrationTest
   test 'Make sure recalc percentages only updates levels specified' do
     project = projects(:one)
     old_percentage = project.badge_percentage_1
-    assert_equal 0, old_percentage, 'Old silver percentage supposed to be 0'
+    assert_equal 0, old_percentage, 'Old silver percentage wrong'
     # Update some columns without triggering percentage calculation
     # or change in updated_at
     assert_no_difference [
@@ -44,8 +44,8 @@ class RecalcTest < ActionDispatch::IntegrationTest
     project = projects(:one)
     old_percentage0 = project.badge_percentage_0
     old_percentage1 = project.badge_percentage_1
-    assert_equal 1, old_percentage0, 'Old passing percentage supposed to be 0'
-    assert_equal 0, old_percentage1, 'Old silver percentage supposed to be 0'
+    assert_equal 1, old_percentage0, 'Old passing percentage wrong'
+    assert_equal 0, old_percentage1, 'Old silver percentage wrong'
     # Update some columns without triggering percentage calculation
     # or change in updated_at
     assert_no_difference [

--- a/test/integration/recalc_test.rb
+++ b/test/integration/recalc_test.rb
@@ -44,7 +44,7 @@ class RecalcTest < ActionDispatch::IntegrationTest
     project = projects(:one)
     old_percentage0 = project.badge_percentage_0
     old_percentage1 = project.badge_percentage_1
-    assert_equal 0, old_percentage0, 'Old passing percentage supposed to be 0'
+    assert_equal 1, old_percentage0, 'Old passing percentage supposed to be 0'
     assert_equal 0, old_percentage1, 'Old silver percentage supposed to be 0'
     # Update some columns without triggering percentage calculation
     # or change in updated_at

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -293,24 +293,16 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 85, p.compute_tiered_percentage
   end
 
-  # If these tests fail, you've probably changed the criteria and
+  # If one of these tests fail, you've probably changed the criteria and
   # haven't changed the fixture values to match. The solution
   # will probably require updating test/fixtures/projects.yml
   test 'Check that fixture percentages are correct' do
-    fixture_projects = projects(
-      :one, :two, :no_repo, :perfect_unjustified, :perfect_passing,
-      :perfect_silver, :perfect
-    )
-    fixture_projects.each do |project|
-      assert_equal project.badge_percentage_0,
-                   project.calculate_badge_percentage('0'),
-                   "Miscalculation level 0 in project #{project.name}"
-      assert_equal project.badge_percentage_1,
-                   project.calculate_badge_percentage('1'),
-                   "Miscalculation level 1 in project #{project.name}"
-      assert_equal project.badge_percentage_2,
-                   project.calculate_badge_percentage('2'),
-                   "Miscalculation level 2 in project #{project.name}"
+    projects.each_entry do |project|
+      Project::LEVEL_IDS.each do |level|
+        assert_equal project["badge_percentage_#{level}"],
+                     project.calculate_badge_percentage(level),
+                     "Miscalculation level #{level} in project #{project.name}"
+      end
     end
   end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -292,5 +292,26 @@ class ProjectTest < ActiveSupport::TestCase
     p.badge_percentage_0 = 85
     assert_equal 85, p.compute_tiered_percentage
   end
+
+  # If these tests fail, you've probably changed the criteria and
+  # haven't changed the fixture values to match. The solution
+  # will probably require updating test/fixtures/projects.yml
+  test 'Check that fixture percentages are correct' do
+    fixture_projects = projects(
+      :one, :two, :no_repo, :perfect_unjustified, :perfect_passing,
+      :perfect_silver, :perfect
+    )
+    fixture_projects.each do |project|
+      assert_equal project.badge_percentage_0,
+                   project.calculate_badge_percentage('0'),
+                   "Miscalculation level 0 in project #{project.name}"
+      assert_equal project.badge_percentage_1,
+                   project.calculate_badge_percentage('1'),
+                   "Miscalculation level 1 in project #{project.name}"
+      assert_equal project.badge_percentage_2,
+                   project.calculate_badge_percentage('2'),
+                   "Miscalculation level 2 in project #{project.name}"
+    end
+  end
 end
 # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
The test fixtures for projects didn't have the correct
percentages; when they were later recalculated to correct
values the result was flapping tests.

This fixes the test fixtures for projects, and adds tests
to specifically detect this kind of problem in the future.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>