### PR TITLE
Update transitive dependencies (`bundle update`)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
       tomlrb
     mixlib-shellout (3.2.7)
       chef-utils
-    msgpack (1.5.1)
+    msgpack (1.5.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -312,7 +312,7 @@ GEM
       get_process_mem (~> 0.2)
       puma (>= 2.7)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-attack (6.5.0)
       rack (>= 1.0, < 3)
     rack-cors (1.1.1)


### PR DESCRIPTION
Update the transitive dependencies by running `bundle update`.

This bumps `rack` from 2.2.3 to 2.2.3.1, repairing
[CVE-2022-30123](https://github.com/advisories/GHSA-wq4h-7r42-5hrr).
This is a shell escape sequence injection vulnerability in the Lint
and CommonLogger components of Rack.
The problem is that carefully crafted requests can cause shell escape
sequences to be written to the terminal via Rack's Lint middleware and
CommonLogger middleware. These escape sequences can be leveraged to
possibly execute commands in the victim's terminal.

We probably aren't vulnerable to this. Known attacks only apply when
`Rack::Lint` or `Rack::CommonLogger` are used, and a `grep -R`
finds neither. However, our general policy is to simply update
if there's a security vulnerability in our components and the update
passes our tests. It's possible that it's being used
(e.g., via one of the libraries we import or via dynamically created
dependencies). The risk is very low in updating for a security vulnerability
as long as our tests pass, and we believe the risk is *higher* if
we don't update. We're prepared to update quickly, so we do it.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>