### PR TITLE
Minor test cleanup, show_exceptions and Rakefile

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,7 +33,8 @@ Rails.application.configure do
     { size: (ENV['RAILS_CACHE_SIZE'] || '128').to_i.megabytes }
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  # This makes it easier to detect uncaught exceptions during testing.
+  config.action_dispatch.show_exceptions = :none
 
   # Raise exceptions during test if a translation is missing
   config.i18n.raise_on_missing_translations = true

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -691,7 +691,9 @@ end
 
 Rake::Task['test:run'].enhance ['test:features']
 
-# Modify system so 'test' forces runnning of system tests
+# Modify system so 'rake test' forces running of system tests.
+# NB: it's best to run 'rake test:all' or 'rails test:all' as that
+# is clearer.
 task test: 'test:system'
 
 # This is the task to run every day, e.g., to record statistics


### PR DESCRIPTION
Clean up test framework - fix deprecated way to use show_exceptions and clarify a Rakefile comment.