### PR TITLE
Update gem paper_trail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ gem 'omniauth-github', '~> 2.0' # Authentication to GitHub (get project info)
 gem 'omniauth-rails_csrf_protection', '~> 1.0' # integrate omniauth with rails
 gem 'pagy', '~> 9.0' # Paginator for web pages
 gem 'paleta', '~> 0.3' # Color manipulation, used for badges
-gem 'paper_trail', '~> 16.0' # Record previous versions of project data
+gem 'paper_trail', '~> 17.0' # Record previous versions of project data
 gem 'pg', '~> 1.4' # PostgreSQL database, used for data storage
 gem 'pg_search', '~> 2.3' # PostgreSQL full-text search
 gem 'puma', '~> 7.0' # Faster webserver; recommended by Heroku

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,8 +327,8 @@ GEM
     ostruct (0.6.3)
     pagy (9.4.0)
     paleta (0.3.0)
-    paper_trail (16.0.0)
-      activerecord (>= 6.1)
+    paper_trail (17.0.0)
+      activerecord (>= 7.1)
       request_store (~> 1.4)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -632,7 +632,7 @@ DEPENDENCIES
   ostruct
   pagy (~> 9.0)
   paleta (~> 0.3)
-  paper_trail (~> 16.0)
+  paper_trail (~> 17.0)
   pg (~> 1.4)
   pg_search (~> 2.3)
   pry-byebug


### PR DESCRIPTION
This is designed to be compatible with Rails 8.1 and has no backwards incompatibilities that matter to us (as far as I can tell!).