### PR TITLE
Improve performance of cdn project purge job

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -318,7 +318,7 @@ class ProjectsController < ApplicationController
           # jobs in the database.
           PurgeCdnProjectJob.set(
             wait: BADGE_PURGE_DELAY.seconds
-          ).perform_later(@project)
+          ).perform_later(@project.record_key)
           # Also send CDN purge last, to increase likelihood of being purged
           # and replaced with correct data even before the delayed purpose.
           @project.purge_cdn_project

--- a/app/jobs/purge_cdn_project_job.rb
+++ b/app/jobs/purge_cdn_project_job.rb
@@ -7,8 +7,11 @@
 class PurgeCdnProjectJob < ApplicationJob
   queue_as :default
 
-  def perform(project)
+  # Rails supports passing the project record directly as "project".
+  # However, this is inefficient; we really only need the record_key
+  # (which we use as the cdn_badge_key).
+  def perform(cdn_badge_key)
     # Send purge message to CDN
-    project.purge_cdn_project
+    FastlyRails.purge_by_key cdn_badge_key
   end
 end


### PR DESCRIPTION
When purging the CDN of a particular project, we really only need its record_key, which is a simple string. So pass just that string to the job, it's more efficient.