### PR TITLE
Change user search to be OR instead of AND

### DIFF
--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -69,6 +69,17 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get '/en/users?email=casesensitive@example.org'
     assert_response :success
     assert_includes @response.body, 'Case Sensitive'
+    assert_not_includes @response.body, 'French Test'
+    assert_not_includes @response.body, 'Mark Watney'
+  end
+
+  test 'Admin can search by name ORed with email, case-insensitive' do
+    log_in_as(@admin)
+    # Stored email address is 'CaseSensitive@example.org'
+    get '/en/users?name=Test&email=github-user@example.com'
+    assert_response :success
+    assert_includes @response.body, 'French Test'
+    assert_includes @response.body, 'GitHub The User'
     assert_not_includes @response.body, 'Mark Watney'
   end
 


### PR DESCRIPTION
The new admin capability for user search is primarily for GDPR requests (and similar). The previous implementation, if provided with both name and email, returned only results that met BOTH criteria (an "AND").

However, for GPDR requests, it's far more convenient to reply all users matching EITHER criteria (an "OR"). We want to ensure that we identify all possible records, even those that only partly match.

This changes user search from "AND" to "OR", to better support GDPR requests and similar.