### PR TITLE
Update gems bullet and minitest-retry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'uglifier', '4.2.0', require: false # Minify JavaScript
 
 group :development, :test do
   gem 'awesome_print', '1.9.2' # Pretty print Ruby objects
-  gem 'bullet', '6.1.3' # Avoid n+1 queries
+  gem 'bullet', '6.1.4' # Avoid n+1 queries
   gem 'bundler-audit', '0.8.0'
   gem 'dotenv-rails', '2.7.6'
   gem 'eslintrb', '2.1.0'
@@ -137,7 +137,7 @@ group :test do
   gem 'capybara-slow_finder_errors', '0.1.5', require: false
   gem 'codecov', '0.5.2', require: false
   gem 'minitest-reporters', '1.4.3', require: false
-  gem 'minitest-retry', '0.2.1', require: false # Avoid Capybara false positives
+  gem 'minitest-retry', '0.2.2', require: false # Avoid Capybara false positives
   # Note: Updating 'rails-controller-testing' to '1.0.5' causes failures
   gem 'rails-controller-testing', '1.0.5' # for `assigns` and `assert_template`
   gem 'selenium-webdriver', '3.142.7', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       railties (>= 3.1)
     bootstrap_form (2.7.0)
     builder (3.2.4)
-    bullet (6.1.3)
+    bullet (6.1.4)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     bundler-audit (0.8.0)
@@ -210,7 +210,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    minitest-retry (0.2.1)
+    minitest-retry (0.2.2)
       minitest (>= 5.0)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.9)
@@ -475,7 +475,7 @@ DEPENDENCIES
   bootstrap-sass (= 3.4.1)
   bootstrap-social-rails (= 4.12.0)
   bootstrap_form (= 2.7.0)
-  bullet (= 6.1.3)
+  bullet (= 6.1.4)
   bundler
   bundler-audit (= 0.8.0)
   capybara-slow_finder_errors (= 0.1.5)
@@ -496,7 +496,7 @@ DEPENDENCIES
   mail (= 2.7.1)
   mdl (= 0.10.0)
   minitest-reporters (= 1.4.3)
-  minitest-retry (= 0.2.1)
+  minitest-retry (= 0.2.2)
   octokit (= 4.18.0)
   omniauth-github (= 1.4.0)
   omniauth-rails_csrf_protection (= 0.1.2)


### PR DESCRIPTION
Update gems bullet (6.1.3->6.1.4) and
minitest-retry (0.2.1->0.2.2).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>