### PR TITLE
Upgrade to Puma 7 and remove puma_worker_killer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,8 +93,7 @@ gem 'paleta', '~> 0.3' # Color manipulation, used for badges
 gem 'paper_trail', '~> 16.0' # Record previous versions of project data
 gem 'pg', '~> 1.4' # PostgreSQL database, used for data storage
 gem 'pg_search', '~> 2.3' # PostgreSQL full-text search
-gem 'puma', '~> 6.5' # Faster webserver; recommended by Heroku
-gem 'puma_worker_killer', '~> 1.0' # Band-aid: Restart to limit memory use
+gem 'puma', '~> 7.0' # Faster webserver; recommended by Heroku
 gem 'rack', '~> 3.2.3' # interface between web server + web framework (Rails)
 gem 'rack-attack', '~> 6.7' # Implement rate limiting
 gem 'rack-cors', '~> 3.0' # Enable CORS so JavaScript clients can get JSON

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,9 +174,6 @@ GEM
     fugit (1.11.2)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
-    get_process_mem (1.0.0)
-      bigdecimal (>= 2.0)
-      ffi (~> 1.0)
     gettext (3.4.9)
       erubi
       locale (>= 2.0.5)
@@ -360,12 +357,8 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (6.6.1)
+    puma (7.0.4)
       nio4r (~> 2.0)
-    puma_worker_killer (1.0.0)
-      bigdecimal (>= 2.0)
-      get_process_mem (>= 0.2)
-      puma (>= 2.7)
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.3)
@@ -640,8 +633,7 @@ DEPENDENCIES
   pg (~> 1.4)
   pg_search (~> 2.3)
   pry-byebug
-  puma (~> 6.5)
-  puma_worker_killer (~> 1.0)
+  puma (~> 7.0)
   rack (~> 3.2.3)
   rack-attack (~> 6.7)
   rack-cors (~> 3.0)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -40,14 +40,16 @@ environment ENV.fetch('RAILS_ENV') { 'development' }
 #
 # preload_app!
 
-# The code in the `on_worker_boot` will be called if you are using
+# The code in the `before_worker_boot` will be called if you are using
 # clustered mode by specifying a number of `workers`. After each worker
 # process is booted this block will be run, if you are using `preload_app!`
 # option you will want to use this block to reconnect to any threads
 # or connections that may have been created at application boot, Ruby
 # cannot share connections between processes.
+# Note: In Puma 7+, the hook was renamed from `on_worker_boot` to
+# `before_worker_boot`.
 #
-# on_worker_boot do
+# before_worker_boot do
 #   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
 # end
 
@@ -58,13 +60,3 @@ plugin :tmp_restart
 # so scheduled jobs will happen even if the system crashes.
 # Set the environment variable if you want it activated (e.g., in production)
 plugin :solid_queue if ENV['SOLID_QUEUE_IN_PUMA'] # || Rails.env.development?
-
-# Use puma_worker_killer to occasionally restart.
-# This is a band-aid to counter memory growth.
-# There's a performance hit (restart time + cache loss), but it
-# forcibly gets rid of junk in memory.
-before_fork do
-  require 'puma_worker_killer'
-
-  PumaWorkerKiller.enable_rolling_restart(8 * 3600) # Every 8 hours in seconds
-end


### PR DESCRIPTION
Update Puma from 6.5 to 7.0 for better performance and active support.

Remove puma_worker_killer gem, which was added in 2020 as a temporary band-aid for memory growth. Modern Ruby 3.3 GC is significantly better than Ruby 2.7 from 2020, so I believe this workaround is now unnecessary. We'll rely on Scout APM (already installed) for memory monitoring and fix actual leaks if they occur rather than masking them with periodic restarts.

Note: puma_worker_killer wasn't actually working in the latest configuration since workers were disabled in the Puma configuration.