### PR TITLE
Rephrase continuity section with less morbid language

### DIFF
--- a/doc/other.md
+++ b/doc/other.md
@@ -588,7 +588,7 @@ Upgrade some "passing" level SHOULD and SUGGESTED:
 #### Continuity
 
 * <a name="access_continuity"></a>The project MUST be able to continue
-    with minimal interruption if any one person is incapacitated or is
+    with minimal interruption if any one person dies, is incapacitated, or is
     otherwise unable or unwilling to continue support of the project.
     In particular, the project MUST be able to create and close
     issues, accept proposed changes, and release versions of software,

--- a/doc/other.md
+++ b/doc/other.md
@@ -587,17 +587,18 @@ Upgrade some "passing" level SHOULD and SUGGESTED:
 
 #### Continuity
 
-*   <a name="access_continuity"></a>The project MUST be able to continue with
-    minimal interruption if any one person is incapacitated or killed.
-    In particular, the project MUST be able to create and close issues,
-    accept proposed changes, and release versions of software, within a
-    week of confirmation that an individual is incapacitated or killed.
-    This MAY be done by ensuring someone else has any necessary
-    keys, passwords, and legal rights to continue the project.
-    Individuals who run a FLOSS project MAY do this by providing keys in
-    a lockbox and a will providing any needed legal rights
-    (e.g., for DNS names).
-    <sup>[<a href="#access_continuity">access_continuity</a>]</sup>
+* <a name="access_continuity"></a>The project MUST be able to continue
+    with minimal interruption if any one person is incapacitated or is
+    otherwise unable or unwilling to continue support of the project.
+    In particular, the project MUST be able to create and close
+    issues, accept proposed changes, and release versions of software,
+    within a week of confirmation of the loss of support from any one
+    individual.  This MAY be done by ensuring someone else has any
+    necessary keys, passwords, and legal rights to continue the
+    project.  Individuals who run a FLOSS project MAY do this by
+    providing keys in a lockbox and a will providing any needed legal
+    rights (e.g., for DNS names).  <sup>[<a
+    href="#access_continuity">access_continuity</a>]</sup>
 
 *   <a name="bus_factor"></a>The project SHOULD have a "bus factor" of 2 or more.
     <sup>[<a href="#bus_factor">bus_factor</a>]</sup>


### PR DESCRIPTION
The term "killed" is overly specific and morbid, especially since the sentiment here applies to loss of support for any reason, such as someone simply discontinuing involvement with the project.

Signed-off-by: Cary Phillips <cary@ilm.com>