### PR TITLE
Remove a deprecation warning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,4 +28,4 @@ Rails.application.configure do
   config.middleware.use Rack::Attack
 end
 
-# Note: the only timezone we use it UTC.
+# NOTE: the only timezone we use is UTC.


### PR DESCRIPTION
* Remove setting `ActiveSupport.to_time_preserves_timezone = :zone`.

This eliminates this deprecation warning:

~~~~
DEPRECATION WARNING: `config.active_support.to_time_preserves_timezone` is deprecated and will be removed in Rails 8.2
(called from <top (required)> at config/application.rb:37) ~~~~

We only set the timezone so that we'd be compatible with the future default, and we only deal in UTC timezone anyway.

* Unfortunately, we *cannot* fix this deprecation warning:

~~~~
DEPRECATION WARNING: ActiveSupport::Configurable is deprecated without replacement, and will be removed in Rails 8.2. You can emulate the previous behavior with `class_attribute`. (called from <top (required)> at config/application.rb:16) ~~~~

This deprecation warning is triggered by Rails itself, specifically in the activesupport-8.1.1 gem. Here's what appears to be happening:

1. The warning fires immediately when the file is loaded - Look at /home/dwheeler/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/ activesupport-8.1.1/lib/active_support/configurable.rb lines 3-7. The deprecation warning is at the TOP of the file, meaning it triggers the moment anyone loads this file.
2. Configurable is autoloaded in ActiveSupport - In active_support.rb line 42, Configurable is declared as an autoload. This means it gets loaded when something references ActiveSupport::Configurable.

Since this appears to be a warning caused from Rails using itself, I'll let the Rails developers sort themselves out. I expect this warning to naturally disappear once the Rails ecosystem (specifically Rails itself) fully migrates away from Configurable.