### PR TITLE
Stop using git ssh on heroku

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,14 +173,12 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Increase git verbosity when using ssh to simplify debugging
-          # Use 'ssh -vvv' instead of 'ssh -v' for extra verbosity
-          command: git config core.sshCommand 'ssh -v'
-      - run:
           # We don't pin these, as Heroku doesn't support pinning.
           # In any case, these aren't included in the final result, nor used
           # in the process of testing the final result... they're
           # just tools we use to *transfer* the final result to deployment.
+          # We are downloading these tools from a trusted source, so we *do*
+          # want to use the latest version, not a pinned version.
           name: Install Heroku CLI tools (to easily control maintenance mode)
           command: |
             wget https://cli-assets.heroku.com/heroku-linux-x64.tar.gz
@@ -188,19 +186,21 @@ jobs:
       - run:
           name: Deploy to Heroku
           command: |
-            echo 'heroku.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAu8erSx6jh+8ztsfHwkNeFr/SZaSOcvoa8AyMpaerGIPZDB2TKNgNkMSYTLYGDK2ivsqXopo2W7dpQRBIVF80q9mNXy5tbt1WE04gbOBB26Wn2hF4bk3Tu+BNMFbvMjPbkVlC2hcFuQJdH4T2i/dtauyTpJbD/6ExHR9XYVhdhdMs0JsjP/Q5FNoWh2ff9YbZVpDQSTPvusUp4liLjPfa/i0t+2LpNCeWy8Y+V9gUlDWiyYwrfMVI0UwNCZZKHs1Unpc11/4HLitQRtvuk0Ot5qwwBxbmtvCDKZvj1aFBid71/mYdGRPYZMIxq1zgP1acePC1zfTG/lvuQ7d0Pe0kaw==' >> ~/.ssh/known_hosts
             export PATH="$PATH:$(pwd)/heroku/bin"
             export HEROKU_APP="$CIRCLE_BRANCH"-bestpractices
             if [ "$HEROKU_APP" = 'main-bestpractices' ] ; then export HEROKU_APP='master-bestpractices'; fi
+            echo 'Set git remote 'heroku' for $HEROKU_APP"
+            heroku git:remote -a "$HEROKU_APP"
+            git remote get-url heroku
             echo "Switching to maintenance mode in $HEROKU_APP"
             heroku maintenance:on --app "$HEROKU_APP"
             # Give production site a few seconds to complete ongoing work.
             [ "$HEROKU_APP" != 'production-bestpractices' ] || sleep 10
             echo "Deploying to $HEROKU_APP"
-            git push git@heroku.com:"$HEROKU_APP".git $CIRCLE_SHA1:refs/heads/master
-      - run:
-          name: Setup Heroku
-          command: bash .circleci/setup-heroku.sh
+            git push heroku "$CIRCLE_BRANCH:main"
+      # - run:
+      #     name: Setup Heroku
+      #     command: bash .circleci/setup-heroku.sh
       - run:
           name: Migrate DB
           command: |


### PR DESCRIPTION
This comment switches from ssh git transport to HTTPS
transport when sending the code update to heroku.

Heroku has deprecated ssh git transport, so it requires
using HTTP instead of SSH. In particular, they've turned off
the ssh server for it:
https://devcenter.heroku.com/changelog-items/2215

As a result, we must modify the deployment script to stop
using the ssh git transport, and instead use these instructions:
https://devcenter.heroku.com/articles/git#deploy-your-code

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>