### PR TITLE
Update gem pagy 4.11.0->5.9.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'omniauth-github', '1.4.0' # Authentication to GitHub (get project info)
 # all testing, and over time we've become more comfortable that this is
 # the "standard way to resolve this issue".
 gem 'omniauth-rails_csrf_protection', '0.1.2' # Counter CVE-2015-9284
-gem 'pagy', '4.11.0' # Paginate some views
+gem 'pagy', '5.9.1' # Paginate some views
 gem 'paleta', '0.3.0' # Color manipulation, used for badges
 gem 'paper_trail', '12.1.0' # Record previous versions of project data
 gem 'pg', '1.2.3' # PostgreSQL database, used for data storage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,8 @@ GEM
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
-    pagy (4.11.0)
+    pagy (5.9.1)
+      activesupport
     paleta (0.3.0)
     paper_trail (12.1.0)
       activerecord (>= 5.2)
@@ -510,7 +511,7 @@ DEPENDENCIES
   octokit (= 4.18.0)
   omniauth-github (= 1.4.0)
   omniauth-rails_csrf_protection (= 0.1.2)
-  pagy (= 4.11.0)
+  pagy (= 5.9.1)
   paleta (= 0.3.0)
   paper_trail (= 12.1.0)
   pg (= 1.2.3)

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 # Pagy initializer file (3.8.3)
-# Customize only what you really need and notice that Pagy works also without any of the following lines.
-# Should you just cherry pick part of this file, please maintain the require-order of the extras
-
+# Customize only what you really need.
 # Extras
 # See https://ddnexus.github.io/pagy/extras
 
@@ -16,7 +14,7 @@
 # Countless extra: Paginate without any count, saving one query per rendering
 # See https://ddnexus.github.io/pagy/extras/countless
 # require 'pagy/extras/countless'
-# Pagy::VARS[:cycle] = false    # default
+# Pagy::DEFAULT[:cycle] = false    # default
 
 # Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
 # See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
@@ -61,14 +59,14 @@ require 'pagy/extras/bootstrap'
 
 # Multi size var used by the *_nav_js helpers
 # See https://ddnexus.github.io/pagy/extras/navs#steps
-# Pagy::VARS[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+# Pagy::DEFAULT[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
 
 # Feature Extras
 
 # Headers extra: http response headers (and other helpers) useful for API pagination
 # See http://ddnexus.github.io/pagy/extras/headers
 # require 'pagy/extras/headers'
-# Pagy::VARS[:headers] = { page: 'Current-Page', items: 'Page-Items', count: 'Total-Count', pages: 'Total-Pages' }     # default
+# Pagy::DEFAULT[:headers] = { page: 'Current-Page', items: 'Page-Items', count: 'Total-Count', pages: 'Total-Pages' }     # default
 
 # Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
 # See https://ddnexus.github.io/pagy/extras/support
@@ -77,8 +75,8 @@ require 'pagy/extras/bootstrap'
 # Items extra: Allow the client to request a custom number of items per page with an optional selector UI
 # See https://ddnexus.github.io/pagy/extras/items
 # require 'pagy/extras/items'
-# Pagy::VARS[:items_param] = :items    # default
-# Pagy::VARS[:max_items]   = 100       # default
+# Pagy::DEFAULT[:items_param] = :items    # default
+# Pagy::DEFAULT[:max_items]   = 100       # default
 
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/extras/overflow
@@ -88,7 +86,7 @@ require 'pagy/extras/bootstrap'
 # just show an empty page if it's empty.
 
 require 'pagy/extras/overflow'
-# Pagy::VARS[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
 
 # Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
 # See https://ddnexus.github.io/pagy/extras/metadata
@@ -96,7 +94,7 @@ require 'pagy/extras/overflow'
 # require 'pagy/extras/shared'
 # require 'pagy/extras/metadata'
 # For performance reason, you should explicitly set ONLY the metadata you use in the frontend
-# Pagy::VARS[:metadata] = [:scaffold_url, :count, :page, :prev, :next, :last]    # example
+# Pagy::DEFAULT[:metadata] = [:scaffold_url, :count, :page, :prev, :next, :last]    # example
 
 # Trim extra: Remove the page=1 param from links
 # See https://ddnexus.github.io/pagy/extras/trim
@@ -105,22 +103,22 @@ require 'pagy/extras/trim'
 
 # Pagy Variables
 # See https://ddnexus.github.io/pagy/api/pagy#variables
-# All the Pagy::VARS are set for all the Pagy instances but can be overridden
+# All the Pagy::DEFAULT are set for all the Pagy instances but can be overridden
 # per instance by just passing them to Pagy.new or the #pagy controller method
 
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
-# Pagy::VARS[:items] = 20                                   # default
-Pagy::VARS[:items] = 30
+# Pagy::DEFAULT[:items] = 20                                   # default
+Pagy::DEFAULT[:items] = 30
 
 # Other Variables
 # See https://ddnexus.github.io/pagy/api/pagy#other-variables
-# Pagy::VARS[:size]       = [1,4,4,1]                       # default
-# Pagy::VARS[:page_param] = :page                           # default
-# Pagy::VARS[:params]     = {}                              # default
-# Pagy::VARS[:anchor]     = '#anchor'                       # example
-# Pagy::VARS[:link_extra] = 'data-remote="true"'            # example
-Pagy::VARS[:size] = [2, 4, 4, 2]
+# Pagy::DEFAULT[:size]       = [1,4,4,1]                       # default
+# Pagy::DEFAULT[:page_param] = :page                           # default
+# Pagy::DEFAULT[:params]     = {}                              # default
+# Pagy::DEFAULT[:anchor]     = '#anchor'                       # example
+# Pagy::DEFAULT[:link_extra] = 'data-remote="true"'            # example
+Pagy::DEFAULT[:size] = [2, 4, 4, 2]
 
 # Rails
 
@@ -190,4 +188,4 @@ Pagy::I18n.load(*PAGY_LOCALES)
 # require 'pagy/extras/i18n'
 
 # Default i18n key
-# Pagy::VARS[:i18n_key] = 'pagy.item_name'   # default
+# Pagy::DEFAULT[:i18n_key] = 'pagy.item_name'   # default


### PR DESCRIPTION
Update the pagination gem pagy from 4.11.0 to 5.9.1.
This update was delayed because of breaking changes in the
transition from pagy 4.X to 5.X. I'm not a fan of breaking changes,
but to be fair, when we followed the directions in:
https://github.com/ddnexus/pagy/blob/master/CHANGELOG.md#version-500
the upgrade was quite smooth.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>