### PR TITLE
Modify some doc/*.md files to rename CII->OpenSSF

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -121,7 +121,7 @@ might request.
     ```
 
     You can also embed the badge status of project NNN in a markdown file with:
-    `[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/NNN/badge)](https://bestpractices.coreinfrastructure.org/projects/NNN)`
+    `[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/NNN/badge)](https://bestpractices.coreinfrastructure.org/projects/NNN)`
 
 *   `GET /(:locale/)projects(.:format)(?:query)`
 
@@ -166,12 +166,12 @@ might request.
     easy to get the relevant badge (if any).
 
     Dashboards using this information that want a simple display
-    of the CII Badge result may want to use combine hypertext
+    of the OpenSSF Badge result may want to use combine hypertext
     links and the "alt" tag like this, where `MY_URL` is the URL to be used:
 
     ```
     <a href="https://bestpractices.coreinfrastructure.org/projects?as=entry&url=MY_URL">
-      <img src="https://bestpractices.coreinfrastructure.org/projects?as=badge&url=MY_URL" alt="CII N/A">
+      <img src="https://bestpractices.coreinfrastructure.org/projects?as=badge&url=MY_URL" alt="OpenSSF N/A">
     </a>
     ```
 
@@ -185,15 +185,15 @@ might request.
     images have smaller rate limits. So while you can embed this query when
     describing a single project, you can't really have a page
     full of these queries (such as the img src above using a /projects query).
-    If you want to show a large number of CII badges images all at once,
+    If you want to show a large number of OpenSSF badges images all at once,
     it's better to use the query interface to find its corresponding
     numeric project id (e.g., at the server). Then just use the numeric
     project id reference instead, e.g., generate this instead (where you
     found NUMBER earlier):
 
-    <img src="https://bestpractices.coreinfrastructure.org/projects/NUMBER/badge" alt="CII N/A">
+    <img src="https://bestpractices.coreinfrastructure.org/projects/NUMBER/badge" alt="OpenSSF N/A">
 
-## Tiered percentage in CII Best Practices Badge
+## Tiered percentage in OpenSSF Best Practices Badge
 
 The `tiered_percentage` field of a project
 (shown as the "tiered %" column on the projects page)

--- a/doc/governance.md
+++ b/doc/governance.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: (MIT OR CC-BY-3.0+) -->
 
 This document briefly describes "how we make decisions" in the
-CII Best Practices Badge Project.
+OpenSSF Best Practices Badge Project.
 
 ## Overall
 
@@ -41,9 +41,8 @@ For details, including contribution requirements, see
 Note that we emphasize two-person review for anything other than
 low-risk contributions.
 
-CII requires two-factor authentication (2FA) for all projects,
-including this one.  In addition, this project does not accept SMS
-as the second factor.
+This project requires two-factor authentication (2FA).
+In addition, this project does not accept SMS as the second factor.
 
 Issues that we have determined are especially important, particularly
 if they will take a while, are added to the "next" milestone

--- a/doc/vetting.md
+++ b/doc/vetting.md
@@ -76,7 +76,7 @@ We believe there is a need for an approach that helps FLOSS be secure
 that can scale up to the millions of FLOSS programs available today and
 takes advantage of the distinctive nature of FLOSS.
 
-## CII Badging approach to vetting
+## OpenSSF Badging approach to vetting
 
 The best practices badge approach is based on self-certification.
 There are literally millions of OSS projects (we counted), so it's unlikely
@@ -93,10 +93,10 @@ mechanisms to mitigate its problems:
 
 * Automation. We work to automatically determine answers, and we will not accept answers where can confirm with high confidence that the answer is false. E.g., if you use "http://" for your project or repo URLs, your project fails the criterion `sites_https`. That means that the badge is not strictly self-certification, instead, the badge is merely based on it. In the long term we hope to implement more automation. The file criteria/criteria.yml documents how we think various criteria could be automated. Patches to improve automation are joyfully welcomed.  That said, as noted above, we want to focus on what criteria are *important* - even if we currently require people to determine the answer.
 * Public display of answers (for criticism).  People are far more willing to lie in private than in public. It's been long observed that
- “Sunlight is said to be the best of disinfectants; electric light the most efficient policeman.” [[Louis Brandeis, 1914, “What Publicity Can Do”, in Other People's Money and How the Bankers Use It](http://louisville.edu/law/library/special-collections/the-louis-d.-brandeis-collection/other-peoples-money-chapter-v)]
+ “Sunlight is said to be the best of disinfectants; electric light the most efficient policeman.” See [Louis Brandeis, 1914, “What Publicity Can Do”, in Other People's Money and How the Bankers Use It](http://louisville.edu/law/library/special-collections/the-louis-d.-brandeis-collection/other-peoples-money-chapter-v)
 * Reduced incentives. We intentionally reduce the incentives for people to create false information.  For example, all links are specifically marked as `rel="nofollow ugc"`; this greatly reduces the incentive to do Search Engine Optimization (SEO) hacking by creating nonsense projects.
 * Notifications and spot-checks. We (the managers of the badging process) get notifications of various events or suspicious claims for review. Anyone can post an issue disputing a claim, and again, we can check the claim.
-* Answers can be overridden by CII if false. Those who repeatedly falsify information can be kicked off. We do not do this lightly, but the fact that we can reduces the incentive to try.
+* Answers can be overridden by the Linux Foundation (LF) if false. Those who repeatedly falsify information can be kicked off. We do not do this lightly, but the fact that we can reduces the incentive to try.
 * FLOSS.  The badging site is itself FLOSS, so if others can identify ways to improve it and even propose implementations of it.
 
 Nothing is perfect; we believe that the approach we're taking is


### PR DESCRIPTION
Modify several .md files to rename CII to OpenSSF.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>