### PR TITLE
Update URL for "Recursive Make Considered Harmful"

### DIFF
--- a/criteria/criteria.yml
+++ b/criteria/criteria.yml
@@ -924,7 +924,7 @@
           met_justification_required: true
           rationale: >
             For more information, see
-            <a href="http://aegis.sourceforge.net/auug97.pdf">"Recursive Make Considered Harmful" by Peter Miller</a>
+            <a href="https://web.archive.org/web/20200209034547/http://aegis.sourceforge.net/auug97.pdf">"Recursive Make Considered Harmful" by Peter Miller</a>
             (note that this incorrect approach can be used in any build system,
             not just <em>make</em>).
             Note that

--- a/doc/nyc-2016.md
+++ b/doc/nyc-2016.md
@@ -89,7 +89,7 @@ the brainstorming session).
   to support it.  This is harder.  We could say, "maximally automate
   dependencies" - but it's hard to measure maximal.  We could say,
   "avoid recursive make", citing
-  ["Recursive Make Considered Harmful" by Peter Miller](http://aegis.sourceforge.net/auug97.pdf).
+  ["Recursive Make Considered Harmful" by Peter Miller](https://web.archive.org/web/20200209034547/http://aegis.sourceforge.net/auug97.pdf).
   Note that
   ["Non-recursive Make Considered Harmful"](http://research.microsoft.com/en-us/um/people/simonpj/papers/ghc-shake/ghc-shake.pdf)
   agrees that recursive make approaches are bad; its argument is that

--- a/doc/other.md
+++ b/doc/other.md
@@ -943,7 +943,7 @@ Upgrade some "passing" level SHOULD and SUGGESTED:
 
     *Rationale*:
     For more information, see
-    <a href="http://aegis.sourceforge.net/auug97.pdf">"Recursive Make Considered Harmful" by Peter Miller</a>
+    <a href="https://web.archive.org/web/20200209034547/http://aegis.sourceforge.net/auug97.pdf">"Recursive Make Considered Harmful" by Peter Miller</a>
     (note that this incorrect approach can be used in any build system,
     not just <i>make</i>).
     Note that


### PR DESCRIPTION
The old URL for Peter Miller's "Recursive Make Considered Harmful"
no longer works. Replace the URL with fixed version provided by
archive.org. Sadly, Peter Miller died on 2014-07-27, but his
good ideas live on.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>