### PR TITLE
Improve efficiency, add defensive check

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -526,7 +526,8 @@ class ProjectsController < ApplicationController
   end
   # rubocop:enable Metrics/MethodLength
 
-  VALID_ADD_RIGHTS_CHANGES = /\A[+-](\d+(,\d+)*)+\z/.freeze
+  # Rights changes, if provided, must match this pattern.
+  VALID_ADD_RIGHTS_CHANGES = /\A *[+-] *\d+ *(, *\d+)*\z/.freeze
 
   # Examine proposed changes to additional rights - if okay, call
   # update_additional_rights_forced to do them.
@@ -851,7 +852,9 @@ class ProjectsController < ApplicationController
   def clean_url(url)
     return url if url.nil?
 
-    url.gsub(%r{\/+\z}, '')
+    # Remove all trailing slashes. Even "/" becomes the empty string
+    url = url.chop while url.end_with?('/')
+    url
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -177,6 +177,11 @@ class Badge
   private
 
   def load_svg(level)
+    # Defensive programming: only allow valid levels.
+    # This was checked earlier, but we re-check here so we're sure *and*
+    # that static analysis tools will know we've checked it.
+    return '' unless self.class.valid?(level)
+
     File.read("app/assets/images/badge_static_#{level}.svg")
   end
 end


### PR DESCRIPTION
Two regexes weren't efficient, replace them with something that is.

This also modifies app/models/badge.rb load_svg to check its input. This was already done earlier, but static analysis tools can't easily see that. It won't hurt us to check twice, as a defense mechanism, so let's do that. Then it's *clear* we only load known-acceptable values.