### PR TITLE
Greatly simplify external cache handling

### DIFF
--- a/app/controllers/badge_static_controller.rb
+++ b/app/controllers/badge_static_controller.rb
@@ -11,7 +11,8 @@ class BadgeStaticController < ApplicationController
   skip_before_action :redir_missing_locale, only: :show
 
   # Cache this using the CDN
-  before_action :set_cache_control_headers, only: %i[show]
+  skip_before_action :set_default_cache_control, only: %i[show]
+  before_action :cache_on_cdn, only: %i[show]
 
   # rubocop:disable Metrics/MethodLength
   def show

--- a/config/initializers/cache_control_fix.rb
+++ b/config/initializers/cache_control_fix.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Middleware to ensure proper cache control headers for CDN protection.
+#
+# Rails CSRF protection sets 'Cache-Control: no-cache', which incorrectly
+# allows CDN caching. I've searched but found no way to control what it sets.
+#
+# This middleware fixes this by determining
+# when the Cache-Control value is exactly 'no-cache'. When it is,
+# the Cache-Control value is changed to 'private, no-cache', which means
+# no CDN caching (private) and web browsers must verify before use (no-cache).
+#
+# To enable CDN caching, simply set Cache-Control to 'public, no-cache'.
+# Since that is NOT exactly equal to 'no-cache', this shim will
+# have no effect.
+#
+# Note: This is rack middleware, so it won't execute in test cases
+# that don't go through rack middleware.
+#
+class CacheControlFixMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+
+    cache_control = headers['Cache-Control'] || headers['cache-control']
+
+    if cache_control == 'no-cache'
+      headers['Cache-Control'] = 'private, no-cache'
+    end
+
+    [status, headers, body]
+  end
+end
+
+# Insert this middleware into the stack. Since middleware wraps the entire
+# request/response cycle, this will process the response after Rails
+# controllers have set their cache control headers.
+Rails.application.config.middleware.use CacheControlFixMiddleware

--- a/test/integration/project_get_test.rb
+++ b/test/integration/project_get_test.rb
@@ -31,7 +31,7 @@ class ProjectGetTest < ActionDispatch::IntegrationTest
     # Check some normal headers
     assert_equal('text/html; charset=utf-8', @response.headers['Content-Type'])
     assert_equal(
-      # Note that this test *is* seing the rack middleware result!
+      # Note that this test *is* seeing the rack middleware result!
       'private, no-cache',
       @response.headers['Cache-Control']
     )

--- a/test/integration/project_get_test.rb
+++ b/test/integration/project_get_test.rb
@@ -31,7 +31,8 @@ class ProjectGetTest < ActionDispatch::IntegrationTest
     # Check some normal headers
     assert_equal('text/html; charset=utf-8', @response.headers['Content-Type'])
     assert_equal(
-      'max-age=0, private, must-revalidate',
+      # Note that this test *is* seing the rack middleware result!
+      'private, no-cache',
       @response.headers['Cache-Control']
     )
 


### PR DESCRIPTION
Eliminate external caching of most pages. Instead, use an external cache (especially the CDN, but also the user web broswer) only for the pages that *most*
matter for performance - particularly badge images.

Before we were using some clever tricks to externally cache more pages. However, this turns out to be tricky to get right because *many* pages vary depending on who is seeing them. This includes the pages headers (which vary depending on whether or not you're logged in), the "flash" reply (which may or may not be in a cookie), and the CSRF countermeasures.

This really isn't *necessary*. Most legitimate retrievals are badge images (because that's what is embedded in READMEs), so optimizing that is enough.

For interactive use, we use fragment caching, which is built into Rails and does a good job handling caches of *parts* of pages.

This simplifies the program, and thus makes it more likely to be correct in the first palce.

Annoyingly, I can't find any way to convince Rails' built-in CSRF mechanism to set the cache-control value to anything other than `no-cache`, and that value still permits CDN caching. So added a tiny `cache_control_fix.rb` shim to the rack middleware stack. This shim changes any cache-control value that is *only* `no-cache` into `private, no-cache` per our desires. Since this *always* runs after our main code, it ensures that anything using the CSRF mechanism is *never* cached by the CDN no matter what.