### PR TITLE
Tweak report_code_statistics

### DIFF
--- a/script/report_code_statistics
+++ b/script/report_code_statistics
@@ -1,11 +1,12 @@
 #!/bin/sh
 echo
+bin/rails stats
+# Compute the direct dependencies from Gemfile.lock by counting
+# ONLY non-empty lines between "DEPENDENCIES" and "RUBY VERSION":
 direct=$(sed -e '1,/^DEPENDENCIES/d' -e '/^RUBY VERSION/,$d' \
              -e '/^$/d' Gemfile.lock | wc -l)
-indirect=$(bundle list | tail -n +2 | wc -l)
+indirect=$(bundle list | grep -c '^  *\* ')
 echo "Number of gems (direct dependencies only) = $direct"
 echo "Number of gems (including indirect dependencies) = $indirect"
-echo
-bin/rails stats
 echo
 true


### PR DESCRIPTION
Reverse order of stats so the gem up-to-date% (if printed) will logically follow, and clean up script.