### PR TITLE
Allow cross-CORS for asset requests

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -109,7 +109,8 @@ CORS_DIFFERENTIATED_RESOURCE_PATTERNS = [
 CORS_UNDIFFERENTIATED_RESOURCE_PATTERNS = [
   %r{\A/([a-z]{2}(-[A-Z]{2})?/)?projects/[1-9][0-9]*/badge\z},
   %r{\A/([a-z]{2}(-[A-Z]{2})?/)?projects(/[1-9][0-9]*)?\.json\z},
-  %r{\A/([a-z]{2}(-[A-Z]{2})?/)?project_stats(/[a-z0-9_]+)?\.json\z}
+  %r{\A/([a-z]{2}(-[A-Z]{2})?/)?project_stats(/[a-z0-9_]+)?\.json\z},
+  %r{\A/assets/([A-Za-z0-9_-](+\.[A-Za-z0-9_-]+)*)\z}
 ].freeze
 CORS_UNDIFFERENTIATED_VARY = ['Accept-Encoding'].freeze
 

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -110,7 +110,7 @@ CORS_UNDIFFERENTIATED_RESOURCE_PATTERNS = [
   %r{\A/([a-z]{2}(-[A-Z]{2})?/)?projects/[1-9][0-9]*/badge\z},
   %r{\A/([a-z]{2}(-[A-Z]{2})?/)?projects(/[1-9][0-9]*)?\.json\z},
   %r{\A/([a-z]{2}(-[A-Z]{2})?/)?project_stats(/[a-z0-9_]+)?\.json\z},
-  %r{\A/assets/([A-Za-z0-9_-](+\.[A-Za-z0-9_-]+)*)\z}
+  %r{\A/assets/([A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*)\z}
 ].freeze
 CORS_UNDIFFERENTIATED_VARY = ['Accept-Encoding'].freeze
 


### PR DESCRIPTION
In the transition from bestpractices.coreinfrastructure.org to www.bestpractices.dev we'll have people who are requesting one and will end up getting some from the other. This will result in some cross-origin requests (CORS) for fonts from /assets.

It's *fine* to serve static content across CORS, so let's allow it in all cases.