### PR TITLE
Add user search for admins

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,7 @@
 <% require 'cgi' %>
 
 <div class="jumbotron">
-<h2 class>All users</h2>
+<h2 class>Users</h2>
 
 <ul class="users">
   <% @users.each do |user| %>
@@ -21,5 +21,16 @@
   <% end %>
 </ul>
 <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
+
+<% if current_user&.admin? %>
+<h2 class>New Search (case-insensitive)</h2>
+ <%= form_for users_path, method: 'get', enforce_utf8: true do %>
+  <label for="name"><%= 'Name' %></label>
+  <%= text_field_tag :name, params[:name], size: 40, placeholder: 'User name' %>
+  <label for="email"><%= 'Email' %></label>
+  <%= text_field_tag :email, params[:email], size: 60, placeholder: 'User email' %>
+  <%= submit_tag 'User Search', name: nil %>
+ <% end %>
+<% end %>
 
 </div>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -18,7 +18,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     log_in_as(@admin)
     get '/en/users'
     assert_response :success
-    assert_includes @response.body, 'All users'
+    assert_includes @response.body, 'Users'
   end
 
   test 'should get new' do
@@ -53,6 +53,40 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_includes @response.body, project.name
     assert_includes @response.body,
                     I18n.t('users.show.projects_additional_rights')
+  end
+
+  test 'Admin can search by name, case-insensitive' do
+    log_in_as(@admin)
+    get '/en/users?name=test'
+    assert_response :success
+    assert_includes @response.body, 'French Test'
+    assert_not_includes @response.body, 'Mark Watney'
+  end
+
+  test 'Admin can search by email, case-insensitive' do
+    log_in_as(@admin)
+    # Stored email address is 'CaseSensitive@example.org'
+    get '/en/users?email=casesensitive@example.org'
+    assert_response :success
+    assert_includes @response.body, 'Case Sensitive'
+    assert_not_includes @response.body, 'Mark Watney'
+  end
+
+  test 'Non-admin will be UNABLE to search by name' do
+    log_in_as(@other_user)
+    get '/en/users?name=test'
+    assert_response :success
+    # The search is ignored, so we'll just see unrelated entries
+    assert_includes @response.body, 'Mark Watney'
+  end
+
+  test 'Non-admin will be UNABLE search by email, case-insensitive' do
+    log_in_as(@other_user)
+    # Stored email address is 'CaseSensitive@example.org'
+    get '/en/users?email=casesensitive@example.org'
+    assert_response :success
+    # The search is ignored, so we'll just see unrelated entries
+    assert_includes @response.body, 'Mark Watney'
   end
 
   test 'indicate admin is admin to admin' do


### PR DESCRIPTION
Admins will be able to search users for name or email. This is added to better support GDPR requests.