### PR TITLE
Remove icons from translations

### DIFF
--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -5,4 +5,4 @@
 # ignore the conflicts and "sync" again, it will fix this file for you.
 
 ---
-timestamp: 1735252133
+timestamp: 1735255299

--- a/config/locales/translation.de.yml
+++ b/config/locales/translation.de.yml
@@ -34,12 +34,9 @@ de:
     account: Konto
     profile: Profil
     settings: Einstellungen
-    logout_html: <i class="fa fa-sign-out" aria-hidden="true"></i>
-      Abmelden
-    signup_html: >-
-      <i class="fa fa-user-plus" aria-hidden="true"></i> Registrieren
-    login_html: <i class="fa fa-sign-in" aria-hidden="true"></i>
-      Anmelden
+    logout_html: Abmelden
+    signup_html: Registrieren
+    login_html: Anmelden
     footer_text_html: >-
       <small><strong>Brauchen Sie Hilfe? Haben Sie eine Frage?
       Sehen Sie ein Problem? Bitte <em><a href="mailto:&#99;ii&#45;badges&#45;questions&#45;own&#101;r&#64;lists&#46;coreinfrastructure&#46;or&#103;">senden
@@ -83,8 +80,7 @@ de:
     update_password: Passwort aktualisieren
   sessions:
     login_header: Einloggen
-    login_with_github_html: <span class="fa fa-github"></span>
-      Mit GitHub anmelden
+    login_with_github_html: Mit GitHub anmelden
     or: oder
     email: E-Mail
     password: Passwort

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -35,14 +35,9 @@ es:
     profile: Perfil
     settings: Ajustes
     choose_locale: Elige la configuración regional
-    logout_html: >-
-      <span class="glyphicon glyphicon-log-out"></span> Cerrar
-      sesión
-    signup_html: <span class="glyphicon glyphicon-user"></span>
-      Registrarse
-    login_html: >-
-      <span class="glyphicon glyphicon-log-in"></span> Iniciar
-      sesión
+    logout_html: Cerrar sesión
+    signup_html: Registrarse
+    login_html: Iniciar sesión
     footer_text_html:
     toggle_navigation:
   admin_only:
@@ -65,7 +60,7 @@ es:
     update_password:
   sessions:
     login_header:
-    login_with_github_html:
+    login_with_github_html: Iniciar sesión con GitHub
     or:
     email:
     password:

--- a/config/locales/translation.fr.yml
+++ b/config/locales/translation.fr.yml
@@ -23,12 +23,9 @@ fr:
     users: Utilisateurs
     profile: Profil
     settings: Paramètres
-    logout_html: >-
-      <i class="fa fa-sign-out" aria-hidden="true"></i> Déconnection
-    signup_html: >-
-      <i class="fa fa-user-plus" aria-hidden="true"></i> S'inscrire
-    login_html: >-
-      <i class="fa fa-sign-in" aria-hidden="true"></i> S'identifier
+    logout_html: Déconnection
+    signup_html: S'inscrire
+    login_html: S'identifier
     footer_text_html: >-
       <small> <strong>Vous avez besoin d'aide ? Vous avez une
       question ? Vous voyez un problème ? Merci de <em><a href="https://github.com/coreinfrastructure/best-practices-badge/issues"
@@ -50,8 +47,7 @@ fr:
     toggle_navigation: Choisir ou non la navigation repliable
   sessions:
     login_header: S'identifier
-    login_with_github_html: >-
-      <span class="fa fa-github"></span> Connectez-vous avec GitHub
+    login_with_github_html: Connectez-vous avec GitHub
     or: ou
     email: Email
     password: Mot de passe

--- a/config/locales/translation.ja.yml
+++ b/config/locales/translation.ja.yml
@@ -34,9 +34,9 @@ ja:
     account: アカウント
     profile: プロフィール
     settings: 設定
-    logout_html: <i class="fa fa-sign-out" aria-hidden="true"></i>ログアウト
-    signup_html: <i class="fa fa-user-plus" aria-hidden="true"></i>サインアップ
-    login_html: <i class="fa fa-sign-in" aria-hidden="true"></i>ログイン
+    logout_html: ログアウト
+    signup_html: サインアップ
+    login_html: ログイン
     footer_text_html: >-
       <small> <strong>疑問、質問、または問題がある場合は<em> <a href="mailto:&#99;ii&#45;badges&#45;questions&#64;lists&#46;coreinfrastructure&#46;or&#103;">電子メールで報告する</a></em>か、<em>
       <a href="https://github.com/coreinfrastructure/best-practices-badge/issues"
