### PR TITLE
Fix display of N/A on Firefox

### DIFF
--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -147,6 +147,7 @@ label.required:after {
   font-family:Arial;
   font-size:1em;
   font-weight: normal;
+  white-space: nowrap;
 }
 
 .checkbox {


### PR DESCRIPTION
In at least some versions of Firefox, the display of "N/A" doesn't look good, because it adds a line break after "/". This adds a tweak that solves the problem - tweak the CSS to prevent any line breaks within radio button labels (.criteria-radio label), eliminating the unhelpful word wrap.

Our radio button labels are very short, so the word wrapping was unhelpful.

This may help other browsers too, I just noticed it in Firefox.