### PR TITLE
Create LLC and TSC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Here's help on how to make contributions, divided into the following sections:
 * reuse (supply chain for third-party components, including updating them),
 * keeping up the main branch, and
 * handling the rename of the "master" branch to "main".
+* governance
 
 ## General information
 
@@ -1031,3 +1032,15 @@ git fetch origin
 git branch -u origin/main main
 git remote set-head origin -a
 ~~~~
+
+## Governance
+
+This project is led by the OpenSSF Best Practices Badge
+Technical Steering Committee (TSC).
+For current members, see [TSC.md](./TSC.md).
+The TSC is supported by a technical lead.
+
+The file [governance.md](docs/governance.md) describes our governance model
+(how we decide things) in more detail.
+That file is considered "incorporated by reference" by this
+CONTRIBUTING document.

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -21,7 +21,7 @@
       <ul class='nav navbar-nav navbar-right'>
         <li><%= yield :insert_progress_bar %></li>
         <%= yield :nav_extras %>
-        <li><%= link_to Icon[:'fa-list'] + t(:projects, scope: :layouts), projects_path %></li>
+        <li><%= link_to Icon[:'fa-list'] + t(:projects, scope: :layouts), projects_path, id: 'projects_page' %></li>
 
         <% if logged_in? %>
           <li class="dropdown">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,13 +38,16 @@ en:
     footer_text_html: >-
       <small> <strong>Need help? Have a question? See a problem?
       Please <em><a href="https://github.com/coreinfrastructure/best-practices-badge/issues"
-      target="_blank" rel="noopener">file an issue</a></em>.</strong> © 2015-2021
+      target="_blank" rel="noopener">file an issue</a></em>.</strong>
+      Copyright © 
+      <a href="https://www.bestpractices.dev" target="_blank" rel="noopener">OpenSSF Best Practices Badge a Series of LF Projects, LLC</a>.
+      For web site terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org" target="_blank" rel="noopener">https://lfprojects.org</a>.
+      For more information, see the websites of the
       <a href="https://openssf.org" target="_blank" rel="noopener">Open Source
-      Security Foundation</a>, a <a href="https://www.linuxfoundation.org/"
-      target="_blank" rel="noopener">Linux Foundation</a> Collaborative Project.
+      Security Foundation (OpenSSF)</a> and <a href="https://www.linuxfoundation.org/"
+      target="_blank" rel="noopener">The Linux Foundation</a>.
       All Rights Reserved. Please see our <a href="https://www.linuxfoundation.org/privacy"
-      target="_blank" rel="noopener">privacy policy</a> and <a href="https://www.linuxfoundation.org/terms"
-      target="_blank" rel="noopener">terms of use</a>. </small>
+      target="_blank" rel="noopener">privacy policy</a>.</small>
   admin_only: Admin only.
   account_activations:
     activated: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,7 +41,7 @@ en:
       target="_blank" rel="noopener">file an issue</a></em>.</strong>
       Copyright © 
       <a href="https://www.bestpractices.dev" target="_blank" rel="noopener">OpenSSF Best Practices Badge a Series of LF Projects, LLC</a>.
-      For web site terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org" target="_blank" rel="noopener">https://lfprojects.org</a>.
+      For web site terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org" target="_blank" rel="noopener">these policies</a>.
       For more information, see the websites of the
       <a href="https://openssf.org" target="_blank" rel="noopener">Open Source
       Security Foundation (OpenSSF)</a> and <a href="https://www.linuxfoundation.org/"

--- a/docs/TSC.md
+++ b/docs/TSC.md
@@ -5,6 +5,7 @@
 The members of the OpenSSF Best Practices Badge
 Technical Steering Committee (TSC) are:
 
+* Christopher "CRob" Robinson (@SecurityCRob)
 * David A. Wheeler (@david-a-wheeler)
 
 The plan is to extend this list of TSC members; the goal is to

