### PR TITLE
Note OpenSSF!

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ as issues or pull (merge) requests.
 There is also a
 [mailing list](https://lists.coreinfrastructure.org/mailman/listinfo/cii-badges)
 for general discussion.
+This project was originally developed under the CII, but it
+is now part of the
+[Open Source Security Foundation (OpenSSF)](https://openssf.org/)
+[Best Practices Working Group (WG)](https://github.com/ossf/wg-best-practices-os-developers).
+
+Interesting pages include:
 
 * Badging **[Criteria for the passing level](https://bestpractices.coreinfrastructure.org/criteria/0)**
 * **[Criteria for all badging levels](https://bestpractices.coreinfrastructure.org/criteria)**

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,8 +125,8 @@ en:
       check_us_out: Check out the CII Best Practices Badge website!
       p1_html: >-
         The <a href="https://www.linuxfoundation.org/">Linux Foundation
-        (LF)</a> <a href="https://www.coreinfrastructure.org/">Core
-        Infrastructure Initiative (CII)</a> Best Practices badge
+        (LF)</a> Core
+        Infrastructure Initiative (CII) Best Practices badge
         is a way for Free/Libre and Open Source Software (FLOSS)
         projects to show that they follow best practices. Projects
         can voluntarily self-certify, at no cost, by using this
@@ -147,6 +147,12 @@ en:
         projects and supports queries (e.g., you can see <a href="/en/projects?gteq=100">projects
         that have a passing badge</a>). You can also see <a href='/en/projects/1/0'>an
         example (where we try to earn our own badge)</a>.
+        This project was originally developed under the CII,
+        but it is now part of the
+        <a href="https://openssf.org/"
+        >Open Source Security Foundation (OpenSSF)</a>
+        <a href="https://github.com/ossf/wg-best-practices-os-developers"
+        Best Practices Working Group (WG)</a>.
       p3_html: >-
         <em>Privacy and legal issues</em>: Please see our <a href="https://www.linuxfoundation.org/privacy">privacy
         policy</a>,


### PR DESCRIPTION
Note that this project is now part of the OpenSSF.
The CII officially has ended, and it's been succeeded by the
Open Source Security Foundation (OpenSSF).

I meant to do this earlier, but in the process of adding information
on the CII website I noticed that this hadn't been done.
So, let's fix it!

For some people this may not *matter*, but it's generally good
to note "where this project fits in" where it's part of
something larger.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>