### PR TITLE
Document admin name-search abilities

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,9 +35,15 @@ class UsersController < ApplicationController
   # Search users for desired_name (which is presumed to be non-empty)
   # @param desired_name [String] The name to search for (case-insensitive partial match)
   def search_name(desired_name)
-    # To maximize finding, use a case-sensitive "find anywhere" search.
+    # To maximize finding, use a case-insensitive "find anywhere" search.
     # An exact case-sensitive search would for names look like this:
     # result = result.where(name: params[:name])
+    #
+    # INTENTIONAL: We do NOT escape LIKE wildcards (% and _) here because
+    # admin users need wildcard search capabilities for GDPR compliance
+    # and legal requests. This allows admins to use % for zero or more
+    # characters and _ for exactly one character in their search patterns.
+    # This is safe because only admin users can access this functionality.
     User.where('lower(name) LIKE ?', "%#{desired_name.strip.downcase}%")
   end
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -23,12 +23,13 @@
 <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
 
 <% if current_user&.admin? %>
-<h2 class>New Search (case-insensitive)</h2>
+<h2 class>New Search</h2>
+<p><strong>Name search is case-insensitive and supports wildcards:</strong> Use % for zero or more characters and _ for exactly one character.</p>
  <%= form_for users_path, method: 'get', enforce_utf8: true do %>
   <label for="name"><%= 'Name' %></label>
-  <%= text_field_tag :name, params[:name], size: 40, placeholder: 'User name' %>
+  <%= text_field_tag :name, params[:name], size: 40, placeholder: 'User name (case-insensitive, % and _)' %>
   <label for="email"><%= 'Email' %></label>
-  <%= text_field_tag :email, params[:email], size: 60, placeholder: 'User email' %>
+  <%= text_field_tag :email, params[:email], size: 60, placeholder: 'User email (case-insensitive exact match)' %>
   <%= submit_tag 'User Search', name: nil %>
  <% end %>
 <% end %>

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -1761,6 +1761,10 @@ list the additional items added since 2013.
    Any inputs to SQL commands are always parameterized, trusted, or both,
    typically using its parametrized mechanisms or similar mechanisms such as
    `sanitize_sql_like`.
+   Note: Admin user search intentionally does NOT escape LIKE wildcards
+   (% and _) to support GDPR compliance and legal requests requiring
+   pattern matching. This is safe because only admin users can access
+   this functionality (UsersController#search_name).
    The shell is not used to download or process file contents (e.g., from
    repositories), instead, various Ruby APIs acquire and process it directly.
 2. Broken Authentication and Session Management.


### PR DESCRIPTION
Admins, when searching on names, can use LIKE pattern matches. Make that clearer and document why that's secure.