### PR TITLE
Update to OpenSSF Code of Conduct (CoC)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,26 +1,96 @@
 # Code of Conduct
 
-Your code and ideas behind it will be carefully reviewed, often resulting
-in critique and criticism.  The review will almost always require
-improvements to the code before it can be included in the project.
-Know that this happens because everyone involved wants to see the best
-possible solution for the overall success of the project.  We do not
-want to do anything to cause the quality of submission and eventual
-result to ever decrease.
+This is an [Open Source Security Foundation (OpenSSF)](https://openssf.org) project, so we follow the [OpenSSF Code of Conduct (CoC)](https://openssf.org/community/code-of-conduct/). Here is a copy of the OpenSSF CoC at the time of this writing, so that anyone with a copy of this repository's data has a copy of it.
 
-If however, anyone feels personally abused, threatened, or otherwise
-uncomfortable due to this process, that is not acceptable.  If so,
-please contact the Linux Foundation's Technical Advisory Board at
-<tab@lists.linux-foundation.org>, or the individual members, and they
-will work to resolve the issue to the best of their ability.  For more
-information on who is on the Technical Advisory Board and what their
-role is, please see:
-<http://www.linuxfoundation.org/programs/advisory-councils/tab>
+## Our Pledge
 
-As a reviewer of code, please strive to keep things civil and focused on
-the technical issues involved.  We are all humans, and frustrations can
-be high on both sides of the process.  Try to keep in mind the immortal
-words of Bill and Ted, "Be excellent to each other."
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation. 
 
-This is based on the Linux kernel "Code of Conduct",
-<https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodeOfConflict?id=b0bc65729070b9cbdbb53ff042984a3c545a0e34>.
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community. 
+
+## Our Standards 
+
+Examples of behavior that contributes to a positive environment for our community include: 
+
+*   Demonstrating empathy and kindness toward other people 
+*   Being respectful of differing opinions, viewpoints, and experiences
+*   Giving and gracefully accepting constructive feedback 
+*   Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience 
+*   Focusing on what is best not just for us as individuals, but for the overall community 
+
+Examples of unacceptable behavior include: 
+
+*   The use of sexualized language or imagery, and sexual attention or advances of any kind 
+*   Trolling, insulting or derogatory comments, and personal or political attacks
+*   Public or private harassment 
+*   Publishing others’ private information, such as a physical or email address, without their explicit permission 
+*   Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Reporting
+
+For incidents occuring in the OpenSSF community, contact [conduct@openssf.org](mailto:conduct@openssf.org).
+
+You can expect a response within three business days. When reporting a potential Code of Conduct violation, please include the following information in your report:
+
+*   Names of the people involved (or if names are unknown, use descriptions and any identifiable info such as appearance, role, username, or handle), including the person who you believe violated the Code of Conduct and any witnesses.
+*   Description of the incident, including the events that occurred, the date and time, and location or community space where the incident occurred.
+*   The portion(s) of the CoC you believe to be violated.
+*   If you have relevant documentary evidence, such as screenshots or photographs, please provide those with your support.
+
+## Enforcement Responsibilities 
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate. 
+
+## Scope 
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. 
+
+## Enforcement 
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at conduct@openssf.org. All complaints will be reviewed and investigated promptly and fairly. 
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident. 
+
+### **Enforcement Guidelines** 
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+#### **1\. Correction** 
+
+**Community Impact:** Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+#### **2\. Warning** 
+
+**Community Impact:** A violation through a single incident or series of actions. 
+
+**Consequence:** A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+#### **3\. Temporary Ban** 
+
+**Community Impact:** A serious violation of community standards, including sustained inappropriate behavior. 
+
+**Consequence:** A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+#### **4\. Permanent Ban** 
+
+**Community Impact:** Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals. 
+
+**Consequence:** A permanent ban from any sort of public interaction within the community. 
+
+## Attribution 
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.0, available at [https://www.contributor-covenant.org/version/2/0/code\_of\_conduct.html](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla’s code of conduct enforcement ladder](https://github.com/mozilla/inclusion). 
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).
+
+*   [](https://www.facebook.com/openssf)
+*   [](https://twitter.com/theopenssf)
+*   [](https://www.linkedin.com/company/openssf/)
+*   [](https://www.youtube.com/c/OpenSSF/)
+*   [](https://github.com/ossf)


### PR DESCRIPTION
We are now an OpenSSF project, so we need to apply the OpenSSF
Code of Conduct (CoC). This project predates the OpenSSF, and when we
added a CoC we used a different CoC from the Linux Foundation.
Now that we *are* part of the OpenSSF, we should have update this. However,
I just realized that I never updated the CoC to match. This fixes that.

We generally haven't had Code of Conduct problems, and the core
*fundamentals* are unchanged: treat everyone else well.
Still, I think it's best to prepare to counter potential problems
ahead-of-time.

The markdown text was created by downloading the text from
<https://openssf.org/community/code-of-conduct/> and then using the
online tool <https://codebeautify.org/html-to-markdown>.
This file *does* link to the OpenSSF CoC page, but I thought it'd be
wise to include a markdown copy of the text so that there was *no*
question about what it said.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>