### PR TITLE
Update nokogiri to version 1.16.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
     net-smtp (0.4.0.1)
       net-protocol
     nio4r (2.7.0)
-    nokogiri (1.16.2-x86_64-linux)
+    nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)


### PR DESCRIPTION
This updates its packaged libxml2 to v2.12.7
to resolve what we believe are false claims that we are vulnerable to CVE-2024-34459.

This is *NOT* believed to be a vulnerability in our software. Nokogiri does not provide or expose the
code that is vulnerable (which is in xmllint).
Still, updating nokogiri will get rid of a false negative, making it easier for us to detect real problems later.