### PR TITLE
Change the OMM link to use archive.org

### DIFF
--- a/criteria/criteria.yml
+++ b/criteria/criteria.yml
@@ -726,7 +726,7 @@
             it is important to have a governance model, and clearly define
             it, so that all participants and potential participants will
             know how decisions will be made. This was inspired by the
-            <a href="https://projects.ow2.org/bin/view/ow2/OMM">OW2 Open-source Maturity Model</a>,
+            <a href="https://web.archive.org/web/20171123114606/https://projects.ow2.org/bin/view/ow2/OMM">OW2 Open-source Maturity Model</a>,
             in particular RDMP-1 and STK-1.
           #autofill: TODO
       - code_of_conduct:
@@ -855,7 +855,7 @@
           met_justification_required: true
           rationale: >
             This was inspired by
-            <a href="https://projects.ow2.org/bin/view/ow2/OMM">DFCT-1.2</a>
+            <a href="https://web.archive.org/web/20171123114606/https://projects.ow2.org/bin/view/ow2/OMM">DFCT-1.2</a>
           #autofill:TODO
   - Reporting: !!omap
     - Bug-reporting process: !!omap

--- a/docs/other.md
+++ b/docs/other.md
@@ -326,7 +326,7 @@ Upgrade some "passing" level SHOULD and SUGGESTED:
     all participants and potential participants will know how decisions
     will be made.
     This was inspired by the
-    <a href="https://projects.ow2.org/bin/view/ow2/OMM">OW2 Open-source Maturity Model</a>,
+    <a href="https://web.archive.org/web/20171123114606/https://projects.ow2.org/bin/view/ow2/OMM">OW2 Open-source Maturity Model</a>,
     in particular RDMP-1 and STK-1.
 
 *   <a name="roles_responsibilities"></a>
@@ -623,7 +623,7 @@ Upgrade some "passing" level SHOULD and SUGGESTED:
     <sup>[<a href="#maintenance_or_update">maintenance_or_update</a>]</sup>
 
     *Rationale*:
-    This was inspired by <a href="https://projects.ow2.org/bin/view/ow2/OMM">DFCT-1.2</a>
+    This was inspired by <a href="https://web.archive.org/web/20171123114606/https://projects.ow2.org/bin/view/ow2/OMM">DFCT-1.2</a>
 
 ### Reporting
 


### PR DESCRIPTION
We credit the "Open-source Maturity Model" in a few places, but it's no longer available at that URL. Use an archive.org link instead, so people who want to track citations can find it.

My thanks to @Darksonn for reporting the broken link!