### PR TITLE
Remove gem jquery-ui-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,8 @@ gem 'httparty' # HTTP convenience. rake fix_use_gravatar
 gem 'imagesLoaded_rails', '~> 4.1' # JavaScript - enable wait for image load
 gem 'jbuilder', '~> 2.11' # Template mechanism for JSON format results
 gem 'jquery-rails', '~> 4.4' # JavaScript jQuery library (for Rails)
-gem 'jquery-ui-rails', '~> 7.0' # JavaScript jQueryUI library (for Rails)
+# We once used 'jquery-ui-rails', JavaScript jQueryUI library (for Rails),
+# for jquery-ui/autocomplete (a polyfill for missing functionality in Safari).
 gem 'lograge', '~> 0.12' # Simplify logs
 gem 'mail', '~> 2.7' # Ruby mail handler
 #

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,8 +22,6 @@
 //  No longer used: = require jquery.turbolinks
 //= require jquery_ujs
 //= require bootstrap
-// This is for a polyfill for Safari:
-//= require jquery-ui/widgets/autocomplete
 // This allows us to wait for image loading to complete:
 //= require imagesloaded
 // Chart creation via chartkick:

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,13 +10,8 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- * Note that this uses jquery-ui/autocomplete (to do a polyfill for Safari).
- * There are reports that jquery-ui interferes with bootstrap; I hope those
- * have been resolved.
- *
  *= require_tree .
  *= require_self
- *= require jquery-ui/autocomplete
  *= require rails_bootstrap_forms
  *= require bootstrap-social
  *= require font-awesome


### PR DESCRIPTION
Remove gem jquery-ui-rails, eliminating vulnerability report https://github.com/coreinfrastructure/best-practices-badge/dependabot/73

We previously updated gem jquery-ui-rails to version 7.0.0, and had expected this to eliminate the vulnerability report. Gem version 7.0.0 was released on 2024-03-13. This is a major version number change, so we had expected it to take some extra work but for it to also eliminate the vulnerability.

However, it turns out that the vulnerability report is for versions <= 7.0.0, not < 7.0.0, as expected and as we originally thought it said. Version 7.0.0 *is* the current version of this gem as of 2024-11-27.

So we investigated our alternatives. It's likely to be unexploitable, since it only affects a checkboxradio with HTML-like initial text label. We limit where attackers can manipulate text, and escape it, which makes this somewhat unlikely. Still, it was hard to be *certain* there was no problem.

However, we *only* use this gem to implement a polyfill for Safari to do an autocomplete of a datalist (FLOSS licenses). The page https://caniuse.com/datalist indicates that support has gotten *much* better, so we don't need the polyfill for typical web browsers like Chrome, Firefox, Edge, Safari, and Opera. Even if a user uses an unlikely browser for editing, this simply means they would have to type in full text.

Therefore, we'll just remove the dependency entirely. Less code means there's less code to maintain and less code to attack.