### PR TITLE
Send to debug log CDN purges from jobs

### DIFF
--- a/app/jobs/purge_cdn_project_job.rb
+++ b/app/jobs/purge_cdn_project_job.rb
@@ -13,5 +13,6 @@ class PurgeCdnProjectJob < ApplicationJob
   def perform(cdn_badge_key)
     # Send purge message to CDN
     FastlyRails.purge_by_key cdn_badge_key
+    Rails.logger.debug "Purged CDN key #{cdn_badge_key}"
   end
 end


### PR DESCRIPTION
Send a debug log when a job does a CDN purge. It's otherwise difficult to see if it happened.

To *see* the debug log results, you need to see it as described in implementation.md. E.g.:

> heroku config:set --app staging-bestpractices RAILS_LOG_LEVEL=debug