### PR TITLE
Modify CSP further to allow alternative domain

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -9,6 +9,7 @@ SecureHeaders::Configuration.default do |config|
   normal_src = ["'self'"]
   normal_src += ['https://' + ENV['PUBLIC_HOSTNAME'] + '.global.ssl.fastly.net'] if ENV['PUBLIC_HOSTNAME']
   normal_src += ['https://' + ENV['PUBLIC_HOSTNAME_ALT'] + '.global.ssl.fastly.net'] if ENV['PUBLIC_HOSTNAME_ALT']
+  normal_src += ['https://' + ENV['PUBLIC_HOSTNAME_ALT']] if ENV['PUBLIC_HOSTNAME_ALT']
   config.hsts = "max-age=#{20.years.to_i}; includeSubDomains; preload"
   config.x_frame_options = 'DENY'
   config.x_content_type_options = 'nosniff'
@@ -20,9 +21,8 @@ SecureHeaders::Configuration.default do |config|
   config.csp = {
     # Control information sources
     default_src: normal_src,
-    img_src: [
-      'secure.gravatar.com', 'avatars.githubusercontent.com',
-      "'self'"
+    img_src: normal_src + [
+      'secure.gravatar.com', 'avatars.githubusercontent.com'
     ],
     object_src: ["'none'"],
     script_src: normal_src,

--- a/test/integration/project_get_test.rb
+++ b/test/integration/project_get_test.rb
@@ -39,7 +39,7 @@ class ProjectGetTest < ActionDispatch::IntegrationTest
     assert_equal(
       "default-src 'self'; base-uri 'self'; block-all-mixed-content; " \
       "form-action 'self'; frame-ancestors 'none'; " \
-      "img-src secure.gravatar.com avatars.githubusercontent.com 'self'; " \
+      "img-src 'self' secure.gravatar.com avatars.githubusercontent.com; " \
       "object-src 'none'; script-src 'self'; style-src 'self'",
       @response.headers['Content-Security-Policy']
     )


### PR DESCRIPTION
To transition to a new domain, we need to allow an alternative domain for a period of time. However, for security reasons we specifically harden *against* other domains, so we need to modify our requirements.