### PR TITLE
Use a special env variable to indicate real site

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -8,7 +8,6 @@
 module SessionsHelper
   SESSION_TTL = 48.hours # Automatically log off session if inactive this long
   RESET_SESSION_TIMER = 1.hour # Active sessions older than this reset timer
-  PRODUCTION_HOSTNAME = 'bestpractices.coreinfrastructure.org'
   GITHUB_PATTERN = %r{
     \Ahttps://github.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/?\Z
   }x.freeze
@@ -190,10 +189,8 @@ module SessionsHelper
   # Returns true iff this is not the REAL final production system,
   # including the master/main and staging systems.
   # It only returns false if we are "truly in production"
-  def in_development?(hostname = ENV.fetch('PUBLIC_HOSTNAME', nil))
-    return true if hostname.nil?
-
-    hostname != PRODUCTION_HOSTNAME
+  def in_development?(is_real = ENV.fetch('BADGEAPP_REAL_PRODUCTION', nil))
+    return is_real.nil?
   end
 
   # Redirects to stored location (or to the default)

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -63,8 +63,13 @@ The application is configured by various environment variables:
   project was last sent a reminder
 * RAILS_ENV (default 'development'): Rails environment, one of
   'test', 'development', 'fake_production', and 'production'.
-  The main/master, staging, and production systems set this to 'production'.
+  The main/master, staging, and production systems set this to 'production',
+  because we want our final test systems to be as
+  "most like the real production system as practical".
   See the discussion below about fake_production.
+* BADGEAPP_REAL_PRODUCTION: Has a non-empty value (conventionally "true") if
+  this is the *true* production system. If not present, we show the user a
+  warning that this isn't the production system.
 * BADGEAPP_DAY_FOR_MONTHLY: Day of the month to monthly activities, e.g.,
   send out monthly reminders.  Default 5.  Set to 0 to disable monthly acts.
 * FASTLY_CLIENT_IP_REQUIRED: If present, download the Fastly list of

--- a/test/unit/not_in_development_test.rb
+++ b/test/unit/not_in_development_test.rb
@@ -11,7 +11,7 @@ require 'test_helper'
 class NotInDevelopmentTest < ActiveSupport::TestCase
   test 'The production system will say it is NOT in development' do
     ac = ApplicationController.new
-    assert ac.in_development?('staging.coreinfrastructure.org')
-    assert_not ac.in_development?('bestpractices.coreinfrastructure.org')
+    assert ac.in_development?
+    assert_not ac.in_development?('true')
   end
 end


### PR DESCRIPTION
We're transitioning to a new web address.
It would be much easier to move if we didn't use the domain name to determine if we're the "real" site.