### PR TITLE
Markdown generation: no level means all levels

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -20,7 +20,8 @@ class ProjectsController < ApplicationController
   before_action :can_edit_else_redirect, only: %i[edit update]
   before_action :can_control_else_redirect, only: %i[destroy delete_form]
   before_action :require_adequate_deletion_rationale, only: :destroy
-  before_action :set_criteria_level, only: %i[show edit update show_markdown]
+  before_action :set_criteria_level, only: %i[show edit update]
+  before_action :set_optional_criteria_level, only: %i[show_markdown]
 
   # Cache with Fastly CDN.  We can't use this header, because logged-in
   # and not-logged-in users see different things (and thus we can't
@@ -737,6 +738,17 @@ class ProjectsController < ApplicationController
   def set_criteria_level
     @criteria_level = criteria_level_params[:criteria_level] || '0'
     @criteria_level = '0' unless @criteria_level.match?(/\A[0-2]\Z/)
+  end
+
+  def set_optional_criteria_level
+    # Apply input filter on criteria_level. If invalid/empty it becomes ''
+    requested_criteria_level = criteria_level_params[:criteria_level]
+    @criteria_level =
+      if requested_criteria_level.match?(/\A[0-2]\Z/)
+        requested_criteria_level.to_str
+      else
+        ''
+      end
   end
 
   def set_valid_query_url

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -742,7 +742,7 @@ class ProjectsController < ApplicationController
 
   def set_optional_criteria_level
     # Apply input filter on criteria_level. If invalid/empty it becomes ''
-    requested_criteria_level = criteria_level_params[:criteria_level]
+    requested_criteria_level = criteria_level_params[:criteria_level] || ''
     @criteria_level =
       if requested_criteria_level.match?(/\A[0-2]\Z/)
         requested_criteria_level.to_str

--- a/app/views/projects/show_markdown.erb
+++ b/app/views/projects/show_markdown.erb
@@ -1,5 +1,11 @@
 <%-
-  criteria_level = @criteria_level || '0'
+  # @criteria_level should always be a string, but handle nil gracefully.
+  if @criteria_level.blank? then
+    criteria_levels = Criteria.keys # All levels
+  else
+    criteria_levels = [@criteria_level]
+  end
+
   def criterion_to_checkbox(value)
     case value
     when 'Met', 'N/A'
@@ -12,9 +18,11 @@
 -%>
 # <%= @project.name %>
 
-[<%= @project.name
-  %>](https://bestpractices.dev/projects/<%= @project.id
-  %>?criteria_level=<%= criteria_level %>):
+<%- criteria_levels.each do |criteria_level| -%>
+
+## [<%= t("projects.form_early.level.#{criteria_level}")
+    %>](https://www.bestpractices.dev/projects/<%= @project.id
+  %>?criteria_level=<%= criteria_level %>)
 
 <%- FullCriteriaHash[criteria_level].each do |major, major_info| -%>
 - **<%= t("headings.#{major}") %>**
@@ -44,5 +52,5 @@
 <%-     end -%>
 <%-   end -%>
 <%- end -%>
-
+<%- end -%>
 <%= Time.new.iso8601 %>

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -244,10 +244,32 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [], body['additional_rights']
   end
 
-  test 'should show markdown with locale' do
+  test 'should show markdown for all levels when level not said' do
     get "/en/projects/#{@project.id}.md"
     assert_response :success
     assert_includes @response.body, 'The project website MUST provide information on how'
+    assert_includes @response.body, 'Passing'
+    assert_includes @response.body, 'Silver'
+    assert_includes @response.body, 'Gold'
+  end
+
+  test 'should show markdown for one given level' do
+    get "/en/projects/#{@project.id}.md?criteria_level=0"
+    assert_response :success
+    assert_includes @response.body, 'The project website MUST provide information on how'
+    assert_includes @response.body, 'Passing'
+    assert_not_includes @response.body, 'Silver'
+    assert_not_includes @response.body, 'Gold'
+  end
+
+  test 'Markdown generates correctly for French' do
+    get "/fr/projects/#{@project.id}.md?criteria_level=0"
+    assert_response :success
+    assert_includes @response.body, 'Le projet DOIT'
+    assert_includes @response.body, 'Argent'
+    assert_not_includes @response.body, 'Passing'
+    assert_not_includes @response.body, 'Silver'
+    assert_not_includes @response.body, 'Gold'
   end
 
   test 'should get edit' do

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -263,11 +263,16 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'Markdown generates correctly for French' do
-    get "/fr/projects/#{@project.id}.md?criteria_level=0"
+    get "/fr/projects/#{@project.id}.md?criteria_level=1"
     assert_response :success
-    # Split up text to fool spellchecker
-    assert_includes @response.body, 'Le ' + 'pro' + 'jet ' + 'DOIT'
-    assert_includes @response.body, 'Argent'
+    # Split up text to fool spellchecker. "Project" is easily misspelled
+    # and there's no mechanism to disable spellchecking for a specific line.
+    assert_includes @response.body,
+                    ('Le ' \
+                     'pro' \
+                     'jet ' + 'DOIT atteindre un badge de niveau basique')
+    assert_not_includes @response.body, '[Basique]' # "Passing"
+    assert_includes @response.body, '[Argent]' # "Silver"
     assert_not_includes @response.body, 'Passing'
     assert_not_includes @response.body, 'Silver'
     assert_not_includes @response.body, 'Gold'

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -266,7 +266,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     get "/fr/projects/#{@project.id}.md?criteria_level=0"
     assert_response :success
     # Split up text to fool spellchecker
-    assert_includes @response.body, 'Le ' + 'pro' + 'jet ' + ' DOIT'
+    assert_includes @response.body, 'Le ' + 'pro' + 'jet ' + 'DOIT'
     assert_includes @response.body, 'Argent'
     assert_not_includes @response.body, 'Passing'
     assert_not_includes @response.body, 'Silver'

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -265,7 +265,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   test 'Markdown generates correctly for French' do
     get "/fr/projects/#{@project.id}.md?criteria_level=0"
     assert_response :success
-    assert_includes @response.body, 'Le projet DOIT'
+    # Split up text to fool spellchecker
+    assert_includes @response.body, 'Le ' + 'pro' + 'jet ' + ' DOIT'
     assert_includes @response.body, 'Argent'
     assert_not_includes @response.body, 'Passing'
     assert_not_includes @response.body, 'Silver'


### PR DESCRIPTION
Interpret "no criteria_levels given" as "provide all levels".