--- a/docs/TSC.md
+++ b/docs/TSC.md
@@ -1,0 +1,11 @@
+# Technical Steering Committee (TSC) Members
+
+<!-- SPDX-License-Identifier: (MIT OR CC-BY-3.0+) -->
+
+The members of the OpenSSF Best Practices Badge
+Technical Steering Committee (TSC) are:
+
+* David A. Wheeler (@david-a-wheeler)
+
+The plan is to extend this list of TSC members; the goal is to
+get started with the TSC construct that is new to the best practices badge.

--- a/docs/TSC.md
+++ b/docs/TSC.md
@@ -5,12 +5,14 @@
 The members of the OpenSSF Best Practices Badge
 Technical Steering Committee (TSC) are:
 
-* Christopher "CRob" Robinson (@SecurityCRob) [Intel]
 * David A. Wheeler (@david-a-wheeler) [The Linux Foundation]
+* Christopher "CRob" Robinson (@SecurityCRob) [Intel]
+* Tony Hansen (@TonyLHansen) [AT&T]
 
 Members represent themselves, not their employers.
 We note employers because we want to ensure that no single organization
 controls this project.
 
-The plan is to extend this list of TSC members; the goal is to
-get started with the TSC construct that is new to the best practices badge.
+The "@" indicates the GitHub id.
+
+See [governance](governance.md) for more information.

--- a/docs/TSC.md
+++ b/docs/TSC.md
@@ -5,8 +5,12 @@
 The members of the OpenSSF Best Practices Badge
 Technical Steering Committee (TSC) are:
 
-* Christopher "CRob" Robinson (@SecurityCRob)
-* David A. Wheeler (@david-a-wheeler)
+* Christopher "CRob" Robinson (@SecurityCRob) [Intel]
+* David A. Wheeler (@david-a-wheeler) [The Linux Foundation]
+
+Members represent themselves, not their employers.
+We note employers because we want to ensure that no single organization
+controls this project.
 
 The plan is to extend this list of TSC members; the goal is to
 get started with the TSC construct that is new to the best practices badge.

--- a/docs/TSC.md
+++ b/docs/TSC.md
@@ -13,6 +13,9 @@ Members represent themselves, not their employers.
 We note employers because we want to ensure that no single organization
 controls this project.
 
-The "@" indicates the GitHub id.
+The initial "@" indicates the GitHub id.
+
+TSC members do not necessarily have admin access to the production
+web application, but they may.
 
 See [governance](governance.md) for more information.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -21,7 +21,7 @@ However, we need to review external contributions to maintain quality.
 
 This project is led by the OpenSSF Best Practices Badge
 Technical Steering Committee (TSC).
