### PR TITLE
Simplify using Google Chrome for testing via VCR

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -69,6 +69,10 @@ WebMock.disable_net_connect!(allow_localhost: true, allow: driver_urls)
 require 'vcr'
 VCR.configure do |config|
   config.ignore_localhost = true
+  # We use Google Chrome for testing, which chattily updates.
+  # Ignore those, as it's the test infrastructure, not the software under test
+  config.ignore_hosts('127.0.0.1', 'localhost',
+                      'googlechromelabs.github.io', 'storage.googleapis.com')
   config.cassette_library_dir = 'test/vcr_cassettes'
   config.hook_into :webmock
   # Sometimes we have the "same" query but with and without per_page=...


### PR DESCRIPTION
Make it simpler test the system with VCR and Google Chrome.

We don't want the system reaching out to the Internet for testing in general. The system itself should work stand alone, and we don't want its testing to interfere to with real systems. We use VCR to record & play back interactions.

However, during testing we use Google Chrome. Chrome is *notoriously* chatty and likes to update. We use Chrome-for-Testing to deal with testing (a usual approach), but it likes to download information from certain locations to handle updates.

These downloads are *not* part of the system's execution itself, and we have no permissions to write to these facilities (so we can't possibly interfere with their interactions). Thus, let's allow these test-infrastructure downloads, so that we don't have to keep trying to fix it up.