### PR TITLE
Prevent Rake task redefinition warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,8 @@
 
 require File.expand_path('config/application', __dir__)
 
-Rails.application.load_tasks
+# Guard against loading tasks multiple times to prevent constant warnings
+
+unless Rake::Task.task_defined?('stats') || Rake::Task.task_defined?('environment') || defined?(STATS_DIRECTORIES)
+  Rails.application.load_tasks
+end

--- a/test/unit/lib/rake_task_test.rb
+++ b/test/unit/lib/rake_task_test.rb
@@ -9,8 +9,11 @@ require 'test_helper'
 class RakeTaskTest < ActiveSupport::TestCase
   test 'regression test for rake reminders' do
     assert_not_equal 0, Project.projects_to_remind.size
-    result = system 'rake reminders >/dev/null'
-    assert result
+
+    # This tests the actual rake command as it would be used in production
+    result = system('bundle exec rake reminders >/dev/null 2>&1')
+    assert result, 'rake reminders command should succeed'
+
     # This should work but isn't reliable on David's dev system.
     # assert_equal 0, Project.projects_to_remind.size
   end


### PR DESCRIPTION
Guard against loading Rails tasks multiple times in Rakefile to prevent constant redefinition warnings during test runs. Also improve the rake task test to use bundle exec and suppress stderr output for cleaner test execution.