### PR TITLE
Eliminate hardcoded list of level IDs

### DIFF
--- a/app/views/static_pages/criteria_stats.html.erb
+++ b/app/views/static_pages/criteria_stats.html.erb
@@ -18,7 +18,7 @@
       <th><%= t '.future' %></th>
     </tr>
     <% previous_criteria = [] # For counting "new this level"
-       ['0', '1', '2'].each do |level| %>
+       Project::LEVEL_IDS.each do |level| %>
       <tr>
         <% future_criteria, active_criteria =
              Criteria[level].values.partition(&:future?) %>


### PR DESCRIPTION
Replace the only case of hardcoded ['0', '1', '2'] with
`Project::LEVEL_IDS`.

*Currently* this doesn't matter, because
we only have 3 level ids (corresponding to passing, silver, & gold).
However, if we ever add additional levels (such platinum), we want
to be able to add that information in very few places, and for the
rest of the code to just automatically work correctly.

To do that, we need to eliminate all hardcoding of level ID lists,
and instead refer to standard value - which is `Project::LEVEL_IDS`
defined in `app/models/project.rb`. I've only found this one case
where we hardcoded values, and it'd be best to fix it now.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>