### PR TITLE
Don't allow NULL in status values

### DIFF
--- a/db/migrate/20251230222557_add_not_null_to_baseline_status_fields.rb
+++ b/db/migrate/20251230222557_add_not_null_to_baseline_status_fields.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Copyright the Linux Foundation and the
+# OpenSSF Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+class AddNotNullToBaselineStatusFields < ActiveRecord::Migration[8.1]
+  using SymbolRefinements
+
+  def up
+    # Get all status field names and filter for osps_ prefix
+    all_status_fields = Criteria.all.map(&:status)
+    baseline_fields = all_status_fields.select { |f| f.to_s.start_with?('osps_') }
+
+    say_with_time "Adding NOT NULL constraint to #{baseline_fields.size} baseline status fields" do
+      baseline_fields.each_with_index do |field, index|
+        say "Adding NOT NULL to #{field} (#{index + 1}/#{baseline_fields.size})", :subitem
+
+        # First ensure no NULL values exist (there shouldn't be any)
+        # Convert any NULLs to 0 (unknown) just to be safe
+        execute <<-SQL.squish
+          UPDATE projects
+          SET "#{field}" = 0
+          WHERE "#{field}" IS NULL
+        SQL
+
+        # Add NOT NULL constraint
+        change_column_null :projects, field, false
+      end
+    end
+  end
+
+  def down
+    all_status_fields = Criteria.all.map(&:status)
+    baseline_fields = all_status_fields.select { |f| f.to_s.start_with?('osps_') }
+
+    say_with_time "Removing NOT NULL constraint from #{baseline_fields.size} baseline status fields" do
+      baseline_fields.each_with_index do |field, index|
+        say "Removing NOT NULL from #{field} (#{index + 1}/#{baseline_fields.size})", :subitem
+
+        # Remove NOT NULL constraint
+        change_column_null :projects, field, true
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_30_044124) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_30_222557) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -282,129 +282,129 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_30_044124) do
     t.text "no_leaked_credentials_justification"
     t.integer "no_leaked_credentials_status", limit: 2, default: 0, null: false
     t.text "osps_ac_01_01_justification"
-    t.integer "osps_ac_01_01_status", limit: 2, default: 0
+    t.integer "osps_ac_01_01_status", limit: 2, default: 0, null: false
     t.text "osps_ac_02_01_justification"
-    t.integer "osps_ac_02_01_status", limit: 2, default: 0
+    t.integer "osps_ac_02_01_status", limit: 2, default: 0, null: false
     t.text "osps_ac_03_01_justification"
-    t.integer "osps_ac_03_01_status", limit: 2, default: 0
+    t.integer "osps_ac_03_01_status", limit: 2, default: 0, null: false
     t.text "osps_ac_03_02_justification"
-    t.integer "osps_ac_03_02_status", limit: 2, default: 0
+    t.integer "osps_ac_03_02_status", limit: 2, default: 0, null: false
     t.text "osps_ac_04_01_justification"
-    t.integer "osps_ac_04_01_status", limit: 2, default: 0
+    t.integer "osps_ac_04_01_status", limit: 2, default: 0, null: false
     t.text "osps_ac_04_02_justification"
-    t.integer "osps_ac_04_02_status", limit: 2, default: 0
+    t.integer "osps_ac_04_02_status", limit: 2, default: 0, null: false
     t.text "osps_br_01_01_justification"
-    t.integer "osps_br_01_01_status", limit: 2, default: 0
+    t.integer "osps_br_01_01_status", limit: 2, default: 0, null: false
     t.text "osps_br_01_02_justification"
-    t.integer "osps_br_01_02_status", limit: 2, default: 0
+    t.integer "osps_br_01_02_status", limit: 2, default: 0, null: false
     t.text "osps_br_02_01_justification"
-    t.integer "osps_br_02_01_status", limit: 2, default: 0
+    t.integer "osps_br_02_01_status", limit: 2, default: 0, null: false
     t.text "osps_br_02_02_justification"
