### PR TITLE
Fix actions/checkout comment pin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       # Update by consulting: https://github.com/actions/checkout/releases
       # We include the hash after '@', and comment "pin @SIMPLE-NAME"; this is
       # the naming convention of https://github.com/mheap/pin-github-action
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin @v3.0.2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin @v3.1.0
 
       # Runs a single command using the runners shell
       - name: Run a one-line script


### PR DESCRIPTION
GitHub actions doesn't update matching "# pin ..." comments, so update its comment.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>