### PR TITLE
Validate email on search_email / search_user

### DIFF
--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -812,6 +812,9 @@ end
 # Presumes we are in a Rails environment
 def real_search_email(email)
   puts "Searching for email '#{email}'; matching ids and names are:"
+  # Trivial email validation check. This isn't sophisticated, this is primarily
+  # to prevent swapping the email & name fields when calling search_user.
+  raise ArgumentError unless /.+@.+/ =~ email
   results = User.where(email: email)
                 .select('id, name, encrypted_email, encrypted_email_iv')
                 .pluck(:id, :name)

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -814,7 +814,8 @@ def real_search_email(email)
   puts "Searching for email '#{email}'; matching ids and names are:"
   # Trivial email validation check. This isn't sophisticated, this is primarily
   # to prevent swapping the email & name fields when calling search_user.
-  raise ArgumentError unless /.+@.+/ =~ email
+  raise ArgumentError unless /.+@.+/.match?(email)
+
   results = User.where(email: email)
                 .select('id, name, encrypted_email, encrypted_email_iv')
                 .pluck(:id, :name)


### PR DESCRIPTION
Validate the email address when calling search_email or search_user.

When we get GDPR requests we search for names and email addresses,
often by calling search_name,  This command requires that you
list the name and then email address.We don't want to allow
accidental swapping of email and then name, as we wouldn't find
data if it *is* there. To greatly reduce the likelihood of this
user error, do a simple validation of email addresses
and raise an exception if it fails.

The validation could be more sophisticated, but it's unlikely names
include '@', so just checking for an '@' with at least one character
around it should be sufficient. We can't prevent all user errors;
this just makes it much more likely to be detected.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>