-For current members, see [TSC.md](./TSC.md).
+For the list of current members, see [TSC.md](./TSC.md).
 
 TSC decisions are by majority vote.
 Decisions can be asynchronous/electronic (e.g., a mailing list or

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -24,9 +24,11 @@ Technical Steering Committee (TSC).
 For current members, see [TSC.md](./TSC.md).
 
 TSC decisions are by majority vote.
-Decisions can be electronic (e.g., a mailing list or
-electronic voting system) or in a meeting (in person or a teleconference),
+Decisions can be asynchronous/electronic (e.g., a mailing list or
+electronic voting system) or synchronous/meeting (e.g., in an
+in-person meeting or a teleconference),
 at the choice of the TSC members.
+A synchronous meeting requires a quorum of a majority of TSC members.
 In case of a tie, the OpenSSF Best Practices Badge
 technical lead can break the tie.
 
@@ -39,6 +41,10 @@ The OpenSSF TAC can add or remove members in the OpenSSF Best
 Practices Badge TSC by TAC majority vote. This is not intended to
 be a common practice, but this mechanism prevents the TSC from being
 overly insular.
+
+TSC members represent themselves, not their employers.
+We note TSC employers because we want to ensure that no single organization
+controls this project.
 
 ## TSC Powers
 
@@ -106,8 +112,7 @@ e.g., MIT license for the source code.
 ## Technical Lead
 
 Many of the day-to-day maintenance tasks of the OpenSSF Best Practices Badge
-are managed by the OpenSSF Best Practices Badge are managed
-by the OpenSSF Best Practices Badge technical lead.
+are managed by the OpenSSF Best Practices Badge technical lead.
 
 The technical lead reports to the OpenSSF TSC, including on significant
 work or decisions to be made.
@@ -137,6 +142,7 @@ Committers are those with authority to directly make changes
 to the main branch of the code.
 The TSC and technical lead can add or revoke commit privilege
 (the TSC overrides the technical lead in case of a conflict).
+Committers can accept contributions from contributors.
 
 ## Contributors
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -15,10 +15,107 @@ Core Infrastructure Initiative (CII) project.
 In terms of
 ["Governance models" (Gardler and Hanganu)](http://oss-watch.ac.uk/resources/governancemodels) the badging project is a bazaar -
 contributions are gladly welcomed from anyone.
-The project is led by a single technical lead designated by the OpenSSF.
-The technical lead has final say on decisions (and thus is
-something of a "benevolent dictator"), but the technical
-lead is subject to being overruled or replaced by the OpenSSF.
+However, we need to review external contributions to maintain quality.
+
+### Technical Steering Committee (TSC)
+
+This project is led by the OpenSSF Best Practices Badge
+Technical Steering Committee (TSC).
+For current members, see [TSC.md](./TSC.md).
+
+TSC decisions are by majority vote.
+Decisions can be electronic (e.g., a mailing list or
+electronic voting system) or in a meeting (in person or a teleconference),
+at the choice of the TSC members.
+In case of a tie, the OpenSSF Best Practices Badge
+technical lead can break the tie.
+
+This TSC reports to the OpenSSF Best Practices Working Group, who in
+turn report to the OpenSSF Technical Advisory Council (TAC).
+
+The TSC can add or remove members to itself (again, by majority vote).
+
+The OpenSSF TAC can add or remove members in the OpenSSF Best
+Practices Badge TSC by TAC majority vote. This is not intended to
+be a common practice, but this mechanism prevents the TSC from being
+overly insular.
+
+## TSC Powers
+
+The TSC may (1) establish work flow procedures for the submission,
+approval, and closure/archiving of projects, (2) set requirements
+for the promotion of Contributors to Committer status, as applicable,
+and (3) amend, adjust, refine and/or eliminate the roles of
+Contributors, and Committers, and create new roles, and publicly
+document any TSC roles, as it sees fit.
+
+The TSC may elect a TSC Chair, who will preside over meetings of
+the TSC and will serve until their resignation or replacement by
+the TSC.  The TSC Chair, or any other TSC member so designated by
+the TSC, will serve as the primary communication contact between
+the Project and OpenSSF, a directed fund of The Linux Foundation.
+
+The TSC will be responsible for all aspects of oversight relating
+to the Project, which may include:
+
+1. coordinating the technical direction of the Project; approving
+   project or system proposals (including, but not limited to, incubation,
+2. deprecation, and changes to a sub-project’s scope);
+3. organizing sub-projects and removing sub-projects;
+4. creating sub-committees or working groups to focus on cross-project
+   technical issues and requirements;
+5. appointing representatives to work with other open source or
+   open standards communities;
+6. establishing community norms, workflows, issuing releases,
+   and security issue reporting policies;
+7. approving and implementing policies and processes for contributing
+   and coordinating with
+   the series manager of the Project (as provided for in the Series
+   Agreement, the “Series Manager”) to resolve matters or concerns
+   that may arise;
+8. discussions, seeking consensus, and where necessary, voting on
+   technical matters relating to the code base that affect multiple
+   projects; and
+   coordinating any marketing, events, or communications regarding the Project.
+
+In practice, the TSC delegates many tasks to the technical lead, who
+serves the TSC.
+
+## TSC Voting
+
+1. While the Project aims to operate as a consensus-based community,
+   if any TSC decision requires a vote to move the Project forward,
+   the voting members of the TSC will vote on a one vote per voting
+   member basis.
+2. Quorum for TSC meetings requires at least fifty percent of all
+   voting members of the TSC to be present. The TSC may continue to
+   meet if quorum is not met but will be prevented from making any
+   decisions at the meeting.
+3. Except as provided in Technical Charter Section 7.c. and 8.a, decisions
+   by vote at a meeting require a majority vote of those in attendance,
+   provided quorum is met. Decisions made by electronic vote without
+   a meeting require a majority vote of all voting members of the TSC.
+4. In the event a vote cannot be resolved by the TSC, any voting
+   member of the TSC may refer the matter to the Series Manager for
+   assistance in reaching a resolution.
+   They may also contact the OpenSSF Best Practices WG.
+
+Technical Charter sections 7.c and 8.a identify the licensing requirements,
+e.g., MIT license for the source code.
+
+## Technical Lead
+
+Many of the day-to-day maintenance tasks of the OpenSSF Best Practices Badge
+are managed by the OpenSSF Best Practices Badge are managed
+by the OpenSSF Best Practices Badge technical lead.
+
+The technical lead reports to the OpenSSF TSC, including on significant
+work or decisions to be made.
+The technical lead's decisions can be
+overruled by the OpenSSF TSC at any time.
+In addition, the OpenSSF TSC can replace the technical lead at any time
+(as always, by majority vote).
+
 Also, since the project is FLOSS, the project can be forked;
 this ability to fork also provides a check against despotism.
 The technical lead's job is focus on doing what's best
@@ -26,11 +123,25 @@ for this project, and the project's goal is to help
 the FLOSS community overall.
 
 The technical lead has commit rights on the software, and administrative
-rights to the production site, and can add or remove those rights to others.
+rights to the production site, and can add or remove those rights to others
+to further the goals of the project
+(subject to being overruled by the TSC).
 Those with commit rights can make changes
 (subject to caveats described below) and accept changes
 (typically pull requests) submitted by others.
 These changes include changes to the process and contribution requirements.
+
+## Committers
+
+Committers are those with authority to directly make changes
+to the main branch of the code.
+The TSC and technical lead can add or revoke commit privilege
+(the TSC overrides the technical lead in case of a conflict).
+
+## Contributors
+
+Contributors are those who choose to contribute to the project.
+See [CONTRIBUTING](../CONTRIBUTING.md).
 
 ## Process
 
@@ -41,7 +152,7 @@ For details, including contribution requirements, see
 Note that we emphasize two-person review for anything other than
 low-risk contributions.
 
-This project requires two-factor authentication (2FA).
+This project requires two-factor authentication (2FA) for direct commit rights.
 In addition, this project does not accept SMS as the second factor.
 
 Issues that we have determined are especially important, particularly
@@ -49,7 +160,7 @@ if they will take a while, are added to the "next" milestone
 (which identifies "what should be prioritized next").
 
 We expect people to focus on improving the project, not attacking other
-people.  Please strive to "Be excellent to each other."
+people. Please strive to "Be excellent to each other."
 For more information, see our [Code of Conduct](../CODE_OF_CONDUCT.md).
 
 ## Criteria changes
@@ -97,7 +208,8 @@ Speeding adding of a criterion is expected to be extremely unusual.
 ## Current people
 
 The current Badge Project technical lead is David A. Wheeler.
-Others with commit rights include Jason Dossett.
+
+To see the current list of TSC members, see [TSC.md](./TSC.md).
 
 ## See also
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -28,9 +28,11 @@ Decisions can be asynchronous/electronic (e.g., a mailing list or
 electronic voting system) or synchronous/meeting (e.g., in an
 in-person meeting or a teleconference),
 at the choice of the TSC members.
-A synchronous meeting requires a quorum of a majority of TSC members.
-In case of a tie, the OpenSSF Best Practices Badge
-technical lead can break the tie.
+A synchronous meeting requires a quorum of at least 50% of TSC members.
+In an asynchronous meeting all TSC members are considered present and a
+majority must vote for the vote to be valid.
+If there is a tie, the OpenSSF Best Practices Badge
+technical lead can break the tie (but is not obligated to do so).
 
 This TSC reports to the OpenSSF Best Practices Working Group, who in
 turn report to the OpenSSF Technical Advisory Council (TAC).
@@ -40,11 +42,14 @@ The TSC can add or remove members to itself (again, by majority vote).
 The OpenSSF TAC can add or remove members in the OpenSSF Best
 Practices Badge TSC by TAC majority vote. This is not intended to
 be a common practice, but this mechanism prevents the TSC from being
-overly insular.
+overly insular and enables a restart if all TSC members are unable to
+continue their roles.
 
 TSC members represent themselves, not their employers.
 We note TSC employers because we want to ensure that no single organization
 controls this project.
+
+For general practices see the "TSC Voting" section below.
 
 ## TSC Powers
 
@@ -128,9 +133,11 @@ for this project, and the project's goal is to help
 the FLOSS community overall.
 
 The technical lead has commit rights on the software, and administrative
-rights to the production site, and can add or remove those rights to others
+rights to the production site (both web app admin rights and rights
+to its infrastructure).
+The technical lead can add or remove those rights to others
 to further the goals of the project
-(subject to being overruled by the TSC).
+(subject, as always, to being overruled by the TSC).
 Those with commit rights can make changes
 (subject to caveats described below) and accept changes
 (typically pull requests) submitted by others.

--- a/test/system/access_home_test.rb
+++ b/test/system/access_home_test.rb
@@ -19,7 +19,8 @@ class AccessHomeTest < ApplicationSystemTestCase
 
   test 'Header has links' do
     visit root_path(locale: :en)
-    assert find_link('Projects').visible?
+    # use an id to ensure we are referring to the correct one
+    assert find('#projects_page').visible?
     assert find_link('Sign Up').visible?
     assert find_link('Login').visible?
   end

--- a/test/system/github_login_test.rb
+++ b/test/system/github_login_test.rb
@@ -38,12 +38,13 @@ class GithubLoginTest < ApplicationSystemTestCase
       assert_equal num + 1, ActionMailer::Base.deliveries.size
       # Check a user can edit a project they can edit on Github
       # This particular check requires GitHub interaction so we do it here
-      click_on 'Projects'
+      # We use a "find" to disambiguate requests
+      find('#projects_page').click
       assert has_content? 'Justified perfect project'
       click_on 'Justified perfect project'
       assert has_content? 'Edit'
       # Check a user cannot edit a Github project they CAN'T push to.
-      click_on 'Projects'
+      find('#projects_page').click
       click_on 'Unjustified perfect project'
       assert_not has_content? 'Edit'
     end

--- a/test/system/github_user_test.rb
+++ b/test/system/github_user_test.rb
@@ -15,12 +15,12 @@ class GithubUserTest < ApplicationSystemTestCase
     click_link 'Log in with GitHub'
     assert has_content? 'Logged in!'
     # Check a user can't edit a project they don't own on app or GitHub
-    click_on 'Projects'
+    find('#projects_page').click
     click_on 'Pathfinder OS'
     assert_not has_content? 'Edit'
     # Check a user can edit a project they own on Github
     # We do this here because this should not require github interaction
-    click_on 'Projects'
+    find('#projects_page').click
     click_on 'Mars Ascent Vehicle (MAV)'
     assert has_content? 'Edit'
     click_on 'Account'


### PR DESCRIPTION
Clean up various legal/charter constructs.

The Linux Foundation plans to move this project into its own LLC (this provides various legal protections), and we must state that.

A side-effect is that we need to create "Technical Steering Committee" (TSC). I think that's a good thing. I intend to start it with me (as I was the original project lead & committer), and work to add others to it, so it's not just me working by myself.

The proposed approach says the OpenSSF TAC can change the TSC by majority vote. The intent is to ensure that I (or anyone else) can't be a dictator, and that it's possible to get things going again if something goes wrong. Originally I was going to have the OpenSSF Best Practices WG do that vote, but I think it'd be better to have the TAC do it.