### PR TITLE
Make password resets *always* reply same message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,12 +69,10 @@ en:
     forgot_password: Forgot password
     reset_password: Reset password
     password_confirmation: Confirmation
-    email_not_found: Email address not found
     password_empty: Password can't be empty
     password_reset: Password has been reset
-    instructions_sent: Email sent with password reset instructions
-    cant_reset_nonlocal: Sorry, can only reset the password for a custom
-      (local) user
+    instructions_sent: >
+      Email sent with password reset instructions (if a local account exists)
     reset_expired: Password reset has expired.
     update_password: Update password
   sessions:

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -17,63 +17,65 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     get '/en/password_resets/new'
     assert_includes @response.body, 'Forgot password'
     assert_includes @response.body, 'Email'
-    # Invalid email
-    post '/en/password_resets', params: { password_reset: { email: '' } }
+
+    # Invalid email. Note that the displayed response is the *same* even
+    # if there's no such email, because we don't want to give away when
+    # email does not exist
+    post '/en/password_resets',
+         params: { password_reset: { email: 'no_such_email@foo.com' } }
+    assert_equal 0, ActionMailer::Base.deliveries.size
+    assert_redirected_to root_url
+    follow_redirect!
     assert_not flash.empty?
-    assert_includes @response.body, 'Forgot password'
-    assert_includes @response.body, 'Email'
+    assert_includes @response.body, 'Email sent with password reset'
+
     # Valid email
+    old_digest = @user.reset_digest
     post '/en/password_resets', params: {
       password_reset: { email: @user.email }
     }
-    assert_not_equal @user.reset_digest, @user.reload.reset_digest
+    new_digest = @user.reload.reset_digest
+    assert_not_equal old_digest, new_digest
     assert_equal 1, ActionMailer::Base.deliveries.size
     assert_not flash.empty?
     assert_redirected_to root_url
-
-    # Password reset form
-    user = assigns(:user)
-
-    # Wrong email
-    get "/en/password_resets/#{user.reset_token}/edit?email="
-    assert_redirected_to root_url
-
-    # Inactive user
-    user.toggle!(:activated)
-    get "/en/password_resets/#{user.reset_token}/edit?email=#{user.email}"
-    assert_redirected_to root_url
+    follow_redirect!
+    assert_includes @response.body, 'Email sent with password reset'
 
     # Right email, wrong token (written here as "wrong_token")
-    user.toggle!(:activated)
-    get "/en/password_resets/wrong_token/edit?email=#{user.email}"
+    get "/en/password_resets/wrong_token/edit?email=#{@user.email}"
     assert_redirected_to root_url
+    follow_redirect!
+    # Unchanged (no email sent)
+    assert_equal 1, ActionMailer::Base.deliveries.size
 
     # Right email, right token
     # What's happened here is that the user has received the "reset password"
     # email and clicked on the provided link. That sends a "get" with
     # the provided reset_token *AND* the parameter email=(user.email).
     # It has to be a "get" because the user is clicking on a hyperlink in
