### PR TITLE
Use PUBLIC_HOSTNAME or 'localhost' for some email

### DIFF
--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -71,6 +71,7 @@ class ReportMailer < ApplicationMailer
     @email_destination = user.email
     @new_level = new_badge_level
     @old_level = old_badge_level
+    @hostname = ENV.fetch('PUBLIC_HOSTNAME', 'localhost')
     set_standard_headers
     I18n.with_locale(user.preferred_locale.to_sym) do
       mail(

--- a/app/views/report_mailer/gained_level.text.erb
+++ b/app/views/report_mailer/gained_level.text.erb
@@ -3,9 +3,9 @@
 
 <%= t 'report_mailer.gained_level_part2' %>
 * <%= t 'report_mailer.in_markdown_add' %>
-  [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/<%= @project.id %>/badge)](https://bestpractices.coreinfrastructure.org/projects/<%= @project.id %>)
+  [![OpenSSF Best Practices](https://<%= @hostname %>/projects/<%= @project.id %>/badge)](https://<%= @hostname %>/projects/<%= @project.id %>)
 * <%= t 'report_mailer.in_html_add' %>
-  <a href="https://bestpractices.coreinfrastructure.org/projects/<%= @project.id %>"><img src="https://bestpractices.coreinfrastructure.org/projects/<%= @project.id %>/badge"></a>
+  <a href="https://<%= @hostname %>/projects/<%= @project.id %>"><img src="https://<% @hostname %>/projects/<%= @project.id %>/badge"></a>
 
 <%= t 'report_mailer.gained_level_part3' %>
 


### PR DESCRIPTION
Modify the application so it starts using an environment variable for the main hostname, instead of it being built-in.

This will make it easier to move from one to another.