### PR TITLE
Fix Array values in the parameter to `Gem.paths=` are deprecated

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+load File.expand_path("spring", __dir__)
 
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'

--- a/bin/rake
+++ b/bin/rake
@@ -1,10 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+load File.expand_path("spring", __dir__)
 
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError
-end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/spring
+++ b/bin/spring
@@ -1,17 +1,14 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
 
-# This file loads spring without using Bundler, in order to be fast.
+# This file loads Spring without using loading other gems in the Gemfile, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
-unless defined?(Spring)
-  require 'rubygems'
-  require 'bundler'
+if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
+  require "bundler"
 
-  if (match = Bundler.default_lockfile.read
-             .match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq }
-    gem 'spring', match[1]
-    require 'spring/binstub'
+  Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem "spring", spring.version
+    require "spring/binstub"
   end
 end


### PR DESCRIPTION
We repeatedly were getting the warning
"Array values in the parameter to `Gem.paths=` are deprecated".

The problem involves the `spring` gem. For details, see:
- https://stackoverflow.com/questions/37864054/rails-5-array-values-in-the-parameter-to-gem-paths-are-deprecated
- https://github.com/rubygems/rubygems/issues/1551

The solution is to run these commands and check in the result:

~~~~sh
bundle update spring
bundle exec spring binstub --remove --all
bundle exec spring binstub --all
~~~~

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>