### PR TITLE
Improve anchored scrolling for navbar height

### DIFF
--- a/app/assets/javascripts/project-form.js
+++ b/app/assets/javascripts/project-form.js
@@ -475,6 +475,9 @@ function scrollToAnchor() {
   }
 
   var $navbar = $('.navbar-fixed-top');
+  if (!$navbar) {
+    return;
+  }
   var navbarHeight = $navbar.length ? $navbar.outerHeight() : 100;
   var targetTop = $target.offset().top;
   var scrollPosition = targetTop - navbarHeight;
@@ -491,7 +494,7 @@ function showHash() {
   var $target = $(hash);
   var $parentPane = $target.parents('.panel');
 
-  if ($parentPane.length) {
+  if ($parentPane && $parentPane.length) {
     var $collapseButton = $parentPane.find('.can-collapse');
     if ($collapseButton.hasClass('collapsed')) {
       // Panel needs to be opened - scroll after it opens

--- a/app/assets/javascripts/project-form.js
+++ b/app/assets/javascripts/project-form.js
@@ -473,14 +473,14 @@ function scrollToAnchor() {
   if (!$target.length) {
     return;
   }
+  var scrollPosition = $target.offset().top;
 
+  // Correct for navbar if present so the navbar doesn't cover it
   var $navbar = $('.navbar-fixed-top');
-  if (!$navbar) {
-    return;
+  if ($navbar) {
+    var navbarHeight = $navbar.length ? $navbar.outerHeight() : 100;
+    scrollPosition -= navbarHeight;
   }
-  var navbarHeight = $navbar.length ? $navbar.outerHeight() : 100;
-  var targetTop = $target.offset().top;
-  var scrollPosition = targetTop - navbarHeight;
 
   $('html, body').animate({scrollTop: scrollPosition}, 0);
 }
@@ -494,7 +494,7 @@ function showHash() {
   var $target = $(hash);
   var $parentPane = $target.parents('.panel');
 
-  if ($parentPane && $parentPane.length) {
+  if ($target && $parentPane && $parentPane.length) {
     var $collapseButton = $parentPane.find('.can-collapse');
     if ($collapseButton.hasClass('collapsed')) {
       // Panel needs to be opened - scroll after it opens


### PR DESCRIPTION
The default web browser behavior when going to an anchor doesn't automatically open a named panel, and opens in the "wrong place" because it doesn't account for the navbar height (so the navbar often covers the contents). So we've long implemented some code so that when you're running client-side JavaScript it behaves in a nicer way.

The previous anchored scrolling implementation used a fixed 100px offset for the navbar. This caused incorrect scroll positioning when the navbar wrapped to multiple lines or had different heights due to various screen sizes.

Key improvements:
- Dynamically measure actual navbar height instead of using a fixed offset
- Use requestAnimationFrame so measurements occur after layout completion
- Handle all anchor navigation scenarios: initial page load, hash changes, and URL bar re-entry with existing hash. That way, for example, users can push "enter" in the URL bar and it will "do the right thing"
- Properly open collapsed panels before scrolling to anchors within them

This ensures anchors always scroll to the correct position regardless of navbar height variations across different devices and content.