### PR TITLE
Note automation on the front page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,8 @@ en:
       p2_html: >-
         You can easily see the <a href="/en/criteria/0">criteria for the
         passing badge</a>.
+        Automated analysis will determine many of the criteria answers for you
+        (and prevent obviously incorrect answers).
         More information on the OpenSSF Best Practices Badging program is
         <a href='https://github.com/coreinfrastructure/best-practices-badge'>available
         on GitHub</a>. <a href="/en/project_stats">Project statistics</a>


### PR DESCRIPTION
Many people didn't know that the best practices badge includes automation (including Eddie!). That makes sense, because it's not even noted on the front page of the active website.

This change notes, on the front page, that we have automation.