### PR TITLE
Fix source code formatting per rubocop 1.22.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,6 +88,7 @@ Metrics/ClassLength:
 # Weird failures on this, disabled for now.
 Layout/LineLength:
   Enabled: false
+  # Max: 79
   # Exclude:
   #   - 'db/migrate/*'
 Metrics/MethodLength:

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -12,7 +12,8 @@ class AccountActivationsController < ApplicationController
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def edit
     user = User.find_by(email: params[:email])
-    if user && !user.activated? && user.authenticated?(:activation, params[:id])
+    if user && !user.activated? && user.authenticated?(:activation,
+                                                       params[:id])
       user.can_login_starting_at = Time.zone.now + LOCAL_LOGIN_COOLOFF_TIME
       user.activate # This saves our result
       flash[:success] = t('account_activations.activated') + ' ' +

--- a/app/controllers/badge_static_controller.rb
+++ b/app/controllers/badge_static_controller.rb
@@ -29,8 +29,7 @@ class BadgeStaticController < ApplicationController
     return unless Badge.valid?(value)
 
     set_surrogate_key_header "/badge_percent/#{value}"
-    send_data Badge[value],
-              type: 'image/svg+xml', disposition: 'inline'
+    send_data Badge[value], type: 'image/svg+xml', disposition: 'inline'
     # Our application router now prevents invalid values. Before we did that,
     # we had an "else" clause that sent a 404 by doing this:
     # render(

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -14,7 +14,7 @@ class PasswordResetsController < ApplicationController
   def create
     @user = User.find_by(email: nested_params(:password_reset, :email))
     if @user
-      # Note: We send the password reset to the email address originally
+      # NOTE: We send the password reset to the email address originally
       # created by the *original* user, and *not* to the requester
       # (who may be attacking the original user's account). This prevents
       # attacks where the finding system is "overly generous" and matches

--- a/app/controllers/project_stats_controller.rb
+++ b/app/controllers/project_stats_controller.rb
@@ -31,7 +31,7 @@ class ProjectStatsController < ApplicationController
   # The time, in number of seconds since midnight, when we log
   # project statistics. This is currently 23:30 UTC, set by Heroku scheduler;
   # change this value if you change the time of day we log statistics.
-  LOG_TIME = (23 * 60 + 30) * 60
+  LOG_TIME = ((23 * 60) + 30) * 60
 
   # If the "current time" is within this number of seconds to
   # seconds_since_midnight_log_time, presume that we're about to change
@@ -475,9 +475,7 @@ class ProjectStatsController < ApplicationController
   # rubocop: disable Metrics/MethodLength
   def create_line_chart(fields)
     # Retrieve just the data we need
-    database_fields =
-      [:created_at] +
-      fields.map(&:to_sym)
+    database_fields = [:created_at] + fields.map(&:to_sym)
     stat_data = ProjectStat.select(*database_fields)
 
     dataset = []

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -70,9 +70,7 @@ class ProjectsController < ApplicationController
   # rubocop:disable Metrics/PerceivedComplexity, Metrics/BlockNesting
   def index
     validated_url = set_valid_query_url
-    if validated_url != request.original_url
-      redirect_to validated_url
-    else
+    if validated_url == request.original_url
       retrieve_projects
 
       # Omit useless unchanged session cookie for performance & privacy
@@ -101,6 +99,8 @@ class ProjectsController < ApplicationController
       else
         show_normal_index
       end
+    else
+      redirect_to validated_url
     end
   end
   # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
@@ -341,10 +341,12 @@ class ProjectsController < ApplicationController
   # These are the fields for *projects*; the .recently_updated scope
   # forces loading of user data (where we get the user name/nickname).
   FEED_DISPLAY_FIELDS = 'projects.id as id, projects.name as name, ' \
-    'projects.updated_at as updated_at, projects.created_at as created_at, ' \
-    'tiered_percentage, ' \
-    'badge_percentage_0, badge_percentage_1, badge_percentage_2, ' \
-    'homepage_url, repo_url, description, user_id'
+                        'projects.updated_at as updated_at, ' \
+                        'projects.created_at as created_at, ' \
+                        'tiered_percentage, ' \
+                        'badge_percentage_0, badge_percentage_1, ' \
+                        'badge_percentage_2, ' \
+                        'homepage_url, repo_url, description, user_id'
 
   def feed
     # @projects = Project.select(FEED_DISPLAY_FIELDS).
@@ -652,9 +654,9 @@ class ProjectsController < ApplicationController
   # rubocop:enable Style/MethodCalledOnDoEndBlock, Metrics/MethodLength
 
   HTML_INDEX_FIELDS = 'projects.id, projects.name, description, ' \
-    'homepage_url, repo_url, license, projects.user_id, ' \
-    'achieved_passing_at, projects.updated_at, badge_percentage_0, ' \
-    'tiered_percentage'
+                      'homepage_url, repo_url, license, projects.user_id, ' \
+                      'achieved_passing_at, projects.updated_at, badge_percentage_0, ' \
+                      'tiered_percentage'
 
   # Retrieve project data using the various query parameters.
   # The parameters determine what to select *and* fields to load

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -78,13 +78,12 @@ class SessionsController < ApplicationController
   end
 
   def local_login
-    user = User.find_by provider: 'local',
-                        email: params[:session][:email]
-    if !user&.authenticate(params[:session][:password])
+    user = User.find_by provider: 'local', email: params[:session][:email]
+    if user&.authenticate(params[:session][:password])
+      local_login_procedure(user)
+    else
       flash.now[:danger] = t('sessions.invalid_combo')
       render 'new'
-    else
-      local_login_procedure(user)
     end
   end
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -9,8 +9,7 @@ class StaticPagesController < ApplicationController
 
   # If a page is *invariant* regardless of locale, don't bother
   # to figure out what the locale is.
-  skip_before_action :set_locale_to_best_available,
-                     only: %i[robots]
+  skip_before_action :set_locale_to_best_available, only: %i[robots]
 
   # There's no value in redirecting these pages to a locale,
   # so do *not* redirect them to a URL based on locale.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@
 
 # rubocop: disable Metrics/ClassLength
 class UsersController < ApplicationController
