### PR TITLE
Support 2 alternative domains

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -10,6 +10,7 @@ SecureHeaders::Configuration.default do |config|
   normal_src += ['https://' + ENV['PUBLIC_HOSTNAME'] + '.global.ssl.fastly.net'] if ENV['PUBLIC_HOSTNAME']
   normal_src += ['https://' + ENV['PUBLIC_HOSTNAME_ALT'] + '.global.ssl.fastly.net'] if ENV['PUBLIC_HOSTNAME_ALT']
   normal_src += ['https://' + ENV['PUBLIC_HOSTNAME_ALT']] if ENV['PUBLIC_HOSTNAME_ALT']
+  normal_src += ['https://' + ENV['PUBLIC_HOSTNAME_ALT2']] if ENV['PUBLIC_HOSTNAME_ALT2']
   config.hsts = "max-age=#{20.years.to_i}; includeSubDomains; preload"
   config.x_frame_options = 'DENY'
   config.x_content_type_options = 'nosniff'


### PR DESCRIPTION
This will simplify transitioning to a new domain, by *always* ensuring the old and new domains will be listed as allowed.