### PR TITLE
Update jquery-ui-rails to ~> 7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'httparty' # HTTP convenience. rake fix_use_gravatar
 gem 'imagesLoaded_rails', '~> 4.1' # JavaScript - enable wait for image load
 gem 'jbuilder', '~> 2.11' # Template mechanism for JSON format results
 gem 'jquery-rails', '~> 4.4' # JavaScript jQuery library (for Rails)
-gem 'jquery-ui-rails', '~> 6.0' # JavaScript jQueryUI library (for Rails)
+gem 'jquery-ui-rails', '~> 7.0' # JavaScript jQueryUI library (for Rails)
 gem 'lograge', '~> 0.12' # Simplify logs
 gem 'mail', '~> 2.7' # Ruby mail handler
 #


### PR DESCRIPTION
This eliminates a warning about a jquery vulnerability. I don't think we are vulnerable at all to it, but
updating to ensure it is not crazy.