### PR TITLE
bundle update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     bullet (7.2.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    bundler-audit (0.9.1)
+    bundler-audit (0.9.2)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
     byebug (11.1.3)
@@ -138,10 +138,10 @@ GEM
       multi_json (>= 1.3)
       rake
     execjs (2.9.1)
-    faraday (2.10.1)
-      faraday-net_http (>= 2.0, < 3.2)
+    faraday (2.11.0)
+      faraday-net_http (>= 2.0, < 3.4)
       logger
-    faraday-net_http (3.1.1)
+    faraday-net_http (3.3.0)
       net-http
     faraday-retry (2.2.1)
       faraday (~> 2.0)
@@ -223,7 +223,7 @@ GEM
       mixlib-shellout
     method_source (1.1.0)
     mini_mime (1.1.5)
-    minitest (5.25.0)
+    minitest (5.25.1)
     minitest-reporters (1.7.1)
       ansi
       builder
@@ -242,7 +242,7 @@ GEM
       bigdecimal (~> 3.1)
     net-http (0.4.1)
       uri
-    net-imap (0.4.14)
+    net-imap (0.4.15)
       date
       net-protocol
     net-pop (0.1.2)
@@ -282,7 +282,7 @@ GEM
     paper_trail (12.3.0)
       activerecord (>= 5.2)
       request_store (~> 1.1)
-    parallel (1.26.2)
+    parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
@@ -393,7 +393,7 @@ GEM
     request_store (1.7.0)
       rack (>= 1.4)
     require_all (3.0.0)
-    rexml (3.3.5)
+    rexml (3.3.6)
       strscan
     rubocop (1.57.0)
       base64 (~> 0.1.1)
@@ -407,7 +407,7 @@ GEM
       rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.0)
+    rubocop-ast (1.32.1)
       parser (>= 3.3.1.0)
     rubocop-performance (1.19.1)
       rubocop (>= 1.7.0, < 2.0)
@@ -486,7 +486,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     uniform_notifier (1.16.0)
-    uri (0.13.0)
+    uri (0.13.1)
     vcr (5.0.0)
     version_gem (1.1.4)
     web-console (4.2.1)


### PR DESCRIPTION
This update addresses a vulnerability in rexml,
one of our dependencies, as follows:

~~~~yaml
Name: rexml
Version: 3.3.5
CVE: CVE-2024-43398
GHSA: GHSA-vmwr-mc7x-5vc3
Criticality: Medium
URL: https://github.com/ruby/rexml/security/advisories/GHSA-vmwr-mc7x-5vc3 Title: REXML denial of service vulnerability
Solution: upgrade to '>= 3.3.6'
~~~~

This vulnerability was in ruby-advisory-db as of:

~~~~yaml
advisories:   918 advisories
last updated: 2024-08-26 13:49:59 -0700
commit:       9a88f501a73e9d55c5142286dac075732d8febb0
~~~~

The vulnerability is only a denial of service, but we like to update to repair vulnerabilities where it makes sense to do so.