-    # and email (which causes a "get").
-    get "/password_resets/#{user.reset_token}/edit", params: {
-      email: user.email
+    # an email (which causes a "get").
+    @user.create_reset_digest
+    get "/password_resets/#{@user.reset_token}/edit", params: {
+      email: @user.email
     }
     follow_redirect!
-    assert_select(+'input[name=email][type=hidden][value=?]', user.email)
+    assert_select(+'input[name=email][type=hidden][value=?]', @user.email)
 
     # No parameters - reject it. This could cause a nil dereference,
     # due to attempting to dereference [:user][:password], and we want to
     # ensure we don't try to do that.
     # This should never happen in normal use, since we don't generate such
     # URLs, so we just redirect to root_url.. test for that.
-    put "/en/password_resets/#{user.reset_token}"
+    put "/en/password_resets/#{@user.reset_token}"
     assert_redirected_to root_url(locale: 'en')
     follow_redirect!
 
     # No "user" value - reject it. This could cause a nil dereference,
     # due to attempting to dereference [:user][:password], and we want to
     # ensure we don't try to do that.
-    put "/en/password_resets/#{user.reset_token}", params: {
-      email: user.email
+    put "/en/password_resets/#{@user.reset_token}", params: {
+      email: @user.email
     }
     assert @response.body.include?('Password Password can&#39;t be empty')
 
@@ -81,17 +83,17 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     # This could cause a nil dereference,
     # due to attempting to dereference [:user][:password], and we want to
     # ensure we don't try to do that.
-    put "/en/password_resets/#{user.reset_token}", params: {
-      email: user.email,
+    put "/en/password_resets/#{@user.reset_token}", params: {
+      email: @user.email,
       user: {
-        junk:              'junk'
+        junk: 'junk'
       }
     }
     assert @response.body.include?('Password can&#39;t be empty')
 
     # Unequal password & confirmation should be rejected
-    put "/en/password_resets/#{user.reset_token}", params: {
-      email: user.email,
+    put "/en/password_resets/#{@user.reset_token}", params: {
+      email: @user.email,
       user: {
         password:              '1235foo',
         password_confirmation: 'bar4567'
@@ -100,8 +102,8 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'div#error_explanation'
 
     # Empty password - send it back
-    patch "/en/password_resets/#{user.reset_token}", params: {
-      email: user.email,
+    patch "/en/password_resets/#{@user.reset_token}", params: {
+      email: @user.email,
       user: {
         password:              '',
         password_confirmation: ''
@@ -110,8 +112,8 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'div#error_explanation'
 
     # Valid password & confirmation should actually work
-    put "/en/password_resets/#{user.reset_token}", params: {
-      email: user.email,
+    put "/en/password_resets/#{@user.reset_token}", params: {
+      email: @user.email,
       user: {
         password:              'foo1234!',
         password_confirmation: 'foo1234!'
@@ -137,8 +139,6 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     follow_redirect!
 
-    # @user = assigns(:user)
-    # @user.update_attribute(:reset_sent_at, 3.hours.ago)
     @user.reset_sent_at = 3.hours.ago
     @user.save!
     patch "/en/password_resets/#{@user.reset_token}", params: {

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -21,20 +21,20 @@ class PasswordResetsTest < ActionDispatch::IntegrationTest
     post password_resets_path,
          params: { password_reset: { email: '' }, locale: :en }
     assert_not flash.empty?
-    assert_template 'password_resets/new'
+    assert_redirected_to root_url(locale: :en)
     # Valid email, github user
     post password_resets_path,
          params: { password_reset: { email: @ghuser.email }, locale: :en }
     assert_equal 0, ActionMailer::Base.deliveries.size
     assert_not flash.empty?
-    assert_redirected_to login_url(locale: :en)
+    assert_redirected_to root_url(locale: :en)
     # Valid email
     post password_resets_path,
          params: { password_reset: { email: @user.email }, locale: :en }
     assert_not_equal @user.reset_digest, @user.reload.reset_digest
     assert_equal 1, ActionMailer::Base.deliveries.size
     assert_not flash.empty?
-    assert_redirected_to root_url
+    assert_redirected_to root_url(locale: :en)
     # Password reset form
     user = assigns(:user)
     # Wrong email


### PR DESCRIPTION
Previously we replied with error reports if there was no account or if
there was a GitHub account (not a local account) with the email address.
However, that allowed attackers to determine if a given email address
was present or not in an account. That's not a large leak of
information; the attacker has to already guess the specific email address,
and they merely get "is present/absent" instead of the specific account.
Many systems *do* provide such error messages, so many users would
be unsurprised by this information leak.
Still, we want to be excellent at providing user privacy, so we're
going to go beyond what some might see as the minimum, and instead
do what we can to maximize our users' privacy.

We previously made a similar change to prevent leaking the presence
or absence of an email address when creating local accounts.

This change modifies the tests to match. While we're at it, we'll
remove a call to the deprecated assigns() helper in the test.

Note: This eliminates some keys for translation, as well as mildly
tweaking the text for a key.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>