### PR TITLE
Fix: rename master->main in GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,12 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    permissions:
+      # Give permissions so results can be stored. See:
+      # https://github.com/actions/first-interaction/issues/10#issuecomment-1041402989
+      contents: write
+      pull-requests: write
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,9 @@ jobs:
     permissions:
       # Give permissions so results can be stored. See:
       # https://github.com/actions/first-interaction/issues/10#issuecomment-1041402989
-      contents: write
-      pull-requests: write
+      # contents: write
+      # pull-requests: write
+      checks: write
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,9 @@ permissions:
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>