### PR TITLE
Bugfix: Change external cache and cookie behavior

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -18,12 +18,10 @@ class StaticPagesController < ApplicationController
   skip_before_action :redir_missing_locale,
                      only: %i[robots error_404 google_verifier]
 
-  # Omit useless unchanged session cookie for performance & privacy
+  # Omit session cookie.
   # We *must not* set error messages in the flash area,
   # because flashes are stored in the session.
-  # Static pages operations never set the flash, so we can do this
-  # in all cases as part of the before_action.
-  before_action :omit_unchanged_session_cookie
+  before_action :omit_session_cookie, only: %i[robots google_verifier]
 
   def home; end
 


### PR DESCRIPTION
Add cases where cookies are set and where the external cache is not saved.  We've been trying to optimize the website by sometimes omitting cookies or aggressively caching. However, this can sometimes cause some subtle bugs.

What *really* matters is that we use the CDN caches for badge images, and that we not set cookies in that case (so that we avoid becoming a tracking cookie). *That* is what's important.
Trying to be clever about cachine other pages that vary, or not sending cookies in special cases, can lead to really complex and hard-to-debug situations.

In general, we try to take the "simple" path, let's do that with caches and cookies too.