### PR TITLE
Rename docs/security.md to docs/assurance-case.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Interesting pages include:
 * **[Design](./docs/design.md)** - our basic design
 * Current **[implementation](./docs/implementation.md)**  - notes about the
   BadgeApp implementation
-* **[security](./docs/security.md)**  - notes about BadgeApp security
+* **[security](./docs/assurance-case.md)**  - notes about BadgeApp security, specifically its assurance case
 * **[testing](./docs/testing.md)**  - notes about BadgeApp automated tests
 * **[api](./docs/api.md)** - Application Programming Interface (API), including data downloads
 * **[Installation](./docs/INSTALL.md)**  - Installation and quick start

--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ to the CII. The domain name is much shorter, too.
 We use the "www" subdomain because there are technical challenges using
 a top-level domain with our CDN; it's more efficient to use the subdomain.
 
-
 ## License
 
 All material here is released under the [MIT license](./LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,4 +48,4 @@ about contributions.
 For a description in more detail about the security requirements
 of this system, and the security assurance case that explains
 why we think we this system is adequately secure, see our
-[security assurance case](docs/security.md).
+[security assurance case](docs/assurance-case.md).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -437,4 +437,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)

--- a/docs/api.md
+++ b/docs/api.md
@@ -513,4 +513,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -3448,4 +3448,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -394,7 +394,8 @@ learning about our users' activities (and thus maintaining user privacy):
   (e.g., to activate a local account), but those links go directly back
   to our site for that given purpose, and do not reveal information to
   anyone else.
-  We use SendGrid to send email, but we have specifically configured the
+  You need to configure the MTA used to send email before you can use it.
+  We used to use SendGrid to send email; we have specifically configured the
   [SendGrid X-SMTPAPI header to disable all of its trackers we know of](https://sendgrid.com/docs/ui/account-and-settings/tracking/),
   which are clicktrack, ganalytics, subscriptiontrack, and opentrack.
   For example, we have never used ganalytics, but by expressly disabling it,
@@ -1956,17 +1957,20 @@ as of 2015-12-14:
    but the data is sufficiently low value, and there aren't
    good alternatives for low value data like this.
    This isn't as bad as it might appear, because we prefer encrypted
-   channels for transmitting all emails. Our application attempts to send
+   channels for transmitting all emails.
+   Historically our application attempts to send
    messages to its MTA using TLS (using `enable_starttls_auto: true`),
-   and that MTA (SendGrid) then attempts to transfer the email the rest
+   and that MTA then attempts to transfer the email the rest
    of the way using TLS if the recipient's email system supports it
    (see <https://sendgrid.com/docs/Glossary/tls.html>).
    This is good protection against passive attacks, and is relatively decent
    protection against active attacks if the user chooses an email system
    that supports TLS (an active attacker has to get between the email
    MTAs, which is often not easy).
+   More recently we're using `enable_starttls: true` which *forces* email to be
+   encrypted point-to-point.
    If users don't like that, they can log in via GitHub and use GitHub's
-   forgotten password system.
+   system for dealing with forgotten passwords.
    The file `config/initializers/filter_parameter_logging.rb`
    intentionally filters passwords so that they are not included in the log.
    We require that local user passwords have a minimum length

--- a/docs/background.md
+++ b/docs/background.md
@@ -1770,4 +1770,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)

--- a/docs/criteria.md
+++ b/docs/criteria.md
@@ -605,4 +605,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)

--- a/docs/design.md
+++ b/docs/design.md
@@ -503,4 +503,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -121,4 +121,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -1535,4 +1535,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)

--- a/docs/other.md
+++ b/docs/other.md
@@ -1712,4 +1712,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -149,4 +149,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,4 +61,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -274,4 +274,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)

--- a/docs/vetting.md
+++ b/docs/vetting.md
@@ -124,4 +124,4 @@ Development processes and security:
 * [design.md](design.md) - Architectural design information
 * [implementation.md](implementation.md) - Implementation notes
 * [testing.md](testing.md) - Information on testing
-* [security.md](security.md) - Why it's adequately secure (assurance case)
+* [assurance-case.md](assurance-case.md) - Why it's adequately secure (assurance case)


### PR DESCRIPTION
It's confusing to have 2 documents named "security.md". Give the assurance case a different name.