### PR TITLE
Fix github actions/checkout pin comment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       # Update by consulting: https://github.com/actions/checkout/releases
       # We include the hash after '@', and comment "pin @SIMPLE-NAME"; this is
       # the naming convention of https://github.com/mheap/pin-github-action
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # pin @v2.3.5
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # pin @v2.4.0
 
       # Runs a single command using the runners shell
       - name: Run a one-line script


### PR DESCRIPTION
Dependabot automatically creates update changes,
but doesn't fix the comments that explain what pin is to.
Fix the comment to match hash value.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>