### PR TITLE
Add rename date from "CII Best Practices badge"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -156,6 +156,8 @@ en:
         The OpenSSF is a foundation of the
         <a href="https://www.linuxfoundation.org/">Linux Foundation
         (LF)</a>.
+        The project was formally renamed from "CII Best Practices badge"
+        on 2021-12-24.
       p3_html: >-
         <em>Privacy and legal issues</em>: Please see our <a href="https://www.linuxfoundation.org/privacy">privacy
         policy</a>,


### PR DESCRIPTION
Note on the front page the official rename date.
This is worded so that someone searching for the exact
phrase "CII Best Practices badge" *will* find a match
on the front page, and thus helping people find it.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>