### PR TITLE
Add section ids to project badge entry

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -71,9 +71,15 @@ module ProjectsHelper
   # Generate HTML for minor heading
   def minor_header_html(minor)
     # rubocop:disable Rails/OutputSafety
+    # Section ids are section_ followed by lowercased letters, digits, _ for space
+    # We strip out everything else.
+    section_id = 'section_' + minor.downcase.tr(' ', '_').gsub(/[^a-z0-9_-]/, '')
+
     safe_join(
       [
-        '<li class="list-group-item"><h3>'.html_safe,
+        '<li class="list-group-item"><h3 id="'.html_safe,
+        section_id,
+        '">'.html_safe,
         t(minor, scope: [:headings]),
         '</h3>'.html_safe
       ]

--- a/app/views/projects/_form_0.html.erb
+++ b/app/views/projects/_form_0.html.erb
@@ -52,7 +52,7 @@
              }) %>
       <div class="panel-collapse collapse in">
         <ul class="list-group">
-          <li class="list-group-item"><h3><%= t('headings.Identification') %></h3>
+          <li class="list-group-item"><h3 id="section_identification"><%= t('headings.Identification') %></h3>
 
             <%= render(partial: 'form_basics',
                        locals:
@@ -200,7 +200,7 @@
           </li>
 
    <%# Note: render() accepts met_suppress: ..., unmet_placeholder:  ... %>
-          <li class="list-group-item"><h3><%= t('headings.Basic project website content') %></h3>
+          <li class="list-group-item"><h3 id="section_basic_project_website_content"><%= t('headings.Basic project website content') %></h3>
             <%= render_status 'description_good', f, project, '0', is_disabled %>
 
             <%= render_status 'interact', f, project, '0', is_disabled %>
@@ -209,7 +209,7 @@
 
             <%= render_status 'contribution_requirements', f, project, '0', is_disabled, true %>
           </li>
-          <li class="list-group-item"><h3><%=
+          <li class="list-group-item"><h3 id="section_floss_license"><%=
             t('FLOSS license',
               scope: :headings) %></h3>
 
@@ -495,7 +495,7 @@
                 '0', 'Security', 'Secure development knowledge',
                 f, project, is_disabled
               ) %>
-          <li class="list-group-item"><h3><%=
+          <li class="list-group-item"><h3 id="section_use_basic_good_cryptographic_practices"><%=
             t('Use basic good cryptographic practices',
               scope: :headings) %></h3>
 

--- a/app/views/projects/_form_1.html.erb
+++ b/app/views/projects/_form_1.html.erb
@@ -45,7 +45,7 @@
              }) %>
       <div class="panel-collapse collapse in">
         <ul class="list-group">
-          <li class="list-group-item"><h3><%= t('headings.Identification') %></h3>
+          <li class="list-group-item"><h3 id="section_identification"><%= t('headings.Identification') %></h3>
             <%= render(partial: 'form_basics',
                  locals:
                    {
@@ -211,7 +211,7 @@
                 '1', 'Security', 'Secure development knowledge',
                 f, project, is_disabled
               ) %>
-          <li class="list-group-item"><h3><%=
+          <li class="list-group-item"><h3 id="section_use_basic_good_cryptographic_practices"><%=
             t('Use basic good cryptographic practices',
               scope: :headings) %></h3>
 

--- a/app/views/projects/_form_2.html.erb
+++ b/app/views/projects/_form_2.html.erb
@@ -45,7 +45,7 @@
              }) %>
       <div class="panel-collapse collapse in">
         <ul class="list-group">
-          <li class="list-group-item"><h3><%= t('headings.Identification') %></h3>
+          <li class="list-group-item"><h3 id="section_identification"><%= t('headings.Identification') %></h3>
             <%= render(partial: 'form_basics',
                  locals:
                    {
@@ -148,7 +148,7 @@
              }) %>
       <div class="panel-collapse collapse in remove-in">
         <ul class="list-group">
-          <li class="list-group-item"><h3><%=
+          <li class="list-group-item"><h3 id="section_use_basic_good_cryptographic_practices"><%=
             t('Use basic good cryptographic practices',
               scope: :headings) %></h3>
 


### PR DESCRIPTION
Add ids for every section, to make it easy to jump directly to them. Section ids have the form "section_" followed by the English name of the section downcased and with spaces turned into underscores. Only characters A-Za-z0-9_- are used, any other characters are removed.

The "section_" prefix is necessary because there are cases where the section name and the criterion overlap (e.g., `floss_license`).