### PR TITLE
update gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'activerecord', '~> 7.0.4' # Rails. ORM and query system.
 # gem 'activestorage' # Not used. Attaches cloud files to ActiveRecord.
 gem 'activesupport', '~> 7.0.4' # Rails. Underlying library.
 # gem 'activetext' # Not used. Text editor that fails to support markdown.
-gem 'attr_encrypted', github: 'andrewfader/attr_encrypted'
+gem 'attr_encrypted', '~> 4'
 gem 'bcrypt', '~> 3.1.18' # Security - for salted hashed interated passwords
 gem 'blind_index', '~> 2.3.0' # Index encrypted email addresses
 gem 'bootstrap-sass', '~> 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/andrewfader/attr_encrypted.git
-  revision: 2f83da674fd783ef2fd18d42e06a6d9123f48f94
-  specs:
-    attr_encrypted (3.1.0)
-      encryptor (~> 3.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -78,6 +71,8 @@ GEM
     ansi (1.5.0)
     argon2-kdf (0.1.7)
     ast (2.4.2)
+    attr_encrypted (4.0.0)
+      encryptor (~> 3.0.0)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
     awesome_print (1.9.2)
@@ -273,7 +268,7 @@ GEM
     paper_trail (12.3.0)
       activerecord (>= 5.2)
       request_store (~> 1.1)
-    parallel (1.22.1)
+    parallel (1.23.0)
     parser (3.2.2.0)
       ast (~> 2.4.1)
     pg (1.4.6)
@@ -307,7 +302,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     public_suffix (5.0.1)
-    puma (6.2.1)
+    puma (6.2.2)
       nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)
@@ -376,7 +371,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.6.0)
-    regexp_parser (2.7.0)
+    regexp_parser (2.8.0)
     request_store (1.5.1)
       rack (>= 1.4)
     require_all (3.0.0)
@@ -501,7 +496,7 @@ DEPENDENCIES
   activemodel (~> 7.0.4)
   activerecord (~> 7.0.4)
   activesupport (~> 7.0.4)
-  attr_encrypted!
+  attr_encrypted (~> 4)
   awesome_print
   bcrypt (~> 3.1.18)
   blind_index (~> 2.3.0)


### PR DESCRIPTION
Looks like the maintainers of attr_encrypted upstreamed an official version of their ruby3/rails7 patches, so we can remove my fork.