### PR TITLE
Add rake task "search_user" to simplify GDPR requests

### DIFF
--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -181,12 +181,23 @@ heroku config:set --app production-bestpractices TZ=:/usr/share/zoneinfo/UTC
 
 We have a simple ability for system admins to search for user names
 and user emails, primarily to support GDPR Requests.
-Use as follows
+Use as follows:
 
 ~~~~
-heroku run --app production-bestpractices rake search_name -- 'NAME'
-heroku run --app production-bestpractices rake search_email -- 'EMAIL'
+    heroku run --app production-bestpractices rake search_user -- 'NAME' 'EMAIL'
+    heroku run --app production-bestpractices rake search_name -- 'NAME'
+    heroku run --app production-bestpractices rake search_email -- 'EMAIL'
 ~~~~
+
+Note that `search_user` is a shorthand to search for `NAME` and then for
+`EMAIL`; this is a common case, so it makes sense to do it at once.
+Both the name and email searches are case-insensitive.
+
+The name search is LIKE search, so it will list all database names that
+contain the searched name. That is, a search for `David` will list all
+records that include `David` in the name field. Thus, a name match might
+*not* be the person being searched for. Our goal is to minimize the chance
+of not detecting someone, but double-check before deleting any matches.
 
 ## Security
 

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -807,19 +807,37 @@ task :slow_tests do
   end
 end
 
+# Search for & print matching email address.
+# Presumes we are in a Rails environment
+def real_search_email(email)
+  puts "Searching for email '#{email}'; matching ids and names are:"
+  results = User.where(email: email)
+                .select('id, name, encrypted_email, encrypted_email_iv')
+                .pluck(:id, :name)
+  puts results
+  puts 'End of results.'
+end
+
 # Search for a given user email address.
 desc 'Search for users with given email (for GDPR requests)'
 task search_email: :environment do
   ARGV.shift # Drop rake task name
   ARGV.shift if ARGV[0] == '--' # Skip garbage
-  search_email = ARGV[0]
-  puts "Searching for '#{search_email}'; matching ids and names are:"
-  results = User.where(email: search_email)
+  email = ARGV[0]
+  real_search_email(email)
+  exit(0) # Work around rake
+end
+
+# Search for & print matching name.
+# Presumes we are in a Rails environment
+def real_search_name(name)
+  puts "Searching for name '#{name}' ignoring case; matching ids and names are:"
+  name_downcase = name.downcase
+  results = User.where('lower(name) LIKE ?', "%#{name_downcase}%")
                 .select('id, name, encrypted_email, encrypted_email_iv')
                 .pluck(:id, :name)
   puts results
   puts 'End of results.'
-  exit(0) # Work around rake
 end
 
 # Search for a given user name.
@@ -833,14 +851,21 @@ desc 'Search for users with given case-insensitive name (for GDPR requests)'
 task search_name: :environment do
   ARGV.shift # Drop rake task name
   ARGV.shift if ARGV[0] == '--' # Skip garbage
-  search_name = ARGV[0]
-  search_name_downcase = search_name.downcase
-  puts "Searching for '#{search_name}'; matching ids and names are:"
-  results = User.where('lower(name) LIKE ?', "%#{search_name_downcase}%")
-                .select('id, name, encrypted_email, encrypted_email_iv')
-                .pluck(:id, :name)
-  puts results
-  puts 'End of results.'
+  name = ARGV[0]
+  real_search_name(name)
+  exit(0) # Work around rake
+end
+
+# Search for a given user name AND email address.
+desc 'Search for users with NAME and EMAIL (for GDPR requests)'
+task search_user: :environment do
+  ARGV.shift # Drop rake task name
+  ARGV.shift if ARGV[0] == '--' # Skip garbage
+  name = ARGV[0]
+  email = ARGV[1]
+  real_search_name(name)
+  puts
+  real_search_email(email)
   exit(0) # Work around rake
 end
 


### PR DESCRIPTION
When the LF gets GDPR requests to erase user data, we
must search the CII Best Practices database.

This commit makes searching simpler and faster, by creating a new
`rake search_user NAME EMAIL` command that can search for
*both* name and email in a single command. Most of the time we
get a single name and email address in each request, and it takes
a while to spin up the rake task, so this way we get all the answers
for a single user at once.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>