### PR TITLE
Fix silver/gold section editing

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -173,6 +173,14 @@ class ProjectsController < ApplicationController
           fields << :"#{criterion.name}_justification"
         end
 
+        # The edit action checks notify_for_static_analysis?('0') for all levels,
+        # so we need to ensure static_analysis fields (from passing level) are
+        # loaded for silver and gold edit pages
+        if level_number != '0' && level_number != 'baseline-1'
+          fields << :static_analysis_status
+          fields << :static_analysis_justification
+        end
+
         # Convert to string, quoting only non-trivial column names
         quoted_fields =
           fields.map do |f|

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -361,6 +361,20 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_includes @response.body, 'Edit Project Badge Status'
   end
 
+  test 'should get edit for silver' do
+    log_in_as(@project.user)
+    get "/en/projects/#{@project.id}/silver/edit"
+    assert_response :success
+    assert_includes @response.body, 'Edit Project Badge Status'
+  end
+
+  test 'should get edit for gold' do
+    log_in_as(@project.user)
+    get "/en/projects/#{@project.id}/gold/edit"
+    assert_response :success
+    assert_includes @response.body, 'Edit Project Badge Status'
+  end
+
   test 'should get edit as additional rights user' do
     test_user = users(:test_user_mark)
     # Create additional rights during test, not as a fixure.


### PR DESCRIPTION
When we minimized what was retrieved, we didn't
include a field that we check as a special case.
Add that special case.