### PR TITLE
Fix translation.io

### DIFF
--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -10,7 +10,7 @@
 if Rails.env.development? || Rails.env.test?
   require 'translation'
   TranslationIO.configure do |config|
-    config.api_key        = 'b6086a4661ba47d79ec771236e298211'
+    config.api_key        = ENV['TRANSLATION_IO_KEY'] || ''
     config.source_locale  = 'en'
     config.target_locales = %i[zh-CN es fr de ja pt-BR ru sw]
 


### PR DESCRIPTION
We had a translation.io secret API key checked into the repo. That's a common mistake that's easy to make, but isn't acceptable. This commit fixes this.

That old exposed API key has been revoked, so it cannot do any harm now.  The code has been changed to acquire the key from the environment, so that the key will no longer need to be in the repo.

We have no evidence the exposed translation.io secret API key was ever exploited. That API key is *never* directly used by the production site, and that key cannot affect the English text.
Instead, that secret provides access to the translations of the text, so someone could have changed the English text our translators saw or the translated text they produced. That said, I think our human translators would have complained if they saw weird English text or a translation they didn't create, so I'm fairly confident that this exposed key was never exploited.

The translation.io API key is *only* used when we synchronize with translation.io to update the translations. This happens occasionally within our development environment. Note that all such translation changes are checked into the repository, so we can see *every* change made in all translations and when they were made in the repo, We could even revert them if necessary, though there's no evidence it's necessary in this case.

This is the result of a search for the term "key" in the application in plausible directories such as the source directory (app) and configuration directory (config).
I implemented that search as follows:

> grep -Ri key app config lib db script docs | wc -l

That produced 635 lines. I then manually reviewed all of them.

This was the *only* case in that search result where a secret key was publicly exposed. As noted earlier, that key no longer works.

I have enabled secret scanning in the repository to help prevent future recurrence.