### PR TITLE
Rename CII to OpenSSF in badge alt text

### DIFF
--- a/app/views/projects/_form_early.html.erb
+++ b/app/views/projects/_form_early.html.erb
@@ -42,7 +42,7 @@
   <%= render(partial: "details", locals: {
          criterion: "got_badge",
          details: t('projects.form_early.got_badge.details_html',
-                    markdown_embedding: %{<code>[![CII Best Practices](https://#{ badge_hostname }/projects/#{ project.id }/badge)](https://#{ badge_hostname }/projects/#{ project.id })</code>}.html_safe,
+                    markdown_embedding: %{<code>[![OpenSSF Best Practices](https://#{ badge_hostname }/projects/#{ project.id }/badge)](https://#{ badge_hostname }/projects/#{ project.id })</code>}.html_safe,
                     html_embedding: %{<code>&lt;a href="https://#{badge_hostname}/projects/#{ project.id }"&gt;&lt;img src="https://#{ badge_hostname }/projects/#{ project.id }/badge"&gt;&lt;/a&gt; </code>}.html_safe)
       }) %>
 <% else %>


### PR DESCRIPTION
https://bestpractices.coreinfrastructure.org/en says:

> This project was formerly known as the Core Infrastructure Initiative (CII) Best Practices badge. and was originally developed under the CII. It is now part of the [OpenSSF](https://openssf.org/) [Best Practices Working Group (WG)](https://github.com/ossf/wg-best-practices-os-developers). The OpenSSF is a foundation of the [Linux Foundation (LF)](https://www.linuxfoundation.org/). The project was formally renamed from "CII Best Practices badge" on 2021-12-24.

However, the badge templates still have the CII name.

For example at https://bestpractices.coreinfrastructure.org/en/projects/6331 :

> You can show your badge status by embedding this in your markdown file:
`[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6331/badge)](https://bestpractices.coreinfrastructure.org/projects/6331)`
or by embedding this in your HTML:
`<a href="https://bestpractices.coreinfrastructure.org/projects/6331"><img src="https://bestpractices.coreinfrastructure.org/projects/6331/badge"></a>`

This PR renames CII to OpenSSF in the Markdown badge alt text.

(The HTML badge doesn't have alt text, but should do.)