### PR TITLE
Enable owners to change project ownership

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -280,8 +280,14 @@ class ProjectsController < ApplicationController
       @project.purge_cdn_project
       old_badge_level = @project.badge_level
       final_project_params = project_params
-      # Only admins can *directly* change the project owner (user_id)
-      final_project_params = project_params.except('user_id') unless current_user.admin?
+      # Determine if we're trying to change ownership.
+      # Only admins and owner (can_control?) can change ownership
+      new_owner = final_project_params[:user_id]
+      owner_change = new_owner.present? && (new_owner == final_project_params[:user_id_repeat]) && User.exists?(id: new_owner)
+      if !can_control? || !owner_change
+        final_project_params = final_project_params.except('user_id')
+      end
+      final_project_params = final_project_params.except('user_id_repeat')
       final_project_params.each do |key, user_value| # mass assign
         @project[key] = user_value
       end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -56,10 +56,12 @@ class Project < ApplicationRecord
     license general_comments user_id disabled_reminders lock_version
     level additional_rights_changes
   ].freeze
+  PROJECT_USER_ID_REPEAT = %i[user_id_repeat].freeze # Repeat to change owner
   ALL_CRITERIA_STATUS = Criteria.all.map(&:status).freeze
   ALL_CRITERIA_JUSTIFICATION = Criteria.all.map(&:justification).freeze
   PROJECT_PERMITTED_FIELDS = (PROJECT_OTHER_FIELDS + ALL_CRITERIA_STATUS +
-                              ALL_CRITERIA_JUSTIFICATION).freeze
+                              ALL_CRITERIA_JUSTIFICATION +
+                              PROJECT_USER_ID_REPEAT).freeze
 
   default_scope { order(:created_at) }
 

--- a/app/views/projects/_form_0.html.erb
+++ b/app/views/projects/_form_0.html.erb
@@ -310,17 +310,30 @@
                 '0', 'Basics', 'Other', f, project, is_disabled
               ) %>
         </ul>
-      <% if current_user && current_user.admin? %>
+      <% if !is_disabled && current_user &&
+            (current_user.admin? || current_user.id == project.user_id) %>
         <div class="row">
         <div class="col-xs-12">
           <br>
-            New owner id (a positive integer):
+            <%= t 'projects.edit.new_owner' %>:
             <%= f.text_field :user_id,
                              hide_label: true, class:"form-control",
                              placeholder: nil,
                              spellcheck: false,
                              disabled: is_disabled %><br>
-            If changed, consider adding the old owner to additional rights list.
+        </div>
+        <div class="col-xs-12">
+          <br>
+            <%= t 'projects.edit.new_owner_repeat' %>:
+            <%# The user must provide the same value here as user_id to
+                cause an ownership change.
+                The client-side pattern here prevents some mistakes.
+                Since it's client-side we don't depend on it for security.
+            %>
+            <input type="text" name="project[user_id_repeat]"
+                   id="project_user_id_repeat" class="form-control"
+                   value="" spellcheck="false" pattern="^(|\d+)$"
+                   placeholder="">
         </div>
         </div>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -525,6 +525,8 @@ en:
         on your project page (see the "how to embed it" text just
         below if you don't know how to do that).
       lost_badge: Project has lost a badge.
+      new_owner: Owner id (a positive integer), change to change ownership
+      new_owner_repeat: Repeated new owner id (to confirm an ownership change)
       static_analysis_updated_html: >-
         We have updated our requirements for the criterion
         static_analysis. Please add


### PR DESCRIPTION
Admins have been able to change project ownership.

Now owners can also change ownership. To prevent accidents, the new owner id must be entered twice. This creates more text for translation.