### PR TITLE
Harden projects_first_in

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -517,7 +517,9 @@ class Project < ApplicationRecord
   # Return which projects should be announced as getting badges in the
   # month target_month with level (as a number, 0=passing)
   def self.projects_first_in(level, target_month)
-    name = COMPLETED_BADGE_LEVELS[level] # field name, e.g. 'passing'
+    # Defense-in-depth: ensure 'level' is a valid value.
+    return unless LEVEL_ID_NUMBERS.member?(level)
+    name = COMPLETED_BADGE_LEVELS[level] # level name, e.g. 'passing'
     # We could omit listing projects which have lost & regained their
     # badge by adding this line:
     # .where('lost_#{name}_at IS NULL')

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -519,6 +519,7 @@ class Project < ApplicationRecord
   def self.projects_first_in(level, target_month)
     # Defense-in-depth: ensure 'level' is a valid value.
     return unless LEVEL_ID_NUMBERS.member?(level)
+
     name = COMPLETED_BADGE_LEVELS[level] # level name, e.g. 'passing'
     # We could omit listing projects which have lost & regained their
     # badge by adding this line:


### PR DESCRIPTION
Harden the method projects_first_in to ensure there's no
SQL injection vulnerability.

Method projects_first_in uses a parameter to create a
SQL query. That parameter should already have been tested by
this point, but Brakeman (at least) can't confirm that,
and if the code changed this could become a security vulnerability.
So instead, first check if "level" is one of the short list
of valid values. That will prevent this from becoming a SQL
injection *even if* level can be somehow set by an attacker.

We can't use use SQL parameterized statements here because the
field names are getting created at run time, and parameterized
statements typically have trouble with field names created at run time.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>