### PR TITLE
Remove `main` tier for deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,6 @@ jobs:
           command: |
             export PATH="$PATH:$(pwd)/heroku/bin"
             export HEROKU_APP="$CIRCLE_BRANCH"-bestpractices
-            if [ "$HEROKU_APP" = 'main-bestpractices' ] ; then export HEROKU_APP='master-bestpractices'; fi
             # Set file .netrc so "git push heroku ..." will work later.
             # Heroku uses HEROKU_API_KEY, but git only knows about ~/.netrc.
             # https://devcenter.heroku.com/articles/authentication
@@ -216,7 +215,6 @@ jobs:
           command: |
             export PATH="$PATH:$(pwd)/heroku/bin"
             export HEROKU_APP="$CIRCLE_BRANCH"-bestpractices
-            if [ "$HEROKU_APP" = 'main-bestpractices' ] ; then export HEROKU_APP='master-bestpractices'; fi
             heroku run --app "$HEROKU_APP" -- bundle exec rails db:migrate
             if [ -f '.recalculate' ] ; then
                 echo 'Recalculation marker found, performing recalculation.'
@@ -240,6 +238,5 @@ workflows:
           filters:
             branches:
               only:
-                - main
                 - staging
                 - production

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -239,11 +239,12 @@ changes.
 
 ## Deployment instructions
 
-This is designed to be easily deployed simply by doing a "git push"
+This is designed to be easily deployed simply by doing a `git push`
 to an appropriate destination.
 
-At this point, a deployment is automatically done to a staging system once
-it's checked into the repository on the master branch.
+We currently run a `rake deploy_staging` command that does a `git push`
+to deploy to a staging site, and later `rake deploy_production` to push
+to the production site.
 
 ## See also
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -364,18 +364,22 @@ is thread safe."
 
 ## Deployment
 
-We have three publicly accessible tiers:
+We have two publicly accessible tiers:
 
-* master - an instance of the master branch
 * staging
 * production
 
 These are currently executed on Heroku.
+
+Historically we also had a `main` aka `master` tier, an instance 
+of the main branch. However, when Heroku removed their free tier pricing,
+we removed the `main` tier to save money.
+
 If you have write authorization to the GitHub repository,
-the commands "rake deploy_staging" and "rake deploy_production"
+the commands `rake deploy_staging` and `rake deploy_production`
 will update the staging and production branches (respectively).
-Those updates will trigger tests by CircleCI (via webhooks).
-If those tests pass, that updated branch is then deployed to
+Those updates will trigger tests by CircleCI as usual (via webhooks).
+If those tests pass, CirccleIC will then deploy that updated branch to
 its respective tier.
 
 Most administrative actions require logging into the relevant Heroku tier

--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -63,7 +63,7 @@ The application is configured by various environment variables:
   project was last sent a reminder
 * RAILS_ENV (default 'development'): Rails environment, one of
   'test', 'development', 'fake_production', and 'production'.
-  The master, staging, and production systems set this to 'production'.
+  The main/master, staging, and production systems set this to 'production'.
   See the discussion below about fake_production.
 * BADGEAPP_DAY_FOR_MONTHLY: Day of the month to monthly activities, e.g.,
   send out monthly reminders.  Default 5.  Set to 0 to disable monthly acts.
@@ -830,7 +830,8 @@ so any files written are temporary.
 That said, it's no worse than a memory-only cache, and it would be a
 valid alternative.
 
-Heroku offers memcached, but the free tiers are only 25M-30M (smaller
+Heroku offers memcached, but the free tiers (when they existed) were
+only 25M-30M (smaller
 than easily available from memory), and they quickly get expensive
 (the next tier up is only 100M).
 Redis also gets expensive.

--- a/doc/security.md
+++ b/doc/security.md
@@ -2658,11 +2658,14 @@ but we think they greatly reduce the risks.
 To be secure, the software has to be secure as actually transitioned
 (deployed) and operated securely.
 
-Our transition process has software normally go through
-three tiers: master, staging, and production.
-The "master" tier runs the software at the HEAD of the master branch.
-Software that runs fine there is promoted to staging; software that
-runs find there is promoted to production (the "real" system).
+Our transition process has software normally go through tiers.
+At this time there are two deployed tiers: staging and production.
+At one time we also had a "main" aka "master" tier; that ran
+the software at the HEAD of the main (formerly master) branch,
+but to reduce costs we no longer have a tier that deploys the main branch.
+At any time software can be promoted from the main branch
+to the staging tier (using `rake deploy_staging`). Software that
+runs fine on the staging branch is promoted to production (the "real" system).
 In an emergency we can skip tiers or promote to them in parallel, but
 doing that is rare.
 


### PR DESCRIPTION
Heroku has eliminated its free services, which we originally used for both our main/master tier and staging tier.

This commit removes the "main/master" tier as a cost-cutting move. We'll still have the "staging" and "production" tiers; use `rake deploy_staging` and `rake deploy_production`  to deploy to those respective tiers. This eliminates the attempt to deploy to the "main/master" tier (which is about to be deleted), as well as updating the documents to reflect this change.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>