### PR TITLE
Remove extraneous parenthesis

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1823,7 +1823,7 @@ en:
           passwords MUST be stored as iterated hashes with a per-user
           salt by using a key stretching (iterated) algorithm
           (e.g., Argon2id, Bcrypt, Scrypt, or PBKDF2). See also
-          <a href="https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html">OWASP Password Storage Cheat Sheet</a>).
+          <a href="https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html">OWASP Password Storage Cheat Sheet</a>.
         details: >-
           This criterion applies only when the software is enforcing
           authentication of users using passwords for external users


### PR DESCRIPTION
While working on a company-internal fork of this project, I copied all the criteria to a Markdown document to make it easier for us to assess which criteria would need to change to suit our internal environment. My editor highlighted this unmatched parenthesis.  I'm not sure if removing it is the right thing to do, though, or if pulling the "see also" sentence into the prior parenthetical statement would be better.