### PR TITLE
Fix tests for staleness and code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,10 @@
 # Configure codecov.
 # https://docs.codecov.io/docs/codecov-yaml
 
+# NOTE: If you change the codecov configuration here (used on the website),
+# you may also need to change the SimpleCov configuration as managed via
+# test/test_helper.rb.
+
 ignore:
   # These files aren't run in production, and any defects can be addressed
   # during the development process, so ignore test coverage for them:

--- a/lib/asset_staleness_middleware.rb
+++ b/lib/asset_staleness_middleware.rb
@@ -30,9 +30,10 @@ class AssetStalenessMiddleware
     checker = AssetStalenessChecker.from_rails_config(Rails.application)
     checker&.check_and_warn(env: Rails.env)
   rescue StandardError => e
-    # Re-raise in development, log in test/production
-    raise if Rails.env.development?
+    # Re-raise in development and test to fail fast
+    raise if Rails.env.local?
 
+    # In production, just log the error
     Rails.logger.error("Asset staleness check failed: #{e.message}")
   end
 end

--- a/test/lib/asset_staleness_middleware_test.rb
+++ b/test/lib/asset_staleness_middleware_test.rb
@@ -70,31 +70,18 @@ class AssetStalenessMiddlewareTest < ActiveSupport::TestCase
     end
   end
 
-  test 'logs errors in test environment' do
-    # Test line 36: Rails.logger.error(...) in test environment
+  test 're-raises errors in test environment' do
+    # Test line 34: raise if Rails.env.local? (includes test environment)
+    # This matches the AssetStalenessChecker's design to fail fast in test
     checker = Object.new
     def checker.check_and_warn(env:)
       raise StandardError, 'Test error in test env'
     end
 
-    logger = Object.new
-    def logger.error(msg)
-      @logged = msg
-    end
-
-    def logger.logged
-      @logged
-    end
-
     middleware = AssetStalenessMiddleware.new(@app)
     AssetStalenessChecker.stub :from_rails_config, checker do
       Rails.stub :env, ActiveSupport::EnvironmentInquirer.new('test') do
-        Rails.stub :logger, logger do
-          # Should not raise in test, just log
-          status, _headers, _body = middleware.call(@env)
-          assert_equal 200, status
-          assert_match(/Asset staleness check failed/, logger.logged)
-        end
+        assert_raises(StandardError, 'Test error in test env') { middleware.call(@env) }
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,10 @@
 # OpenSSF Best Practices badge contributors
 # SPDX-License-Identifier: MIT
 
+# NOTE: If you change SimpleCov configuration (used locally), you may also
+# need to change codecov configuration (used on the website) as managed
+# via codecov.yml.
+
 # *MUST* load 'simplecov' FIRST, before any other code is run.
 # See: https://github.com/colszowka/simplecov/issues/296
 require 'simplecov'
@@ -23,12 +27,17 @@ else
 end
 
 # Start SimpleCov to track coverage
+# NOTE: If you change SimpleCov configuration (used locally), you may also
+# need to change codecov configuration (used on the website) as managed
+# via codecov.yml.
 SimpleCov.start 'rails' do
   add_group 'Validators', 'app/validators'
   add_filter '/config/'
   add_filter '/lib/tasks'
   add_filter '/test/'
   add_filter '/vendor/'
+  # Exclude baseline development scripts (not run in production)
+  add_filter %r{^/lib/baseline_.*\.rb$}
 end
 
 # Some tests flap, producing false failures, so enable auto-retry


### PR DESCRIPTION
* Cause test suite to *fail* if the assets aren't precompiled but should be. I've now wasted *many* hours trying to track down non-existent problems because I or my AI system forgot to precompile the assets.
* Modify code coverage so that local coverage reports (using SimpleCov) match the website CodeCov report. We'll skip counting code coverage of files that aren't used during production.