-  # Note: If a "before" filter renders or redirects, the action will not run,
+  # NOTE: If a "before" filter renders or redirects, the action will not run,
   # and other additional filters scheduled to run after it are cancelled.
   # See: http://guides.rubyonrails.org/action_controller_overview.html
   # Require being logged in for "index" to slightly discourage enumeration

--- a/app/helpers/project_stats_helper.rb
+++ b/app/helpers/project_stats_helper.rb
@@ -22,8 +22,8 @@ module ProjectStatsHelper
             time: {
               # Use these ISO 8601 formats so we're language-neutral
               displayFormats: {
-                'day': 'yyyy-MM-dd', 'month': 'yyyy-MM',
-                'second': 'HH:MM:ss'
+                day: 'yyyy-MM-dd', month: 'yyyy-MM',
+                second: 'HH:MM:ss'
               }
             }
           }

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -24,7 +24,7 @@ module UsersHelper
   def avatar_for(user)
     image_tag(
       user.avatar_url, alt: user.name, class: 'avatar', size: '80x80',
-                       'referrerpolicy': 'no-referrer'
+                       referrerpolicy: 'no-referrer'
     )
   end
 end

--- a/app/lib/chief.rb
+++ b/app/lib/chief.rb
@@ -96,8 +96,8 @@ class Chief
   def log_detective_failure(source, e, detective, proposal, data)
     Rails.logger.error do
       'ERROR:: ' \
-      "In method #{source}, exception #{e} on #{detective.class.name}, " \
-      "current_proposal= #{proposal}, current_data= #{data}"
+        "In method #{source}, exception #{e} on #{detective.class.name}, " \
+        "current_proposal= #{proposal}, current_data= #{data}"
     end
   end
 
@@ -153,8 +153,7 @@ class Chief
       # Now add the explanation, if we can.
       next unless key.to_s.end_with?('_status') && data.key?(:explanation)
 
-      justification_key =
-        (key.to_s.chomp('_status') + '_justification').to_sym
+      justification_key = (key.to_s.chomp('_status') + '_justification').to_sym
       if project.attribute_present?(justification_key)
         unless project[justification_key].end_with?(data[:explanation])
           project[justification_key] =

--- a/app/lib/floss_license_detective.rb
+++ b/app/lib/floss_license_detective.rb
@@ -55,14 +55,14 @@ class FlossLicenseDetective < Detective
     'GNU General Public License version 3.0 or later (GPL-3.0-or-later)',
     'GNU Library or "Lesser" General Public License version 2.1 (LGPL-2.1)',
     'GNU Library or "Lesser" General Public License version 2.1 only ' \
-      '(LGPL-2.1-only)',
+    '(LGPL-2.1-only)',
     'GNU Library or "Lesser" General Public License version 2.1 or later ' \
-      '(LGPL-2.1-or-later)',
+    '(LGPL-2.1-or-later)',
     'GNU Library or "Lesser" General Public License version 3.0 (LGPL-3.0)',
     'GNU Library or "Lesser" General Public License version 3.0 only ' \
-      '(LGPL-3.0-only)',
+    '(LGPL-3.0-only)',
     'GNU Library or "Lesser" General Public License version 3.0 or later ' \
-      '(LGPL-3.0-or-later)',
+    '(LGPL-3.0-or-later)',
     'Historical Permission Notice and Disclaimer (HPND)',
     'IBM Public License 1.0 (IPL-1.0)',
     'IPA Font License (IPA)',
@@ -145,15 +145,17 @@ class FlossLicenseDetective < Detective
           {
             value: 'Met', confidence: 5,
             explanation: "The #{license} license is approved by the " \
-                     'Open Source Initiative (OSI).'
+                         'Open Source Initiative (OSI).'
           }
       }
     elsif license.match?(/\A[^(]/)
-      { floss_license_osi_status:
-          {
-            value: 'Unmet', confidence: 1,
-            explanation: '// Did not find license in the OSI list.'
-          } }
+      {
+        floss_license_osi_status:
+                  {
+                    value: 'Unmet', confidence: 1,
+                    explanation: '// Did not find license in the OSI list.'
+                  }
+      }
     else
       # We currently don't handle (...), so don't even guess.
       {}

--- a/app/lib/github_basic_detective.rb
+++ b/app/lib/github_basic_detective.rb
@@ -49,7 +49,7 @@ class GithubBasicDetective < Detective
   }.freeze
 
   EXCLUDE_IMPLEMENTATION_LANGUAGES = [
-    :HTML, :CSS, :Roff, :"DIGITAL Command Language"
+    :HTML, :CSS, :Roff, :'DIGITAL Command Language'
   ].freeze
 
   # Clean up name of license to be like the SPDX display.