@@ -68,8 +68,7 @@ ja:
     update_password: パスワードを更新してください
   sessions:
     login_header: ログイン
-    login_with_github_html: <span class="fa fa-github"></span>
-      GitHub でログインする
+    login_with_github_html: GitHub でログインする
     or: または
     email: 電子メール
     password: パスワード

--- a/config/locales/translation.ru.yml
+++ b/config/locales/translation.ru.yml
@@ -35,13 +35,9 @@ ru:
     account: Учетная запись
     profile: Профиль
     settings: Настройки
-    logout_html: <span class="glyphicon glyphicon-log-out"></span>
-      Выйти
-    signup_html: >-
-      <span class="glyphicon glyphicon-user"></span> Зарегистрироваться
-    login_html: >-
-      <span class="glyphicon glyphicon-log-in"></span> Войти в
-      систему
+    logout_html: Выйти
+    signup_html: Зарегистрироваться
+    login_html: Войти в систему
     footer_text_html: >-
       <small> <strong>Нужна помощь? Есть вопрос? Видите ошибку?
       Пожалуйста, отправьте <em><a href="mailto:&#99;ii&#45;badges&#45;questions&#45;own&#101;r&#64;lists&#46;coreinfrastructure&#46;or&#103;">электронное
@@ -87,8 +83,7 @@ ru:
     update_password: Обновление пароля
   sessions:
     login_header: Войти
-    login_with_github_html: <span class="fa fa-github"></span>
-      Войти через GitHub
+    login_with_github_html: Войти через GitHub
     or: или
     email: Электронная почта
     password: Пароль

--- a/config/locales/translation.sw.yml
+++ b/config/locales/translation.sw.yml
@@ -36,11 +36,9 @@ sw:
     profile: Maelezo mafupi
     settings: Mipangilio
     choose_locale: Chagua eneo
-    logout_html: <i class="fa fa-sign-out" aria-hidden="true"></i>
-      Ondoka
+    logout_html: Ondoka
     signup_html:
-    login_html: <i class="fa fa-sign-in" aria-hidden="true"></i>
-      Ingia
+    login_html: Ingia
     footer_text_html: >-
       <small> <strong>Unahitaji msaada? Una swali? Unaona hitilafu?
       Tafadhali <em><a href="mailto:&#99;ii&#45;badges&#45;questions&#64;lists&#46;coreinfrastructure&#46;or&#103;">tuma
@@ -82,8 +80,7 @@ sw:
     update_password:
   sessions:
     login_header: Ingia
-    login_with_github_html: <span class="fa fa-github"></span>Ingia
-      kwa kutumia GitHub
+    login_with_github_html: Ingia kwa kutumia GitHub
     login_automatic_signup: >-
       Ingio inayotumia GitHub itajisajili kiatomati ikiwa ni lazima.
       Ukijisajili, jina lako (kama lilivyopewa GitHub) na jina

--- a/config/locales/translation.zh-CN.yml
+++ b/config/locales/translation.zh-CN.yml
@@ -21,12 +21,9 @@ zh-CN:
     users: 用户
     profile: 资料
     settings: 设置
-    logout_html: "<span class =“glyphicon glyphicon-log-out”></span>
-      注销"
-    signup_html: <span class="glyphicon glyphicon-user"></span>
-      注册
-    login_html: <span class="glyphicon glyphicon-log-in"></span>
-      登录
+    logout_html: 注销
+    signup_html: 注册
+    login_html: 登录
     footer_text_html: >-
       <small> <strong>需要帮助？有疑问？发现问题？请 <a href="mailto:&#99;ii&#45;badges&#45;questions&#45;own&#101;r&#64;lists&#46;coreinfrastructure&#46;or&#103;">发送邮件</a>
       或 <em><a href="https://github.com/coreinfrastructure/best-practices-badge/issues"
@@ -42,8 +39,7 @@ zh-CN:
     toggle_navigation: 切换可折叠导航
   sessions:
     login_header: 登录
-    login_with_github_html: <span class="fa fa-github"></span>
-      使用GitHub账户登录
+    login_with_github_html: 使用GitHub账户登录
     or: 或
     email: 电子邮件
     password: 密码


### PR DESCRIPTION
The translations were including special constructs to retrieve icons from Font Awesome. In retrospect, that was a mistake. They aren't translations; the icons stay the same in translations. This also makes it harder to change how icons are retrieved or which icons are used.

A previous commit inserted the icons and then the translations. However, if we don't fix the translations, in many places a user will see the icon twice (one from the app and one from the locale's translation).

This fixes the translations so that they no longer include the icons.