### PR TITLE
Update gem dotenv to version 3.1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,7 +115,7 @@ group :development, :test do
   gem 'awesome_print' # Pretty print Ruby objects
   gem 'bullet' # Avoid n+1 queries
   gem 'bundler-audit' # Alert if Gemfile.lock gems have known vulnerabilities
-  gem 'dotenv-rails', '~> 2.7' # Load env vars from .env files into Rails ENV
+  gem 'dotenv', '~> 3.0' # Load env vars from .env files into Rails ENV
   gem 'eslintrb' # Linter for JavaScript code.
   gem 'json', '~> 2.0' # Process JSON format
   gem 'license_finder', '~> 7.0' # Verify that all sw licenses are acceptable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,10 +135,7 @@ GEM
     csv (3.3.5)
     date (3.4.1)
     docile (1.4.1)
-    dotenv (2.8.1)
-    dotenv-rails (2.8.1)
-      dotenv (= 2.8.1)
-      railties (>= 3.2)
+    dotenv (3.1.8)
     drb (2.2.3)
     encryptor (3.0.0)
     erb (5.0.2)
@@ -612,7 +609,7 @@ DEPENDENCIES
   capybara-slow_finder_errors
   chartkick (~> 4.0)
   codecov
-  dotenv-rails (~> 2.7)
+  dotenv (~> 3.0)
   eslintrb
   faraday-retry (~> 2.1)
   font_awesome5_rails


### PR DESCRIPTION
This updated gem includes integrations for Rails,
so we no longer need a separate dotenv-rails.