### PR TITLE
Timestamp rake translation:sync

### DIFF
--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1630604976
+timestamp: 1631285408


### PR DESCRIPTION
Record a timestamp for "rake translation:sync".
When we change English text that is to be translated,
we need to synchronize that with the dataset at transiation.io
so that our translators can translate.
This records the timestamp so that later translation:syncs
will know that our database is synchronized to this date.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>