### PR TITLE
Extract compute_key_array method for better testability

### DIFF
--- a/app/helpers/unsubscribe_helper.rb
+++ b/app/helpers/unsubscribe_helper.rb
@@ -9,13 +9,20 @@ module UnsubscribeHelper
   # Maximum unsubscribe token age in days from environment (computed once at startup)
   MAX_TOKEN_AGE_DAYS = (ENV['BADGEAPP_UNSUBSCRIBE_DAYS'] || '30').to_i
 
+  # Compute key array from comma-separated string
+  # @param keys_string [String] Comma-separated string of keys
+  # @return [Array<String>] Array of keys with empty ones removed and frozen
+  def self.compute_key_array(keys_string)
+    keys_string.split(',').map(&:strip).reject(&:empty?).freeze
+  end
+
   # Unsubscribe secret keys for key rotation (computed once at startup)
   # This allows tokens generated with any of these keys to be valid
   # Format: comma-separated list of keys, with the first being the current key for generation
   UNSUBSCRIBE_KEYS =
     begin
       keys_env = ENV['BADGEAPP_UNSUBSCRIBE_KEYS'] || Rails.application.secret_key_base
-      keys_env.split(',').map(&:strip).reject(&:empty?).freeze
+      compute_key_array(keys_env)
     end
 
   # Generate secure unsubscribe token with email and issued date.

--- a/test/helpers/unsubscribe_helper_test.rb
+++ b/test/helpers/unsubscribe_helper_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Copyright the Linux Foundation and the
+# OpenSSF Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+require 'test_helper'
+
+# rubocop: disable Metrics/BlockLength
+class UnsubscribeHelperTest < ActionView::TestCase
+  test 'compute_key_array with one key' do
+    key_string = 'fake_key_123'
+    result = UnsubscribeHelper.compute_key_array(key_string)
+
+    assert_equal ['fake_key_123'], result
+    assert result.frozen?
+  end
+
+  test 'compute_key_array with two keys separated by comma' do
+    key_string = 'fake_key_123,fake_key_456'
+    result = UnsubscribeHelper.compute_key_array(key_string)
+
+    assert_equal %w[fake_key_123 fake_key_456], result
+    assert result.frozen?
+  end
+
+  test 'compute_key_array with three keys separated by commas' do
+    key_string = 'fake_key_123,fake_key_456,fake_key_789'
+    result = UnsubscribeHelper.compute_key_array(key_string)
+
+    assert_equal %w[fake_key_123 fake_key_456 fake_key_789], result
+    assert result.frozen?
+  end
+
+  test 'compute_key_array handles whitespace around keys' do
+    key_string = ' fake_key_123 , fake_key_456 ,  fake_key_789  '
+    result = UnsubscribeHelper.compute_key_array(key_string)
+
+    assert_equal %w[fake_key_123 fake_key_456 fake_key_789], result
+    assert result.frozen?
+  end
+
+  test 'compute_key_array rejects empty keys' do
+    key_string = 'fake_key_123,,fake_key_456, ,fake_key_789'
+    result = UnsubscribeHelper.compute_key_array(key_string)
+
+    assert_equal %w[fake_key_123 fake_key_456 fake_key_789], result
+    assert result.frozen?
+  end
+
+  test 'compute_key_array with empty string returns empty array' do
+    key_string = ''
+    result = UnsubscribeHelper.compute_key_array(key_string)
+
+    assert_equal [], result
+    assert result.frozen?
+  end
+
+  test 'compute_key_array with only commas and spaces returns empty array' do
+    key_string = ' , , , '
+    result = UnsubscribeHelper.compute_key_array(key_string)
+
+    assert_equal [], result
+    assert result.frozen?
+  end
+end
+# rubocop: enable Metrics/BlockLength


### PR DESCRIPTION
This refactors the UNSUBSCRIBE_KEYS computation in UnsubscribeHelper by extracting the key parsing logic into a separate compute_key_array class method. This change makes it easier to test the key parsing functionality in isolation.

The new method takes a comma-separated string of keys and returns an array of trimmed, non-empty keys that is frozen. This maintains the exact same behavior as before while enabling comprehensive testing.

Added UnsubscribeHelperTest with tests covering:
- Single key parsing
- Multiple key parsing (2 and 3 keys)
- Whitespace handling
- Empty key rejection
- Edge cases with empty strings