-    t.integer "osps_br_02_02_status", limit: 2, default: 0
+    t.integer "osps_br_02_02_status", limit: 2, default: 0, null: false
     t.text "osps_br_03_01_justification"
-    t.integer "osps_br_03_01_status", limit: 2, default: 0
+    t.integer "osps_br_03_01_status", limit: 2, default: 0, null: false
     t.text "osps_br_03_02_justification"
-    t.integer "osps_br_03_02_status", limit: 2, default: 0
+    t.integer "osps_br_03_02_status", limit: 2, default: 0, null: false
     t.text "osps_br_04_01_justification"
-    t.integer "osps_br_04_01_status", limit: 2, default: 0
+    t.integer "osps_br_04_01_status", limit: 2, default: 0, null: false
     t.text "osps_br_05_01_justification"
-    t.integer "osps_br_05_01_status", limit: 2, default: 0
+    t.integer "osps_br_05_01_status", limit: 2, default: 0, null: false
     t.text "osps_br_06_01_justification"
-    t.integer "osps_br_06_01_status", limit: 2, default: 0
+    t.integer "osps_br_06_01_status", limit: 2, default: 0, null: false
     t.text "osps_br_07_01_justification"
-    t.integer "osps_br_07_01_status", limit: 2, default: 0
+    t.integer "osps_br_07_01_status", limit: 2, default: 0, null: false
     t.text "osps_br_07_02_justification"
-    t.integer "osps_br_07_02_status", limit: 2, default: 0
+    t.integer "osps_br_07_02_status", limit: 2, default: 0, null: false
     t.text "osps_do_01_01_justification"
-    t.integer "osps_do_01_01_status", limit: 2, default: 0
+    t.integer "osps_do_01_01_status", limit: 2, default: 0, null: false
     t.text "osps_do_02_01_justification"
-    t.integer "osps_do_02_01_status", limit: 2, default: 0
+    t.integer "osps_do_02_01_status", limit: 2, default: 0, null: false
     t.text "osps_do_03_01_justification"
-    t.integer "osps_do_03_01_status", limit: 2, default: 0
+    t.integer "osps_do_03_01_status", limit: 2, default: 0, null: false
     t.text "osps_do_03_02_justification"
-    t.integer "osps_do_03_02_status", limit: 2, default: 0
+    t.integer "osps_do_03_02_status", limit: 2, default: 0, null: false
     t.text "osps_do_04_01_justification"
-    t.integer "osps_do_04_01_status", limit: 2, default: 0
+    t.integer "osps_do_04_01_status", limit: 2, default: 0, null: false
     t.text "osps_do_05_01_justification"
-    t.integer "osps_do_05_01_status", limit: 2, default: 0
+    t.integer "osps_do_05_01_status", limit: 2, default: 0, null: false
     t.text "osps_do_06_01_justification"
-    t.integer "osps_do_06_01_status", limit: 2, default: 0
+    t.integer "osps_do_06_01_status", limit: 2, default: 0, null: false
     t.text "osps_gv_01_01_justification"
-    t.integer "osps_gv_01_01_status", limit: 2, default: 0
+    t.integer "osps_gv_01_01_status", limit: 2, default: 0, null: false
     t.text "osps_gv_01_02_justification"
-    t.integer "osps_gv_01_02_status", limit: 2, default: 0
+    t.integer "osps_gv_01_02_status", limit: 2, default: 0, null: false
     t.text "osps_gv_02_01_justification"
-    t.integer "osps_gv_02_01_status", limit: 2, default: 0
+    t.integer "osps_gv_02_01_status", limit: 2, default: 0, null: false
     t.text "osps_gv_03_01_justification"
-    t.integer "osps_gv_03_01_status", limit: 2, default: 0
+    t.integer "osps_gv_03_01_status", limit: 2, default: 0, null: false
     t.text "osps_gv_03_02_justification"
