### PR TITLE
Add "blocked" field to users table

### DIFF
--- a/db/migrate/20220203172721_add_blocked_to_users.rb
+++ b/db/migrate/20220203172721_add_blocked_to_users.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# Copyright the Linux Foundation and OpenSSF Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+# Make it possible to identify blocked user accounts and a rationale
+# (why they were blocked, typically with the date of getting blocked)
+
+class AddBlockedToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :blocked, :boolean, null: false, default: false
+    add_column :users, :blocked_rationale, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_30_015708) do
+ActiveRecord::Schema.define(version: 2022_02_03_172721) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -422,6 +422,8 @@ ActiveRecord::Schema.define(version: 2021_03_30_015708) do
     t.string "email_bidx"
     t.boolean "use_gravatar", default: false, null: false
     t.datetime "can_login_starting_at"
+    t.boolean "blocked", default: false, null: false
+    t.text "blocked_rationale"
     t.index ["email_bidx"], name: "email_local_unique_bidx", unique: true, where: "((provider)::text = 'local'::text)"
     t.index ["email_bidx"], name: "index_users_on_email_bidx"
     t.index ["last_login_at"], name: "index_users_on_last_login_at"


### PR DESCRIPTION
This adds "blocked" and "blocked_rationale" fields to the users table.

Unfortunately some users choose to create fraudulent entries.
They're rare, but when it happens we want to block them
from being able to change anything, and record why.

This commit *only* modifies the schema so we can record this
information - it does not *enforce* them. I'm creating them as
separate commits so that we can record this information immediately.
We can then later add the code to use this information to enforce it.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>