### PR TITLE
Check in config/locales/localization.pt-BR.yml

### DIFF
--- a/config/locales/localization.pt-BR.yml
+++ b/config/locales/localization.pt-BR.yml
@@ -1,0 +1,90 @@
+# THIS FILE CONTAINS LOCALIZATION KEYS : date and number formats, number precisions,
+# number separators and all non-textual values depending on the language.
+# These values must not reach the translator, so they are separated in this file.
+#
+# More info here: https://translation.io/blog/gettext-is-better-than-rails-i18n#localization
+#
+# You can edit and/or add new localization keys here, they won't be touched by Translation.io.
+#
+# If you want to add a new localization key prefix, use the option described here:
+# https://github.com/translation/rails#custom-localization-key-prefixes
+#
+---
+pt-BR:
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%u %n"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: R$
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    percentage:
+      format:
+        delimiter: "."
+        format: "%n%"
+        precision: 1
+    precision:
+      format:
+        delimiter: "."
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+  support:
+    array:
+      last_word_connector: " e "
+      two_words_connector: " e "
+      words_connector: ", "
+  spree:
+    date_picker:
+      first_day: 0
+    say_no: false
+    say_yes: true
+  i18n:
+    transliterate:
+      rule:
+        ª: a
+        º: o
+        à: a
+        á: a
+        â: a
+        ã: a
+        æ: Ae
+        ç: c
+        é: e
+        ê: e
+        í: i
+        ó: o
+        õ: o
+        ú: u
+  date:
+    formats:
+      default: "%d/%m/%Y"
+      long: "%d de %B de %Y"
+      short: "%d de %B"
+    order:
+    - :day
+    - :month
+    - :year
+  time:
+    formats:
+      default: "%a, %d de %B de %Y, %H:%M:%S %z"
+      long: "%d de %B de %Y, %H:%M"
+      short: "%d de %B, %H:%M"


### PR DESCRIPTION
This checks in file "config/locales/localization.pt-BR.yml".
We've had this file for some time, but didn't check it in
accidentally so it's not been posted. Thankfully the effects are
subtle, but they're unintended; let's fix that.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>