### PR TITLE
Address claimed security issues from Claude Code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,9 @@ class ApplicationController < ActionController::Base
   before_action :set_paper_trail_whodunnit
 
   # Limit time before must log in again.
+  # The `validate_session_timestamp` will log out users once their
+  # login session time has expired, and it's checked before any main
+  # action unless specifically exempted.
   before_action :validate_session_timestamp
   after_action :persist_session_timestamp
 

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -14,6 +14,10 @@ class PasswordResetsController < ApplicationController
 
   def edit; end
 
+  # Process password reset requests.
+  # NOTE: Rate limiting for password reset requests is handled by Rack::Attack
+  # (see config/initializers/rack_attack.rb)
+  #
   # NOTE: password resets *always* reply with the same message, in all cases.
   # At one time we replied with error reports if there was no account or if
   # there was a GitHub account (not a local account) with the email address.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -116,6 +116,9 @@ class UsersController < ApplicationController
     redirect_to @user unless current_user_can_edit?(@user)
   end
 
+  # Create new user account (signup functionality).
+  # NOTE: Rate limiting for account creation is handled by Rack::Attack
+  # (see config/initializers/rack_attack.rb)
   # rubocop: disable Metrics/MethodLength, Metrics/AbcSize
   def create
     if Rails.application.config.deny_login

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -89,7 +89,15 @@ module SessionsHelper
     logged_in? && current_user.admin?
   end
 
-  # Remembers a user in a persistent session.
+  # Remembers a user in a persistent session in a permanent cookie.
+  # This is cryptographically secure, because we protect it in the permanent
+  # cookies using Rails' mechanisms. This means that if an attacker
+  # gains access to the remember token (e.g., by capturing the browser's
+  # cookie values), the attacker will be gain persistent access to the
+  # user's account. However, this is *not* considered a vulnerability, since
+  # that is the *point* of the remember token, and this only occurs when
+  # a user specifically requests it. We could try to add device fingerprinting,
+  # but an attacker could forge that.
   def remember(user)
     user.remember
     cookies.permanent.signed[:user_id] = user.id


### PR DESCRIPTION
Claude Code identified a number of possible security issues. None are significant. However, since we want to re-run analysis later, I added many inline comments to
justify why there isn't a serious problem. That way, later AI tools (and humans!) will have the information they need to help them realize that these aren't serious security issues.

In some cases I added additional hardening. None was strictly necessary, but adding more hardening to make the software even *harder* to attack seemed like a good idea, as long as they were easy to add and didn't add a maintenance burden.

Claimed issues:

1. Race Condition in User Email Validation in `app/models/user.rb`. It's true that Rails' validation by itself has a race condition, but we *also* enforce that in the database where there can't be a race condition. We do the Rails validation first because we can provide nicer error messages in that case. Comments added to explain this.

2. Session Hijacking Through Remember Token Weakness, `app/models/user.rb` and `app/helpers/sessions_helper.rb`. This is a fundamental property of a remember token - if a remember token is acquired by an attacker, the attacker can reuse it. Documented.

3. Timing Attack in Password Reset, `app/models/user.rb`, because of a `find_by`. This isn't vulnerable to a timing attack because we have a partial index that prevents the revelation of timing information. Documented, including the index name.

4. Mass Assignment in OAuth User Creation, `app/models/user.rb`. If GitHub become malicious, input validation won't save us. I added some small half-hearted validations in case there's a bug in GitHub, but there's no point in trying to be serious about this. By design GitHub is one of the services we trust, and that is clearly documented. They've generally been quite reliable, so I think that is reasonable.

5. Weak Session Timeout Implementation, `app/helpers/sessions_helper.rb`. False positive. I added in-line comment documentation to make this clearer.

6. Information Disclosure in Error Messages, `app/controllers/sessions_controller.rb` in the line `flash.now[:danger] = t('sessions.incorrect_login_info')`. No, there's no information disclosure. The other branches all deal with cases where the user *already* knows that information. In particular, the user knows whether or not we permit login (we usually do), and the user knows if they want a GitHub or local authentication. So nothing is revealed. Documented.

7. Missing Rate Limiting on Critical Actions. The tool reported "there's no evidence of rate limiting on password reset, account creation, or login attempts."
There *is* rate limiting on account creation and login attempts through Rack::Attack.
There wasn't a rate limit for password reset; it's not strictly needed, since it would require a break in well-tested cryptographic algorithm or a failure in our constant-time comparison
for that to work. Still, what the heck, it'd be easy to add a rate limit for password resets, and we *like* hardening things. Adding rate limits means if we have a subtle timing vulnerability it will be much harder to exploit (it'd probably be unexpoitable now). So I added that rate limit, and documented all three. I added a note in the various controllers to look at the Rack::Attack configuration for rate limits, so a reader of those controllers would know where to look for more informaiton.