@@ -93,24 +93,25 @@ class GithubBasicDetective < Detective
       results[:repo_public_status] = {
         value: 'Met', confidence: 3,
         explanation: 'Repository on GitHub, which provides ' \
-          'public git repositories with URLs.'
+                     'public git repositories with URLs.'
       }
       results[:repo_track_status] = {
         value: 'Met', confidence: 4,
         explanation: 'Repository on GitHub, which uses git. ' \
-          'git can track the changes, ' \
-          'who made them, and when they were made.'
+                     'git can track the changes, ' \
+                     'who made them, and when they were made.'
       }
       results[:repo_distributed_status] = {
         value: 'Met', confidence: 4,
         explanation: 'Repository on GitHub, which uses git. ' \
-          'git is distributed.'
+                     'git is distributed.'
       }
       results[:contribution_status] = {
         value: 'Met', confidence: 2,
         explanation: 'Projects on GitHub by default use issues and ' \
-          'pull requests, as encouraged by documentation such as ' \
-          '<https://guides.github.com/activities/contributing-to-open-source/>.'
+                     'pull requests, as encouraged by documentation such as ' \
+                     '<https://guides.github.com/activities/' \
+                     'contributing-to-open-source/>.'
       }
       results[:discussion_status] = {
         value: 'Met', confidence: 3,

--- a/app/lib/hardened_sites_detective.rb
+++ b/app/lib/hardened_sites_detective.rb
@@ -30,7 +30,7 @@ class HardenedSitesDetective < Detective
     {
       value: 'Unmet', confidence: 5,
       explanation: '// One or more of the required security hardening headers '\
-        'is missing.'
+                   'is missing.'
     }.freeze
   UNMET_NOSNIFF =
     {

--- a/app/lib/how_access_repo_files_detective.rb
+++ b/app/lib/how_access_repo_files_detective.rb
@@ -23,10 +23,13 @@ class HowAccessRepoFilesDetective < Detective
   end
 
   def assemble_result(fullname)
-    { repo_files:
-          {
-            value: GithubContentAccess.new(fullname, @octokit_client_factory),
-            confidence: 5
-          } }
+    {
+      repo_files:
+                {
+                  value: GithubContentAccess.new(fullname,
+                                                 @octokit_client_factory),
+                  confidence: 5
+                }
+    }
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -23,10 +23,10 @@ class ApplicationMailer < ActionMailer::Base
   # we'll store it that way.
   NORMAL_X_SMTPAPI =
     '{ "filters" : { ' \
-       '"clicktrack" : { "settings" : { "enable" : 0 } }, ' \
-       '"ganalytics" : { "settings" : { "enable" : 0 } }, ' \
-       '"subscriptiontrack" : { "settings" : { "enable" : 0 } }, ' \
-       '"opentrack" : { "settings" : { "enable" : 0 } } ' \
+    '"clicktrack" : { "settings" : { "enable" : 0 } }, ' \
+    '"ganalytics" : { "settings" : { "enable" : 0 } }, ' \
+    '"subscriptiontrack" : { "settings" : { "enable" : 0 } }, ' \
+    '"opentrack" : { "settings" : { "enable" : 0 } } ' \
     '} }'
 
   # This forces fast failure on start if NORMAL_X_SMTPAPI is not valid JSON

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -12,7 +12,7 @@ class UserMailer < ApplicationMailer
   # Time in seconds to intentionally delay activation message
   # as a way to counter spammers.
   ACTIVATION_MESSAGE_DELAY_TIME = (
-    ENV['ACTIVATION_MESSAGE_DELAY_TIME'] || 5 * 60
+    ENV['ACTIVATION_MESSAGE_DELAY_TIME'] || (5 * 60)
   ).to_i
 
   # Compute and return the new X-SMTPAPI header value to cause a send delay.

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -105,7 +105,8 @@ class Badge
   # rubocop:disable Metrics/AbcSize
   def badge_svg(specs, percentage)
     color = specs[:color] ||
-            '#' + Paleta::Color.new(:hsl, percentage * 0.45 + 15, 85, 43).hex
+            ('#' + Paleta::Color.new(:hsl, (percentage * 0.45) + 15, 85,
+                                     43).hex)
     text = percentage ? specs[:text] + " #{percentage}%" : specs[:text]
     <<-BADGE_AS_SVG.squish
     <svg xmlns="http://www.w3.org/2000/svg" width="#{specs[:width]}"

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -159,12 +159,9 @@ class Project < ApplicationRecord
 
   # For these fields we'll have just simple validation rules.
   # We'll rely on Rails' HTML escaping system to counter XSS.
-  validates :name, length: { maximum: MAX_SHORT_STRING_LENGTH },
-                   text: true
-  validates :description, length: { maximum: MAX_TEXT_LENGTH },
-                          text: true
-  validates :license, length: { maximum: MAX_SHORT_STRING_LENGTH },
-                      text: true
+  validates :name, length: { maximum: MAX_SHORT_STRING_LENGTH }, text: true
+  validates :description, length: { maximum: MAX_TEXT_LENGTH }, text: true
+  validates :license, length: { maximum: MAX_SHORT_STRING_LENGTH }, text: true
   validates :general_comments, text: true
 
   # We'll do automated analysis on these URLs, which means we will *download*

--- a/app/models/project_stat.rb
+++ b/app/models/project_stat.rb
@@ -25,7 +25,7 @@ class ProjectStat < ApplicationRecord
   end.freeze
   # rubocop:enable Style/MethodCalledOnDoEndBlock
 
-  # Note: The constants below are for clarity.  Don't just change them,
+  # NOTE: The constants below are for clarity.  Don't just change them,
   # or trend lines will be recording different cutoffs.
   # See below for their meaning.
   REACTIVATION_PERIOD = 14 # number of days from reminder to update.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,17 +42,21 @@ class User < ApplicationRecord
 
   # Email addresses are stored as encrypted values.
   # If a key isn't provided, use a bogus one to make testing easy.
-  attr_encrypted :email, algorithm: 'aes-256-gcm', key: [(
-    ENV['EMAIL_ENCRYPTION_KEY'] || TEST_EMAIL_ENCRYPTION_KEY
-  )].pack('H*')
+  attr_encrypted :email, algorithm: 'aes-256-gcm', key: [
+    (
+        ENV['EMAIL_ENCRYPTION_KEY'] || TEST_EMAIL_ENCRYPTION_KEY
+      )
+  ].pack('H*')
 
   # Email addresses are indexed as blind indexes of downcased email addresses,
   # so we can efficiently search for them while keeping them encrypted.
   # Usage: User.where(email: 'test@example.org')
   # or:    User.where(email: 'test@example.org', provider: 'local')
-  blind_index :email, key: [(
-    ENV['EMAIL_BLIND_INDEX_KEY'] || TEST_EMAIL_BLIND_INDEX_KEY
-  )].pack('H*'), expression: ->(v) { v.try(:downcase) }
+  blind_index :email, key: [
+    (
+        ENV['EMAIL_BLIND_INDEX_KEY'] || TEST_EMAIL_BLIND_INDEX_KEY
+      )
+  ].pack('H*'), expression: ->(v) { v.try(:downcase) }
 
   scope :created_since, (
     lambda do |time|

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -47,12 +47,12 @@ class UrlValidator < ActiveModel::EachValidator
 
   # Return true if URL matches URL_REGEX and its decoding is valid UTF-8.
   def url_acceptable?(value)
-    if !URL_REGEX.match?(value)
-      false
-    else
+    if URL_REGEX.match?(value)
       # The unescapes the *entire* URL, but that's okay because we've
       # already confirmed that the domain name doesn't have "%"
       unescape_unforced(value).force_encoding('UTF-8').valid_encoding?
+    else
+      false
     end
   end
 

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -113,7 +113,7 @@ CORS_UNDIFFERENTIATED_RESOURCE_PATTERNS = [
 ].freeze
 CORS_UNDIFFERENTIATED_VARY = ['Accept-Encoding'].freeze
 
-# Note: "Vary: Accept-Encoding" will still happen, but Fastly CDN
+# NOTE: "Vary: Accept-Encoding" will still happen, but Fastly CDN
 # normalizes this to one of a few values per:
 # https://docs.fastly.com/en/guides/enabling-automatic-gzipping
 # As a result, "Vary: Accept-Encoding" does *not* significantly impede

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -23,7 +23,10 @@ SecureHeaders::Configuration.default do |config|
   config.csp = {
     # Control information sources
     default_src: normal_src,
-    img_src: ['secure.gravatar.com', 'avatars.githubusercontent.com', "'self'"],
+    img_src: [
+      'secure.gravatar.com', 'avatars.githubusercontent.com',
+      "'self'"
+    ],
     object_src: ["'none'"],
     script_src: normal_src,
     style_src: normal_src,

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -10,7 +10,8 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }.to_i
+threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+                   .to_i
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is

--- a/doc/send-translations.rb
+++ b/doc/send-translations.rb
@@ -128,7 +128,7 @@ def change_translation(id, new_value)
   return true unless $REAL
 
   new_value_json = { 'target' => new_value }.to_json
-  # Note: This popen invocation does NOT go through the shell,
+  # NOTE: This popen invocation does NOT go through the shell,
   # so we do not use shell escapes.
   IO.popen(
     [
@@ -159,7 +159,7 @@ def post_translation(key, lang, source, new_value)
     'source' => source,
     'target' => new_value
   }.to_json
-  # Note: This popen invocation does NOT go through the shell,
+  # NOTE: This popen invocation does NOT go through the shell,
   # so we do not use shell escapes.
   # POST https://translation.io/api/v1/segments(.json)
   IO.popen(

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -65,7 +65,7 @@ end
 desc 'Run rails_best_practices with options'
 task :rails_best_practices do
   sh 'bundle exec rails_best_practices ' \
-      '--features --spec --without-color --exclude railroader/'
+     '--features --spec --without-color --exclude railroader/'
 end
 
 desc 'Setup railroader if needed'
@@ -94,7 +94,7 @@ task :bundle do
   sh 'bundle check || bundle install'
 end
 
-# Note: We've had some trouble with bundle doctor, so it might
+# NOTE: We've had some trouble with bundle doctor, so it might
 # not be run by default.
 desc 'Run bundle doctor - check for some Ruby gem configuration problems'
 task :bundle_doctor do
@@ -146,7 +146,7 @@ task :bundle_audit do
 end
 # rubocop: enable Metrics/BlockLength
 
-# Note: If you don't want mdl to be run on a markdown file, rename it to
+# NOTE: If you don't want mdl to be run on a markdown file, rename it to
 # end in ".markdown" instead.  (E.g., for markdown fragments.)
 desc 'Run markdownlint (mdl) - check for markdown problems on **.md files'
 task :markdownlint do
@@ -404,6 +404,7 @@ task :fake_production do
   sh 'RAILS_ENV=fake_production rails server -p 4000'
 end
 
+# rubocop:disable Metrics/MethodLength
 def normalize_values(input, locale)
   # The destination locale is "locale".
   input.transform_values! do |value|
@@ -413,10 +414,12 @@ def normalize_values(input, locale)
       normalize_string value, locale
     elsif value.is_a?(NilClass)
       value
-    else raise TypeError 'Not Hash, String or NilClass'
+    else
+      raise TypeError 'Not Hash, String or NilClass'
     end
   end
 end
+# rubocop:enable Metrics/MethodLength
 
 # rubocop:disable Metrics/MethodLength
 def normalize_string(value, locale)
@@ -453,9 +456,7 @@ def normalize_yaml(path)
     # Compute locale from filename (it must be before the last period)
     locale = filename.split('.')[-2]
     normalized = normalize_values(YAML.load_file(filename), locale)
-    IO.write(
-      filename, normalized.to_yaml(line_width: 60).gsub(/\s+$/, '')
-    )
+    IO.write(filename, normalized.to_yaml(line_width: 60).gsub(/\s+$/, ''))
   end
 end
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -61,7 +61,8 @@ Capybara.server = :puma, { Silent: true }
 # https://medium.com/@john200Ok/running-rails-6-system-tests-using-chrome-headless-and-selenium-on-gitlab-ci-9b4de5cafcd0
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400] do |option|
+  driven_by :selenium, using: :headless_chrome,
+screen_size: [1400, 1400] do |option|
     option.add_argument('no-sandbox')
   end
 end

--- a/test/controllers/project_stats_controller_test.rb
+++ b/test/controllers/project_stats_controller_test.rb
@@ -250,7 +250,7 @@ class ProjectStatsControllerTest < ActionDispatch::IntegrationTest
     # Ensure that cache_time() produces correct answers
     controller = ProjectStatsController.new
     # We'll presume that logs are sent at 23:30 daily
-    log_time = (23 * 60 + 30) * 60
+    log_time = ((23 * 60) + 30) * 60
     assert_equal 120, controller.cache_time(log_time - 70)
     assert_equal 120, controller.cache_time(log_time + 70)
     assert_equal log_time, controller.cache_time(0)

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -184,8 +184,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   # that it has STOPPED working once we've removed that functionality.
   # We have documented this deprecation in doc/api.md.
   test 'should project JSON data if HTTP header Accept: application/json ' do
-    get "/en/projects/#{@project.id}",
-        headers: { 'Accept': 'application/json' }
+    get "/en/projects/#{@project.id}", headers: { Accept: 'application/json' }
     assert_response :success
     # The JSON looks like {...} and has "id", while the HTML does not.
     assert_equal '{', response.body[0]
@@ -419,7 +418,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should fail to update project if not logged in' do
-    # Note: no log_in_as
+    # NOTE: no log_in_as
     old_name = @project.name
     new_name = old_name + '_updated'
     # Run patch (the point of the test), which invokes the 'update' method
@@ -446,9 +445,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       homepage_url: 'example.org' # bad url
     }
     # Run patch (the point of the test), which invokes the 'update' method
-    patch "/en/projects/#{@project.id}", params: {
-      project: new_project_data
-    }
+    patch "/en/projects/#{@project.id}", params: { project: new_project_data }
     # "Success" here only in the HTTP sense - we *do* get a form...
     assert_response :success
     # ... but we just get the edit form.
@@ -474,17 +471,13 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       lock_version: @project.lock_version
     }
     log_in_as(@project.user)
-    patch "/en/projects/#{@project.id}", params: {
-      project: new_project_data1
-    }
+    patch "/en/projects/#{@project.id}", params: { project: new_project_data1 }
     assert_redirected_to project_path(@project, locale: :en)
     get "/en/projects/#{@project.id}/edit"
     assert_includes @response.body, 'Edit Project Badge Status'
     assert_includes @response.body, new_name1
     assert_not_includes @response.body, new_name2
-    patch "/en/projects/#{@project.id}", params: {
-      project: new_project_data2
-    }
+    patch "/en/projects/#{@project.id}", params: { project: new_project_data2 }
     assert_includes flash['danger'],
                     'Another user has made a change to that record ' \
                     'since you accessed the edit form.'
@@ -565,7 +558,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
   test 'CORS Cannot evade /badge match with /badge.json/..' do
     get "/projects/#{@perfect_passing_project.id}/badge.json/..",
-        headers: { 'Origin': 'example.com' }
+        headers: { Origin: 'example.com' }
     assert_response :not_found
     assert_equal 'Accept-Encoding, Origin', @response.headers['Vary']
     assert_equal '*', @response.headers['Access-Control-Allow-Origin']
@@ -573,7 +566,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
   test 'Cannot evade /badge match with /projects/NUM/../badge.json' do
     get "/projects/#{@perfect_passing_project.id}/../badge.json",
-        headers: { 'Origin': 'example.com' }
+        headers: { Origin: 'example.com' }
     assert_response :not_found
     # We don't really care about these for a "not found":
     # assert_equal 'Accept-Encoding', @response.headers['Vary']
@@ -586,7 +579,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
         params: { format: 'svg' }
     assert_response :success
     assert_equal contents('badge-passing.svg'), @response.body
-    # Note: Requestors MUST use the ".json"
+    # NOTE: Requestors MUST use the ".json"
     # suffix to requst the data in JSON format
     # (and NOT use the HTTP Accept header to try to select the output format).
     # Therefore we don't need to include "Accept" as part of "Vary".
@@ -597,7 +590,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
   test 'A perfect passing project requested with CORS' do
     get "/en/projects/#{@project.id}/badge.json",
-        headers: { 'Origin': 'example.com' }
+        headers: { Origin: 'example.com' }
     assert_equal 'Accept-Encoding', @response.headers['Vary']
   end
 
@@ -695,7 +688,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should NOT destroy own project if rationale too short' do
     log_in_as(@project.user)
-    assert_no_difference('Project.count', ActionMailer::Base.deliveries.size) do
+    assert_no_difference('Project.count',
+                         ActionMailer::Base.deliveries.size) do
       delete "/en/projects/#{@project.id}",
              params: { deletion_rationale: 'Nah.' }
     end
@@ -705,7 +699,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should NOT destroy own project if rationale has few non-whitespace' do
     log_in_as(@project.user)
-    assert_no_difference('Project.count', ActionMailer::Base.deliveries.size) do
+    assert_no_difference('Project.count',
+                         ActionMailer::Base.deliveries.size) do
       delete "/en/projects/#{@project.id}",
              params: { deletion_rationale: ' x y ' + ("\n" * 30) }
     end
@@ -729,14 +724,16 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     log_in_as(@user2, password: 'password1')
     # Verify that we are actually logged in
     assert_equal @user2.id, session[:user_id]
-    assert_no_difference('Project.count', ActionMailer::Base.deliveries.size) do
+    assert_no_difference('Project.count',
+                         ActionMailer::Base.deliveries.size) do
       delete "/en/projects/#{@project.id}" # calls controller method "destroy"
     end
   end
 
   test 'should not destroy project if not logged in' do
     # Notice that we do *not* call log_in_as.
-    assert_no_difference('Project.count', ActionMailer::Base.deliveries.size) do
+    assert_no_difference('Project.count',
+                         ActionMailer::Base.deliveries.size) do
       delete "/en/projects/#{@project.id}" # calls controller method "destroy"
     end
   end
@@ -795,8 +792,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'update', @project_two.versions.last.event
     assert_equal @project_two.user.id,
                  @project_two.versions.last.whodunnit.to_i
-    assert_equal old_repo_url,
-                 @project_two.versions.last.reify.repo_url
+    assert_equal old_repo_url, @project_two.versions.last.reify.repo_url
   end
 
   test 'admin can change other users non-blank repo_url' do

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -6,7 +6,7 @@
 
 require 'test_helper'
 
-# Note: we inherit from ActionDispatch::IntegrationTest, not
+# NOTE: we inherit from ActionDispatch::IntegrationTest, not
 # ActionController::TestCase, because the latter is obsolete.
 # rubocop: disable Metrics/BlockLength, Metrics/ClassLength
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -60,8 +60,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get "/en/users/#{@admin.id}"
     assert_response :success
     assert I18n.t('users.show.is_admin').present?
-    assert_includes @response.body,
-                    I18n.t('users.show.is_admin')
+    assert_includes @response.body, I18n.t('users.show.is_admin')
   end
 
   test 'do NOT indicate non-admin is admin to admin' do
@@ -69,24 +68,21 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     log_in_as(@admin)
     get "/en/users/#{@user.id}"
     assert_response :success
-    assert_not_includes @response.body,
-                        I18n.t('users.show.is_admin')
+    assert_not_includes @response.body, I18n.t('users.show.is_admin')
   end
 
   test 'do NOT indicate admin is admin to non-admin' do
     log_in_as(@user, password: 'password1')
     get "/en/users/#{@user.id}"
     assert_response :success
-    assert_not_includes @response.body,
-                        I18n.t('users.show.is_admin')
+    assert_not_includes @response.body, I18n.t('users.show.is_admin')
   end
 
   test 'do NOT indicate admin is admin if not logged in' do
     # No log_in_as
     get "/en/users/#{@user.id}"
     assert_response :success
-    assert_not_includes @response.body,
-                        I18n.t('users.show.is_admin')
+    assert_not_includes @response.body, I18n.t('users.show.is_admin')
   end
 
   test 'should NOT show email address when not logged in' do
@@ -171,7 +167,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can create local user' do
-    # Note: We don't rate limit *creating* a local user, but we have
+    # NOTE: We don't rate limit *creating* a local user, but we have
     # additional requirements for actual *activation* of local user accounts.
     VCR.use_cassette('can_create_local_user') do
       # This will produce a "create" call on the controller
@@ -324,8 +320,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to user_path(id: @user.id)
     follow_redirect!
-    my_assert_select '.alert-danger',
-                     'Cannot delete a user who owns projects.'
+    my_assert_select '.alert-danger', 'Cannot delete a user who owns projects.'
   end
 
   test 'admin should be able to destroy self without projects' do

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -40,10 +40,8 @@ class SessionsHelperTest < ActionView::TestCase
 
   # Unit test.  There are tricky cases, so try various forms
   test 'check force_locale_url' do
-    assert_equal 'https://a.b.c/',
-                 force_locale_url('https://a.b.c/', nil)
-    assert_equal 'https://a.b.c/',
-                 force_locale_url('https://a.b.c', nil)
+    assert_equal 'https://a.b.c/', force_locale_url('https://a.b.c/', nil)
+    assert_equal 'https://a.b.c/', force_locale_url('https://a.b.c', nil)
     assert_equal 'https://a.b.c/fr', force_locale_url('https://a.b.c/', :fr)
     assert_equal 'https://a.b.c/fr', force_locale_url('https://a.b.c', :fr)
     assert_equal 'https://a.b.c/en',
@@ -77,6 +75,7 @@ class SessionsHelperTest < ActionView::TestCase
       @pull = pull
     end
   end
+
   class StubOctokitResult
     attr_reader :permissions
 
@@ -84,6 +83,7 @@ class SessionsHelperTest < ActionView::TestCase
       @permissions = StubOctokitPermissions.new(admin, push, pull)
     end
   end
+
   class StubOctokitClient
     def initialize(**params); end
 
@@ -122,8 +122,7 @@ class SessionsHelperTest < ActionView::TestCase
   end
 
   test 'unit test of get_gethub_owner' do
-    assert_equal 'ciitest',
-                 get_github_owner('https://github.com/ciitest/1234')
+    assert_equal 'ciitest', get_github_owner('https://github.com/ciitest/1234')
     assert_equal 'asdf-123',
                  get_github_owner('https://github.com/asdf-123/456')
     assert_equal 'ciitest2',

--- a/test/integration/project_get_test.rb
+++ b/test/integration/project_get_test.rb
@@ -47,22 +47,13 @@ class ProjectGetTest < ActionDispatch::IntegrationTest
       'no-referrer-when-downgrade',
       @response.headers['Referrer-Policy']
     )
-    assert_equal(
-      'nosniff',
-      @response.headers['X-Content-Type-Options']
-    )
-    assert_equal(
-      'DENY',
-      @response.headers['X-Frame-Options']
-    )
+    assert_equal('nosniff', @response.headers['X-Content-Type-Options'])
+    assert_equal('DENY', @response.headers['X-Frame-Options'])
     assert_equal(
       'none',
       @response.headers['X-Permitted-Cross-Domain-Policies']
     )
-    assert_equal(
-      '1; mode=block',
-      @response.headers['X-XSS-Protection']
-    )
+    assert_equal('1; mode=block', @response.headers['X-XSS-Protection'])
     # Check warning on development system
     assert_match 'This is not the production system', response.body
 

--- a/test/integration/recalc_test.rb
+++ b/test/integration/recalc_test.rb
@@ -87,6 +87,8 @@ class RecalcTest < ActionDispatch::IntegrationTest
   end
 
   test 'Raises ArgumentError' do
-    assert_raises(ArgumentError) { Project.update_all_badge_percentages(['3']) }
+    assert_raises(ArgumentError) do
+      Project.update_all_badge_percentages(['3'])
+    end
   end
 end

--- a/test/integration/translation_test.rb
+++ b/test/integration/translation_test.rb
@@ -46,7 +46,7 @@ class TranslationTest < ActionDispatch::IntegrationTest
   end
 
   test 'Correctly redirect to browser default locale at root' do
-    get '/', headers: { 'HTTP_ACCEPT_LANGUAGE': 'fr,en-US;q=0.7,en;q=0.3' }
+    get '/', headers: { HTTP_ACCEPT_LANGUAGE: 'fr,en-US;q=0.7,en;q=0.3' }
     assert_redirected_to root_url(locale: :fr)
   end
 
@@ -56,24 +56,24 @@ class TranslationTest < ActionDispatch::IntegrationTest
   end
 
   test 'Do not switch locale if German given' do
-    get '/de', headers: { 'HTTP_ACCEPT_LANGUAGE': 'fr,en-US;q=0.7,en;q=0.3' }
+    get '/de', headers: { HTTP_ACCEPT_LANGUAGE: 'fr,en-US;q=0.7,en;q=0.3' }
     assert_response :success
   end
 
   test 'Do not switch locale if English given' do
-    get '/en', headers: { 'HTTP_ACCEPT_LANGUAGE': 'fr,en-US;q=0.7,en;q=0.3' }
+    get '/en', headers: { HTTP_ACCEPT_LANGUAGE: 'fr,en-US;q=0.7,en;q=0.3' }
     assert_response :success
   end
 
   test 'Correctly switch to browser default locale in /projects' do
     get '/projects',
-        headers: { 'HTTP_ACCEPT_LANGUAGE': 'fr,en-US;q=0.7,en;q=0.3' }
+        headers: { HTTP_ACCEPT_LANGUAGE: 'fr,en-US;q=0.7,en;q=0.3' }
     assert_redirected_to projects_url(locale: :fr)
   end
 
   test 'Do not switch locale of /projects if one given' do
     get '/de/projects',
-        headers: { 'HTTP_ACCEPT_LANGUAGE': 'fr,en-US;q=0.7,en;q=0.3' }
+        headers: { HTTP_ACCEPT_LANGUAGE: 'fr,en-US;q=0.7,en;q=0.3' }
     assert_response :success
   end
 end

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -15,12 +15,14 @@ class UsersEditTest < ActionDispatch::IntegrationTest
     log_in_as(@user)
     get edit_user_path(@user)
     assert_template 'users/edit'
-    patch user_path(@user), params: { user: {
-      name:  '',
-      email: 'foo@invalid',
-      password:              '',
-      password_confirmation: ''
-    } }
+    patch user_path(@user), params: {
+      user: {
+        name:  '',
+            email: 'foo@invalid',
+            password:              '',
+            password_confirmation: ''
+      }
+    }
     assert_template 'users/edit'
   end
 
@@ -28,12 +30,14 @@ class UsersEditTest < ActionDispatch::IntegrationTest
     log_in_as(@user)
     get edit_user_path(@user)
     assert_template 'users/edit'
-    patch user_path(@user), params: { user: {
-      name:  '',
-      email: '',
-      password:              'password',
-      password_confirmation: 'password'
-    } }
+    patch user_path(@user), params: {
+      user: {
+        name:  '',
+            email: '',
+            password:              'password',
+            password_confirmation: 'password'
+      }
+    }
     assert_template 'users/edit'
   end
 
@@ -45,12 +49,14 @@ class UsersEditTest < ActionDispatch::IntegrationTest
     name  = 'Foo Bar'
     email = 'foo@bar.com'
     VCR.use_cassette('successful_edit_-_name_email') do
-      patch user_path(@user), params: { user: {
-        name:  name,
-        email: email,
-        password:              '',
-        password_confirmation: ''
-      } }
+      patch user_path(@user), params: {
+        user: {
+          name:  name,
+                email: email,
+                password:              '',
+                password_confirmation: ''
+        }
+      }
     end
     assert_not flash.empty?
     assert_redirected_to @user
@@ -78,12 +84,14 @@ class UsersEditTest < ActionDispatch::IntegrationTest
     name  = 'Foo Bar'
     email = 'foo@bar.com'
     VCR.use_cassette('successful_edit_-_password') do
-      patch user_path(@user), params: { user: {
-        name:  name,
-        email: email,
-        password:              'Agoodp@$$word',
-        password_confirmation: 'Agoodp@$$word'
-      } }
+      patch user_path(@user), params: {
+        user: {
+          name:  name,
+                email: email,
+                password:              'Agoodp@$$word',
+                password_confirmation: 'Agoodp@$$word'
+        }
+      }
     end
     assert_not flash.empty?
     assert_redirected_to @user

--- a/test/integration/users_manipulate_project_test.rb
+++ b/test/integration/users_manipulate_project_test.rb
@@ -74,10 +74,7 @@ class UsersManipulateProjectTest < ActionDispatch::IntegrationTest
 
       # Check that returned settings are correct.
       # Note: You can use byebug... css_select to interactively check things.
-      assert_select(
-        +'#project_name[value=?]',
-        'best-practices-badge'
-      )
+      assert_select(+'#project_name[value=?]', 'best-practices-badge')
       assert_select '#project_discussion_status_met[checked]'
       assert_select '#project_contribution_status_met[checked]'
       assert_select '#project_floss_license_status_met[checked]'

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -115,15 +115,18 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
   end
   # rubocop: enable Metrics/BlockLength
 
+  # rubocop: disable Metrics/BlockLength
   test 'resend account activation for unactivated account' do
     VCR.use_cassette('resend_account_activation_for_unactivated_account') do
       get signup_path
-      login_params = { user: {
-        name: 'Example User',
-        email: 'user@example.com',
-        password:              'a-g00d!Xpassword',
-        password_confirmation: 'a-g00d!Xpassword'
-      } }
+      login_params = {
+        user: {
+          name: 'Example User',
+                email: 'user@example.com',
+                password:              'a-g00d!Xpassword',
+                password_confirmation: 'a-g00d!Xpassword'
+        }
+      }
       assert_difference 'User.count', 1 do
         post users_path, params: login_params
       end
@@ -135,13 +138,15 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
       user = assigns(:user)
       assert_not user.activated?
       # Valid activation token
-      get edit_account_activation_path(user.activation_token, email: user.email)
+      get edit_account_activation_path(user.activation_token,
+                                       email: user.email)
       assert user.reload.activated?
       follow_redirect!
       assert_template 'sessions/new'
       assert_not user_logged_in?
     end
   end
+  # rubocop: enable Metrics/BlockLength
 
   test 'redirect activated user to login' do
     @user = users(:test_user)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -74,28 +74,28 @@ class ProjectTest < ActiveSupport::TestCase
 
     # Accept U+0020 (space) and U+00E9 c3 a9 "LATIN SMALL LETTER E WITH ACUTE"
     assert validator.url_acceptable?('https://github.com/linuxfoundation/' \
-                                    'cii-best-practices-badge%20%c3%a9')
+                                     'cii-best-practices-badge%20%c3%a9')
     # Accept U+8C0A Unicode Han Character 'friendship; appropriate, suitable'
     # encoded in UTF-8 as 0xE8 0xB0 0x8A (e8b08a); see
     # http://www.fileformat.info/info/unicode/char/8c0a/index.htm
     assert validator.url_acceptable?('https://github.com/linuxfoundation/' \
-                                    '%E8%B0%8A')
+                                     '%E8%B0%8A')
     # Accept U+1000 Unicode Character 'MYANMAR LETTER KA'
     # encoded in UTF-8 as 0xE1 0x80 0x80
     # http://www.fileformat.info/info/unicode/char/1000/index.htm
     assert validator.url_acceptable?('https://github.com/linuxfoundation/' \
-                                    '%e1%80%80')
+                                     '%e1%80%80')
     # Don't accept "c0 80", an overlong (2-byte) encoding of U+0000 (NUL).
     # Note that "modified UTF-8" does accept this.
     assert_not validator.url_acceptable?('https://github.com/linuxfoundation/' \
-                                    'cii-best-practices-badge%20%c0%80')
+                                         'cii-best-practices-badge%20%c0%80')
     # Don't accept non-UTF-8, even if the individual bytes are acceptable.
     assert_not validator.url_acceptable?('https://github.com/linuxfoundation/' \
-                                    'cii-best-practices-badge%eex')
+                                         'cii-best-practices-badge%eex')
     assert_not validator.url_acceptable?('https://github.com/linuxfoundation/' \
-                                    'cii-best-practices-badge%ee')
+                                         'cii-best-practices-badge%ee')
     assert_not validator.url_acceptable?('https://github.com/linuxfoundation/' \
-                                    'cii-best-practices-badge%ff%ff')
+                                         'cii-best-practices-badge%ff%ff')
   end
   # rubocop:enable Metrics/BlockLength
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -36,7 +36,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'email should not be too long' do
-    @user.email = 'e' * 250 + '@mail.com'
+    @user.email = ('e' * 250) + '@mail.com'
     assert_not @user.valid?
   end
 
