### PR TITLE
Add DELAY_BETWEEN_RESET_PASSWORDS

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -4,6 +4,7 @@
 # OpenSSF Best Practices badge contributors
 # SPDX-License-Identifier: MIT
 
+# rubocop: disable Metrics/ClassLength
 class PasswordResetsController < ApplicationController
   before_action :obtain_user, only: %i[edit update]
   before_action :require_valid_user, only: %i[edit update]
@@ -11,7 +12,7 @@ class PasswordResetsController < ApplicationController
 
   def new; end
 
-  # Note: password resets *always* reply with the same message, in all cases.
+  # NOTE: password resets *always* reply with the same message, in all cases.
   # At one time we replied with error reports if there was no account or if
   # there was a GitHub account (not a local account) with the email address.
   # However, that allowed attackers to determine if a given email address
@@ -33,7 +34,7 @@ class PasswordResetsController < ApplicationController
       # attacks where the finding system is "overly generous" and matches
       # the "wrong" email address (e.g., exploiting dotless i). See:
       # https://eng.getwisdom.io/hacking-github-with-unicode-dotless-i/
-      reset_password(@user)
+      email_reset_password(@user)
     end
     flash[:info] = t('password_resets.instructions_sent')
     redirect_to root_url
@@ -56,9 +57,27 @@ class PasswordResetsController < ApplicationController
 
   private
 
-  def reset_password(user)
+  DELAY_BETWEEN_RESET_PASSWORDS = Integer(
+    (ENV['DELAY_BETWEEN_RESET_PASSWORDS'] || 4.hours.seconds.to_s), 10
+  ).seconds
+
+  # Return true iff sent_at is too soon (compared to the current time)
+  # to send a reset password request.
+  def reset_password_too_soon(sent_at)
+    # We've never sent one before, so it's obviously not too soon.
+    return false if sent_at.blank?
+
+    DELAY_BETWEEN_RESET_PASSWORDS.since(sent_at) > Time.zone.now
+  end
+
+  def email_reset_password(user)
     # Local password resets only make sense for local users
     return unless user.provider == 'local'
+
+    # Once a password reset has been sent, wait at least
+    # DELAY_BETWEEN_RESET_PASSWORDS before sending another so attackers
+    # can't badger our users with password reset requests.
+    return if reset_password_too_soon(user.reset_sent_at)
 
     @user.create_reset_digest
     @user.send_password_reset_email
@@ -97,3 +116,4 @@ class PasswordResetsController < ApplicationController
     params[outer][inner]
   end
 end
+# rubocop: enable Metrics/ClassLength


### PR DESCRIPTION
Once a password reset has been sent, wait at least
DELAY_BETWEEN_RESET_PASSWORDS before sending another so attackers
can't badger our users with password reset requests.

Note that this adds a test to verify this.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>