### PR TITLE
Limit privileges of GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
-# This is a basic workflow to help you get started with Actions
-
+# This is a simple GitHub Actions CI workflow.
 name: CI
+
+# Limit permissions. See:
+# https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
+# Since we set "permissions", anything unset has access "none".
+permissions:
+  contents: read
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch


### PR DESCRIPTION
Limit the privileges granted to our GitHub Action workflow
to just the subset required.

This was flagged by Scorecard. See:
https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

More information about GitHub Actions permissions are here:
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions

This sets "permissions" with a restrictive set of permissions.
Anything unset has access "none" once "permissions" is set.

Hopefully none of the code in GitHub actions is malicious or has
an unintentional vulnerability that can be exploited in this context.
However, it's better to limit privileges so that even if there *is*
a vulnerability, the damage is highly constrained.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>