### PR TITLE
Remove old YAML format for versions data

### DIFF
--- a/db/migrate/20241219131058_remove_old_yaml_object_from_versions.rb
+++ b/db/migrate/20241219131058_remove_old_yaml_object_from_versions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Remove old_yaml_object. We now store version information in the
+# column "object" in JSON format and we have converted all the data in
+# YAML format to the JSON format. We *could* retain the YAML copy,
+# but it takes up a lot of space for no gain.
+
+class RemoveOldYamlObjectFromVersions < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :versions, :old_yaml_object, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_18_182207) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_19_131058) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -35,8 +35,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_18_182207) do
 
   create_table "pg_search_documents", id: :serial, force: :cascade do |t|
     t.text "content"
-    t.string "searchable_type"
     t.integer "searchable_id"
+    t.string "searchable_type"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id"
@@ -437,7 +437,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_18_182207) do
     t.integer "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
-    t.text "old_yaml_object"
     t.datetime "created_at", precision: nil
     t.jsonb "object"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"


### PR DESCRIPTION
We now use JSON to store all versions data, and have converted the existing YAML into JSON. Remove the YAML copy of the old data.