-    t.integer "osps_gv_03_02_status", limit: 2, default: 0
+    t.integer "osps_gv_03_02_status", limit: 2, default: 0, null: false
     t.text "osps_gv_04_01_justification"
-    t.integer "osps_gv_04_01_status", limit: 2, default: 0
+    t.integer "osps_gv_04_01_status", limit: 2, default: 0, null: false
     t.text "osps_le_01_01_justification"
-    t.integer "osps_le_01_01_status", limit: 2, default: 0
+    t.integer "osps_le_01_01_status", limit: 2, default: 0, null: false
     t.text "osps_le_02_01_justification"
-    t.integer "osps_le_02_01_status", limit: 2, default: 0
+    t.integer "osps_le_02_01_status", limit: 2, default: 0, null: false
     t.text "osps_le_02_02_justification"
-    t.integer "osps_le_02_02_status", limit: 2, default: 0
+    t.integer "osps_le_02_02_status", limit: 2, default: 0, null: false
     t.text "osps_le_03_01_justification"
-    t.integer "osps_le_03_01_status", limit: 2, default: 0
+    t.integer "osps_le_03_01_status", limit: 2, default: 0, null: false
     t.text "osps_le_03_02_justification"
-    t.integer "osps_le_03_02_status", limit: 2, default: 0
+    t.integer "osps_le_03_02_status", limit: 2, default: 0, null: false
     t.text "osps_qa_01_01_justification"
-    t.integer "osps_qa_01_01_status", limit: 2, default: 0
+    t.integer "osps_qa_01_01_status", limit: 2, default: 0, null: false
     t.text "osps_qa_01_02_justification"
-    t.integer "osps_qa_01_02_status", limit: 2, default: 0
+    t.integer "osps_qa_01_02_status", limit: 2, default: 0, null: false
     t.text "osps_qa_02_01_justification"
-    t.integer "osps_qa_02_01_status", limit: 2, default: 0
+    t.integer "osps_qa_02_01_status", limit: 2, default: 0, null: false
     t.text "osps_qa_02_02_justification"
-    t.integer "osps_qa_02_02_status", limit: 2, default: 0
+    t.integer "osps_qa_02_02_status", limit: 2, default: 0, null: false
     t.text "osps_qa_03_01_justification"
-    t.integer "osps_qa_03_01_status", limit: 2, default: 0
+    t.integer "osps_qa_03_01_status", limit: 2, default: 0, null: false
     t.text "osps_qa_04_01_justification"
-    t.integer "osps_qa_04_01_status", limit: 2, default: 0
+    t.integer "osps_qa_04_01_status", limit: 2, default: 0, null: false
     t.text "osps_qa_04_02_justification"
-    t.integer "osps_qa_04_02_status", limit: 2, default: 0
+    t.integer "osps_qa_04_02_status", limit: 2, default: 0, null: false
     t.text "osps_qa_05_01_justification"
-    t.integer "osps_qa_05_01_status", limit: 2, default: 0
+    t.integer "osps_qa_05_01_status", limit: 2, default: 0, null: false
     t.text "osps_qa_05_02_justification"
-    t.integer "osps_qa_05_02_status", limit: 2, default: 0
+    t.integer "osps_qa_05_02_status", limit: 2, default: 0, null: false
     t.text "osps_qa_06_01_justification"
-    t.integer "osps_qa_06_01_status", limit: 2, default: 0
+    t.integer "osps_qa_06_01_status", limit: 2, default: 0, null: false
     t.text "osps_qa_06_02_justification"
-    t.integer "osps_qa_06_02_status", limit: 2, default: 0
+    t.integer "osps_qa_06_02_status", limit: 2, default: 0, null: false
     t.text "osps_qa_06_03_justification"
-    t.integer "osps_qa_06_03_status", limit: 2, default: 0
+    t.integer "osps_qa_06_03_status", limit: 2, default: 0, null: false
     t.text "osps_qa_07_01_justification"
