### PR TITLE
Enable controlling of project show cache

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -32,6 +32,9 @@ class ProjectsController < ApplicationController
 
   helper_method :repo_data
 
+  # Cache control for show action - can be disabled via environment variable
+  CACHE_SHOW_PROJECT = ENV['BADGEAPP_CACHE_SHOW_PROJECT'] != 'false'
+
   # These are the only allowed values for "sort" (if a value is provided)
   ALLOWED_SORT =
     %w[

--- a/app/views/projects/_form_0.html.erb
+++ b/app/views/projects/_form_0.html.erb
@@ -21,7 +21,8 @@
    # The badge URL has one value for some time after the project entry
    # is edited, and then changes. To handle that gracefully, we
    # expire the cache after a period of time.
-   cache_if is_disabled, [project, locale, additional_rights_list],
+   cache_if ProjectsController::CACHE_SHOW_PROJECT && is_disabled,
+           [project, locale, additional_rights_list],
             expires_in: 12.hours do %>
 <%= render(partial: 'form_early',
            locals:

--- a/app/views/projects/_form_1.html.erb
+++ b/app/views/projects/_form_1.html.erb
@@ -16,7 +16,8 @@
 <%# The badge URL has one value for some time after the project entry
    is edited, and then changes. To handle that gracefully, we
    expire the cache after a period of time. %>
-<% cache_if is_disabled, [project, locale], expires_in: 12.hours do %>
+<% cache_if ProjectsController::CACHE_SHOW_PROJECT && is_disabled,
+            [project, locale], expires_in: 12.hours do %>
 <%= render(partial: 'form_early',
            locals:
              {

--- a/app/views/projects/_form_2.html.erb
+++ b/app/views/projects/_form_2.html.erb
@@ -16,7 +16,8 @@
 <%# The badge URL has one value for some time after the project entry
    is edited, and then changes. To handle that gracefully, we
    expire the cache after a period of time. %>
-<% cache_if is_disabled, [project, locale], expires_in: 12.hours do %>
+<% cache_if ProjectsController::CACHE_SHOW_PROJECT && is_disabled,
+            [project, locale], expires_in: 12.hours do %>
 <%= render(partial: 'form_early',
            locals:
              {


### PR DESCRIPTION
Enable controlling of the project show cache.

At one time it was "obvious" we should cache the "show project" detailed information. However, we are now being constantly spidered so much that cached values will often be evicted before they can be used. The constant spidering, combined with constant caching, is causing our memory use to increase over time.

This change allows us to control caching with an environment variable. By default we cache a project show (what we've already been doing). This will let us enable/disable caching quickly. If we like this new setup, we may switch to it entirely, but enabling quick changes seems like the safest first step.