### PR TITLE
Bump minitest-reporters from 1.4.3 to 1.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,7 +142,7 @@ end
 group :test do
   gem 'capybara-slow_finder_errors', '0.1.5', require: false
   gem 'codecov', '0.6.0', require: false
-  gem 'minitest-reporters', '1.4.3', require: false
+  gem 'minitest-reporters', '1.5.0', require: false
   gem 'minitest-retry', '0.2.2', require: false # Avoid Capybara false positives
   # Note: Updating 'rails-controller-testing' to '1.0.5' causes failures
   gem 'rails-controller-testing', '1.0.5' # for `assigns` and `assert_template`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
     minitest (5.15.0)
-    minitest-reporters (1.4.3)
+    minitest-reporters (1.5.0)
       ansi
       builder
       minitest (>= 5.0)
@@ -506,7 +506,7 @@ DEPENDENCIES
   lograge (= 0.11.2)
   mail (= 2.7.1)
   mdl (= 0.11.0)
-  minitest-reporters (= 1.4.3)
+  minitest-reporters (= 1.5.0)
   minitest-retry (= 0.2.2)
   octokit (= 4.18.0)
   omniauth-github (= 1.4.0)


### PR DESCRIPTION
Dependabot tried to do this in #1755 but its approach didn't work.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>