### PR TITLE
Allow tilde (~) in project URLs, fixes #1780

### DIFF
--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -28,7 +28,7 @@ class UrlValidator < ActiveModel::EachValidator
         https?://
         [A-Za-z0-9][-A-Za-z0-9_.]*  # domain name per DNS spec; includes I18N.
         (/
-          ([-A-Za-z0-9_.:/+!,#]|    # allow these ASCII chars.
+          ([-A-Za-z0-9_.:/+!,#~]|    # allow these ASCII chars.
            %(20|[89A-Ea-e][0-9A-Fa-f]|[Ff][0-7]))*  # Allow some %-encoded
         )?)\z}x.freeze
 


### PR DESCRIPTION
Allow tilde (~) in project URLs, fixes #1780.
We're intentionally restrictive in project URLs.
However, projects hosted on [SourceHut](https://sourcehut.org/)
use URLs in the format

    https://git.sr.ht/~username/repo

So we need to allow tilde (~).
Here's a test case:
https://git.sr.ht/~emersion/annotatesh

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>