### PR TITLE
Implement baseline CI/CD check OSPS-BR-01.02

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,12 @@ jobs:
     # https://github.com/CircleCI-Public/browser-tools-orb/issues/75
     # https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v1.4.2
     - browser-tools/install-chromedriver
+    # Implement OSPS-BR-01.02: Validate branch name before use in pipeline
+    # Protect against malicious branch names that could cause cache poisoning
+    # or command injection attacks. Branch names are used in cache keys below.
+    - run:
+        name: Validate branch name
+        command: script/validate_branch_name "$CIRCLE_BRANCH"
     - run: pwd
     - run: ls -l
     - run: |
@@ -165,6 +171,27 @@ jobs:
     executor: ruby-only
     steps:
       - checkout
+      # OSPS-BR-01.02: Validate branch name before use in deployment
+      # Defense in depth - even though workflow filters limit to staging/production,
+      # the code should validate explicitly to prevent accidents or misconfigurations
+      - run:
+          name: Validate branch name format
+          command: script/validate_branch_name "$CIRCLE_BRANCH"
+      - run:
+          name: Validate deployment branch allowlist
+          command: |
+            # Deploy job should ONLY run on staging or production branches
+            # Using POSIX-compliant case statement
+            case "$CIRCLE_BRANCH" in
+              staging|production)
+                echo "Deployment branch validated: $CIRCLE_BRANCH"
+                ;;
+              *)
+                echo "ERROR: Deploy job on invalid branch: $CIRCLE_BRANCH"
+                echo "Deploy is only allowed for: staging, production"
+                exit 1
+                ;;
+            esac
       - run:
           # We are downloading these tools from a trusted source, so we *do*
           # want to use the latest version, not a pinned version.

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      # OSPS-BR-01.02: Validate branch name before use in pipeline
+      # This protects against potential future use of branch names in commands
+      # GITHUB_REF_NAME is the short ref name (e.g., "main" not "refs/heads/main")
+      - name: Validate branch name
+        run: script/validate_branch_name "$GITHUB_REF_NAME"
       - name: Codespell
         uses: codespell-project/actions-codespell@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,12 @@ jobs:
       # the naming convention of https://github.com/mheap/pin-github-action
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pin @v4.1
 
+      # OSPS-BR-01.02: Validate branch name before use in pipeline
+      # This protects against potential future use of branch names in commands
+      # GITHUB_REF_NAME is the short ref name (e.g., "main" not "refs/heads/main")
+      - name: Validate branch name
+        run: script/validate_branch_name "$GITHUB_REF_NAME"
+
       # Runs a single command using the runners shell
       - name: Run a one-line script
         run: echo Hello, world!

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,6 +36,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # OSPS-BR-01.02: Validate branch name before use in pipeline
+      # This protects against potential future use of branch names in commands
+      # GITHUB_REF_NAME is the short ref name (e.g., "main" not "refs/heads/main")
+      - name: "Validate branch name"
+        run: script/validate_branch_name "$GITHUB_REF_NAME"
+
       - name: "Run analysis"
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:

--- a/script/validate_branch_name
+++ b/script/validate_branch_name
@@ -1,0 +1,72 @@
+#!/bin/sh
+# frozen_string_literal: true
+
+# Copyright the Linux Foundation and the CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+# Validate branch name for CI/CD pipelines
+# Implements OSPS-BR-01.02: Branch name sanitization and validation
+#
+# This script validates that branch names contain only safe characters
+# and don't start with characters that could be confused as option flags.
+# This prevents command injection and cache poisoning attacks.
+#
+# Usage: validate_branch_name BRANCH_NAME
+#
+# Exit codes:
+#   0 - Branch name is valid
+#   1 - Branch name is invalid
+
+set -e
+
+# Check for required argument
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 BRANCH_NAME" >&2
+  exit 1
+fi
+
+BRANCH_NAME="$1"
+
+# Reject empty branch name
+if [ $# = '' ]; then
+  echo "ERROR: Branch name must not be empty" >&2
+  exit 1
+fi
+
+# Reject branch names starting with hyphen
+# (these could be confused as being an option flag)
+case "$BRANCH_NAME" in
+  -*)
+    echo "ERROR: Branch name must not start with '-': $BRANCH_NAME" >&2
+    exit 1
+    ;;
+esac
+
+# Reject branch names including ..
+# (these could escape up a directory)
+case "$BRANCH_NAME" in
+  *..*)
+    echo "ERROR: Branch name must not include ..: $BRANCH_NAME" >&2
+    exit 1
+    ;;
+esac
+
+# Validate allowed characters using POSIX-compliant case statement
+# Allowed: A-Z, a-z, 0-9, /, _, ., +, -
+case "$BRANCH_NAME" in
+  *[!A-Za-z0-9/_.+-]*)
+    echo "ERROR: Branch name has unsafe characters: $BRANCH_NAME" >&2
+    echo "Branch names only allow A-Za-z0-9/_.+-" >&2
+    exit 1
+    ;;
+esac
+
+# Length check (POSIX-compliant)
+BRANCH_LENGTH=$(printf '%s' "$BRANCH_NAME" | wc -c)
+if [ "$BRANCH_LENGTH" -gt 200 ]; then
+  echo "ERROR: Branch name too long: $BRANCH_LENGTH characters" >&2
+  exit 1
+fi
+
+echo "Branch name validated (per OSPS-BR-01.02): $BRANCH_NAME"
+exit 0


### PR DESCRIPTION
Implement baseline requirement OSPS-BR-01.02
(Branch name sanitization and validation), and document that in the assurance case.

This also documents that we already met OSPS-BR-01.01 (Input parameter sanitization), with justification, in the assurance case.