### PR TITLE
Delayed job to purge CDN data to fix race condition

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@
 
 require 'ipaddr'
 
+# rubocop: disable Metrics/ClassLength
 class ApplicationController < ActionController::Base
   include Pagy::Backend
 
@@ -71,6 +72,9 @@ class ApplicationController < ActionController::Base
     (ENV['BADGEAPP_BADGE_CACHE_MAX_AGE'] || '8640000').to_i,
     2 * BADGE_CACHE_MAX_AGE
   ].max
+
+  # Delay in seconds before a delayed purge
+  BADGE_PURGE_DELAY = (ENV['BADGEAPP_PURGE_DELAY'] || '8').to_i
 
   BADGE_CACHE_SURROGATE_CONTROL =
     "max-age=#{BADGE_CACHE_MAX_AGE}, stale-if-error=#{BADGE_CACHE_STALE_AGE}"
@@ -288,3 +292,4 @@ class ApplicationController < ActionController::Base
 
   include SessionsHelper
 end
+# rubocop: enable Metrics/ClassLength

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2015-2017, the Linux Foundation, IDA, and the
+# Copyright the Linux Foundation, IDA, and the
 # OpenSSF Best Practices badge contributors
 # SPDX-License-Identifier: MIT
 
@@ -276,7 +276,7 @@ class ProjectsController < ApplicationController
   def update
     if repo_url_change_allowed?
       # Send CDN purge early, to give it time to distribute purge request
-      purge_cdn_project
+      @project.purge_cdn_project
       old_badge_level = @project.badge_level
       project_params.each do |key, user_value| # mass assign
         @project[key] = user_value
@@ -298,8 +298,30 @@ class ProjectsController < ApplicationController
         # after saving.
         if @project.save
           successful_update(format, old_badge_level, @criteria_level)
+          # We must send a purge later, not just now, due to a subtle race
+          # condition. Here's what is going on.
+          # The server and the CDN communicate over TCP/IP. This *server*
+          # will always produce the newest information once it's committed.
+          # However, TCP/IP does *NOT* guarantee that different replies
+          # from a server will be received (by the CDN) in the same order that
+          # they were sent. This means that the CDN can receive *old* data
+          # after # receiving a purge request and newer data, resulting in
+          # a CDN caches with obsolete data that will be held for a long time.
+          # A solution: Wait a short time, then send *another* purge. That way
+          # even if the CDN receives updates out-of-order, that old data will
+          # be purged. The next request following this additional purge will
+          # receive the updated data, and then the CDN will have correct data.
+          #
+          # Note: ActiveJob by default stores jobs in RAM. If the system is
+          # restarted while a job is active, and jobs are stored in RAM, the
+          # job will be lost and not executed. The long-term solution is to put
+          # jobs in the database.
+          PurgeCdnProjectJob.set(
+            wait: BADGE_PURGE_DELAY.seconds
+          ).perform_later(@project)
           # Also send CDN purge last, to increase likelihood of being purged
-          purge_cdn_project
+          # and replaced with correct data even before the delayed purpose.
+          @project.purge_cdn_project
         else
           format.html { render :edit, criteria_level: @criteria_level }
           format.json do
@@ -338,7 +360,7 @@ class ProjectsController < ApplicationController
       end
       format.json { head :no_content }
     end
-    purge_cdn_project
+    @project.purge_cdn_project
   end
   # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
@@ -605,12 +627,6 @@ class ProjectsController < ApplicationController
 
   def integer_list?(value)
     !(value =~ /\A[1-9][0-9]{0,15}( *, *[1-9][0-9]{0,15}){0,20}\z/).nil?
-  end
-
-  # Purge data about this project from the CDN (if the CDN has any)
-  def purge_cdn_project
-    cdn_badge_key = @project.record_key
-    FastlyRails.purge_by_key cdn_badge_key
   end
 
   # Maximum number of GitHub repos to retrieve when retrieving a list of

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Copyright the Linux Foundation and the
+# OpenSSF Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/purge_cdn_project_job.rb
+++ b/app/jobs/purge_cdn_project_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Copyright the Linux Foundation, IDA, and the
+# OpenSSF Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+class PurgeCdnProjectJob < ApplicationJob
+  queue_as :default
+
+  def perform(project)
+    # Send purge message to CDN
+    project.purge_cdn_project
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -545,6 +545,12 @@ class Project < ApplicationRecord
       .reorder('last_reminder_at')
   end
 
+  # Purge data about this project from the CDN (if the CDN has any)
+  def purge_cdn_project
+    cdn_badge_key = record_key
+    FastlyRails.purge_by_key cdn_badge_key
+  end
+
   private
 
   # def all_active_criteria_passing?

--- a/test/jobs/purge_cdn_project_job_test.rb
+++ b/test/jobs/purge_cdn_project_job_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright 2015- the Linux Foundation and the
+# OpenSSF Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+require 'test_helper'
+
+class PurgeCdnProjectJobTest < ActiveJob::TestCase
+  setup do
+    @project = projects(:one)
+  end
+
+  test 'Purging CDN Project data' do
+    assert_enqueued_jobs 0
+    PurgeCdnProjectJob.set(wait: 24.hours).perform_later(@project)
+    assert_enqueued_jobs 1
+    PurgeCdnProjectJob.perform_now(@project)
+  end
+end


### PR DESCRIPTION
Add a delayed job to purge CDN project data to fix a race condition.

In some cases the CDN can end up with old data due to a race condition between the server and CDN. There doesn't seem to be a reasonable solution to *end* the race. So to solve this, add an additional delayed job to re-purge data for a given project. That way, if the CDN loses the race, the obsolete data will soon be purged and the next request will get the correct data. At worst there will be a few seconds where users see the old data, but that's unsurprising behavior - it will look like it took a few seconds to see the new data (which is actually a reasonable way to look at this).