### PR TITLE
Test on CircleCI using PostgreSQL 13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,11 @@ version: 2.1
 # OpenSSF Scorecard. You can see the hash pins on the various "image:"
 # values. That prevents downloading of later subversions AND of later
 # updates. When you *DO* want to update, you can easily find out the hash
-# of a given docker container by just running something like:
-# > docker pull circleci/postgres:11.5-ram
-# This will return with the SHA-256 hash of the current version.
+# of a given docker container via:
+# https://hub.docker.com/r/cimg/postgres/tags
+# For more info: https://circleci.com/developer/images/image/cimg/postgres
+# You could also run something like:
+# > docker pull circleci/postgres:13.14
 #
 orbs:
   browser-tools: circleci/browser-tools@1.4.1
@@ -27,7 +29,7 @@ jobs:
         PG_USER: ubuntu
         RAILS_ENV: test
         RACK_ENV: test
-    - image: cimg/postgres@sha256:baf39240249c9aeaaf09a3052e3663a5e99fa515c38ed6293b6689ffa15bb48e # pin :11.17
+    - image: cimg/postgres@sha256:sha256:23f8b7c8f4362ab6a88235f5c2f030e94fda54d7a80bbfaa2a50a03cbdd2b997 # pin :13.14
       environment:
         POSTGRES_USER: ubuntu
         POSTGRES_DB: circle_ruby_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
         PG_USER: ubuntu
         RAILS_ENV: test
         RACK_ENV: test
-    - image: cimg/postgres@sha256:sha256:23f8b7c8f4362ab6a88235f5c2f030e94fda54d7a80bbfaa2a50a03cbdd2b997 # pin :13.14
+    - image: cimg/postgres@sha256:23f8b7c8f4362ab6a88235f5c2f030e94fda54d7a80bbfaa2a50a03cbdd2b997 # pin :13.14
       environment:
         POSTGRES_USER: ubuntu
         POSTGRES_DB: circle_ruby_test


### PR DESCRIPTION
Modify the CircleCI configuration so that we test using PostgreSQL 13. We're about to switch from 12->13, and we want to ensure that (1) it works and (2) we make the test environment maximally similar to production.