-    t.integer "osps_qa_07_01_status", limit: 2, default: 0
+    t.integer "osps_qa_07_01_status", limit: 2, default: 0, null: false
     t.text "osps_sa_01_01_justification"
-    t.integer "osps_sa_01_01_status", limit: 2, default: 0
+    t.integer "osps_sa_01_01_status", limit: 2, default: 0, null: false
     t.text "osps_sa_02_01_justification"
-    t.integer "osps_sa_02_01_status", limit: 2, default: 0
+    t.integer "osps_sa_02_01_status", limit: 2, default: 0, null: false
     t.text "osps_sa_03_01_justification"
-    t.integer "osps_sa_03_01_status", limit: 2, default: 0
+    t.integer "osps_sa_03_01_status", limit: 2, default: 0, null: false
     t.text "osps_sa_03_02_justification"
-    t.integer "osps_sa_03_02_status", limit: 2, default: 0
+    t.integer "osps_sa_03_02_status", limit: 2, default: 0, null: false
     t.text "osps_vm_01_01_justification"
-    t.integer "osps_vm_01_01_status", limit: 2, default: 0
+    t.integer "osps_vm_01_01_status", limit: 2, default: 0, null: false
     t.text "osps_vm_02_01_justification"
-    t.integer "osps_vm_02_01_status", limit: 2, default: 0
+    t.integer "osps_vm_02_01_status", limit: 2, default: 0, null: false
     t.text "osps_vm_03_01_justification"
-    t.integer "osps_vm_03_01_status", limit: 2, default: 0
+    t.integer "osps_vm_03_01_status", limit: 2, default: 0, null: false
     t.text "osps_vm_04_01_justification"
-    t.integer "osps_vm_04_01_status", limit: 2, default: 0
+    t.integer "osps_vm_04_01_status", limit: 2, default: 0, null: false
     t.text "osps_vm_04_02_justification"
-    t.integer "osps_vm_04_02_status", limit: 2, default: 0
+    t.integer "osps_vm_04_02_status", limit: 2, default: 0, null: false
     t.text "osps_vm_05_01_justification"
-    t.integer "osps_vm_05_01_status", limit: 2, default: 0
+    t.integer "osps_vm_05_01_status", limit: 2, default: 0, null: false
     t.text "osps_vm_05_02_justification"
-    t.integer "osps_vm_05_02_status", limit: 2, default: 0
+    t.integer "osps_vm_05_02_status", limit: 2, default: 0, null: false
     t.text "osps_vm_05_03_justification"
-    t.integer "osps_vm_05_03_status", limit: 2, default: 0
+    t.integer "osps_vm_05_03_status", limit: 2, default: 0, null: false
     t.text "osps_vm_06_01_justification"
-    t.integer "osps_vm_06_01_status", limit: 2, default: 0
+    t.integer "osps_vm_06_01_status", limit: 2, default: 0, null: false
     t.text "osps_vm_06_02_justification"
-    t.integer "osps_vm_06_02_status", limit: 2, default: 0
+    t.integer "osps_vm_06_02_status", limit: 2, default: 0, null: false
     t.text "regression_tests_added50_justification"
     t.integer "regression_tests_added50_status", limit: 2, default: 0, null: false
     t.text "release_notes_justification"

--- a/lib/baseline_migration_generator.rb
+++ b/lib/baseline_migration_generator.rb
@@ -169,7 +169,7 @@ class BaselineMigrationGenerator
       lines << "    # #{level} criteria (#{fields.size} criteria)"
       fields.each do |field|
         field_name = field['database_field']
-        lines << "    add_column :projects, :#{field_name}_status, :string, default: '?'"
+        lines << "    add_column :projects, :#{field_name}_status, :smallint, default: 0, null: false"
         lines << "    add_column :projects, :#{field_name}_justification, :text"
       end
     end


### PR DESCRIPTION
In the integer status values, 0 means unknown (and is the default), so we shouldn't allow NULL as well.