@@ -161,7 +161,8 @@ class UserTest < ActiveSupport::TestCase
     User.find_each do |user|
       # puts(user.name)
       assert user.name.present?, "Empty name for #{user.id}"
-      assert user.encrypted_email.present?, "Email not present for #{user.name}"
+      assert user.encrypted_email.present?,
+             "Email not present for #{user.name}"
       assert(
         user.encrypted_email_iv.present?,
         "Email IV not present for #{user.name}"

--- a/test/system/github_project_test.rb
+++ b/test/system/github_project_test.rb
@@ -52,8 +52,7 @@ class GithubProjectTest < ApplicationSystemTestCase
       assert has_no_selector?(
         "option[value='https://github.com/ciitest2/test-repo-shared']"
       )
-      select 'ciitest/cii-best-practices-badge',
-             from: 'project[repo_url]'
+      select 'ciitest/cii-best-practices-badge', from: 'project[repo_url]'
       click_on 'Submit GitHub Repository'
       assert has_content? 'Thanks for adding the Project! Please fill out ' \
                           'the rest of the information to get the Badge.'

--- a/test/system/login_test.rb
+++ b/test/system/login_test.rb
@@ -48,7 +48,7 @@ class LoginTest < ApplicationSystemTestCase
     visit projects_path(locale: :en)
     click_on 'Login'
     fill_in 'Email', with: @user.email
-    # Note: we do NOT fill in a password.
+    # NOTE: we do NOT fill in a password.
     click_button 'Log in using custom account'
     assert has_content? 'Invalid email/password combination'
     assert_equal login_path(locale: :en), current_path
@@ -73,8 +73,7 @@ class LoginTest < ApplicationSystemTestCase
     fill_in 'project_name', with: 'It doesnt matter'
     # Below we are clicking the final save button, it has a value of ''
     click_button('Save', exact: true)
-    assert_equal edit_project_path(@project, locale: :en),
-                 current_path
+    assert_equal edit_project_path(@project, locale: :en), current_path
     assert has_content? 'Project was successfully updated.'
     # TODO: Get the clicking working again with capybara.
     # Details: If we expand all panels first and dont click this test passes.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -234,8 +234,7 @@ module ActiveSupport
       github_login_vcr_file = "test/vcr_cassettes/#{cassette}.yml"
       return Null unless File.exist?(github_login_vcr_file)
 
-      y = YAML.load_file(github_login_vcr_file)
-              .with_indifferent_access
+      y = YAML.load_file(github_login_vcr_file).with_indifferent_access
       query_string = y[:http_interactions][0][:response][:body][:string]
       Rack::Utils.parse_nested_query(query_string)['access_token']
     end

--- a/test/unit/lib/build_detective_test.rb
+++ b/test/unit/lib/build_detective_test.rb
@@ -15,9 +15,7 @@ class BuildDetectiveTest < ActiveSupport::TestCase
   end
 
   test 'Build' do
-    results = BuildDetective.new.analyze(
-      @evidence, repo_url: @repo_url
-    )
+    results = BuildDetective.new.analyze(@evidence, repo_url: @repo_url)
     assert results == {}
   end
 end

--- a/test/unit/lib/github_basic_detective_test.rb
+++ b/test/unit/lib/github_basic_detective_test.rb
@@ -45,10 +45,10 @@ class GithubBasicDetectiveTest < ActiveSupport::TestCase
       # We need to use the older hash syntax to spell some names
       # rubocop:disable Style/HashSyntax
       assert_equal 'C++, C', detective.language_cleanup( # actually sorts
-        C: 1000, :"C++" => 5000
+        C: 1000, :'C++' => 5000
       )
       assert_equal 'C#, JavaScript', detective.language_cleanup(
-        HTML: 1000, :"C#" => 5000, JavaScript: 800
+        HTML: 1000, :'C#' => 5000, JavaScript: 800
       )
       # This is the list from https://api.github.com/repos/
       # assimilation/assimilation-official/languages
@@ -57,9 +57,9 @@ class GithubBasicDetectiveTest < ActiveSupport::TestCase
                      Python: 1_151_127,
                      C: 1_059_779,
                      Shell: 285_358,
-                     :"C++" => 44_086,
+                     :'C++' => 44_086,
                      CMake: 33_855,
-                     :"C#" => 29_834,
+                     :'C#' => 29_834,
                      HTML: 2_290,
                      Ruby: 1_359
                    )

--- a/test/unit/lib/repo_files_examine_detective_test.rb
+++ b/test/unit/lib/repo_files_examine_detective_test.rb
@@ -12,7 +12,7 @@ class RepoFilesExamineDetectiveTest < ActiveSupport::TestCase
     def get_info(_pattern)
       [
         {
-          'name': 'LICENSES', 'type': 'dir', 'html_url': './LICENSES/'
+          name: 'LICENSES', type: 'dir', html_url: './LICENSES/'
         }.with_indifferent_access
       ]
     end


### PR DESCRIPTION
This commit will help us eventually update rubocop.

Currently we can't update rubocop easily because it reports many issues.
This commit is the result of all automated fixes when you update to
rubocop 1.22.1, set LineLength to 79, and use `rubocop -a`.
In a few cases I had to hand-fix the formatting.

They're all trivial changes, mainly changes in indentation, reversals
of conditionals (to avoid the use of negation in the condition), and
elimination of unnecessary key quotation.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>