### PR TITLE
Change how feed view is linked

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,9 +22,7 @@
     type="font/woff2" crossorigin>
   <link rel="preload" href="<%=
     image_path('cci-logo-header.png') %>" as="image" type="image/png">
-  <%= auto_discovery_link_tag :atom,
-                              { controller: 'projects', action: 'feed' },
-                              { title: t('feed_title') } %>
+  <link rel="alternate" type="application/atom+xml" title="<%= t('feed_title') %>" href="/<%= I18n.locale %>/feed" />
   <link rel="publisher" href="https://plus.google.com/+LinuxfoundationOrg" />
 <% end # cache for this locale -%>
 <%# Provide info on all alternate locales for search engines, etc. See: -%>


### PR DESCRIPTION
I am trying to determine why users are being redirected when they should *not* be redirected.

When viewing the main page, the URLs are fine until "auto_discovery_link_tag" is called, and from then on the domain name is wrong. My hypothesis: this routine is incorrectly setting a global variable for the hostname, causing later calls to be wrong.

So let's instead force the URL to a local reference, which is fine and eliminates the call entirely. I don't know if this will solve the problem, but this change is harmless, and its results can tell us if we're on the right track.