### PR TITLE
Add a project .mdlrc file

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style "config/markdown_style.rb"

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -6,6 +6,12 @@
 
 # Rake tasks for BadgeApp
 
+# If you use our standard development environment using `rbenv` you usually
+# don't need to prefix commands with "bundle exec" or "bin/" to ensure
+# you're running in the correct Ruby virtual environment.
+# However, the rake tasks generally use "bundle exec" to be *sure* that
+# we're in the correct environment, regardless of the circumstance.
+
 require 'json'
 
 # NOTE: Our default runs test:all, not just test.
@@ -173,8 +179,7 @@ end
 # end in ".markdown" instead.  (E.g., for markdown fragments.)
 desc 'Run markdownlint (mdl) - check for markdown problems on **.md files'
 task :markdownlint do
-  style_file = 'config/markdown_style.rb'
-  sh "bundle exec mdl -s #{style_file} *.md docs/*.md"
+  sh "bundle exec mdl *.md docs/*.md"
 end
 
 # Apply JSCS to look for issues in JavaScript files.


### PR DESCRIPTION
By adding a .mdlrc file, we make it easier to directly invoke markdownlint (mdl) for specific files, because the .mdlrc file tells the system where to load our style.

This is handy when we have a problem with a specific file or set of files. we can run mdl directly on just those files with just `mdl FILENAMES`, without having to carefully re-specify our style on the command line.

This simplified our rake file, and we may as well document why we use "bundle exec" there even though it's not necessary in the development environment if configured as recommended.