### PR TITLE
Add defensive measures if a status is a string

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -37,17 +37,24 @@ module ProjectsHelper
   # @return [String] String representation ('?', 'Unmet', 'N/A', 'Met')
   # @return [nil] if value is nil or out of range
   #
-  # This method converts database integer status values to their
+  # This method converts database status values to their
   # external API string representations for backward compatibility.
+  #
+  # Handles both pre-migration strings and post-migration integers
+  # for graceful deployment during the enum optimization rollout.
+  # This defensive approach prevents crashes if any cached/serialized
+  # string values exist.
   #
   # Examples:
   #   status_to_string(0) # => '?'
   #   status_to_string(1) # => 'Unmet'
   #   status_to_string(2) # => 'N/A'
   #   status_to_string(3) # => 'Met'
+  #   status_to_string('Met') # => 'Met' (pre-migration compatibility)
   #   status_to_string(nil) # => nil
   def status_to_string(value)
     return if value.nil?
+    return value if value.is_a?(String) # Pre-migration: already a string
 
     CriterionStatus::STATUS_VALUES[value]
   end

--- a/app/views/projects/_project.json.jbuilder
+++ b/app/views/projects/_project.json.jbuilder
@@ -7,9 +7,11 @@ transformed_attrs = project.attributes.dup
 
 # Convert status fields from integers to strings for API compatibility
 # Database stores integers (0=?, 1=Unmet, 2=N/A, 3=Met), API returns strings
+# Also handles pre-migration strings gracefully (defensive programming)
 Project::ALL_CRITERIA_STATUS.each do |status_field|
   status_value = transformed_attrs[status_field.to_s]
   next if status_value.nil?
+  next if status_value.is_a?(String) # Already a string (pre-migration data)
 
   transformed_attrs[status_field.to_s] = CriterionStatus::STATUS_VALUES[status_value]
 end


### PR DESCRIPTION
Add defensive measures so that displays work even if a criterion's status is a string internally.

We've converted all "status" values from strings to small integers internally everywhere. This only impacts how the data is stored and processed internally; external viewers see the more meaningful strings. This greatly optimizes processing.

However, an initial push to staging caused problems, because it was trying convert a string instead of the expected int. I believe it was from a stale dyno cache (restarting appears to have fixed the problem), but it's impossible to reproduce the problem. We want the system to work reliably.

This introduces two small defensive measures, so that if the software somehow ends up with a string internally, it'll quietly pass it out to the outside world. This means it'll appear to work just fine to the outside world.