### PR TITLE
Fix status chooser to NOT include project id

### DIFF
--- a/app/views/projects/_status_chooser.html.erb
+++ b/app/views/projects/_status_chooser.html.erb
@@ -19,7 +19,7 @@
     <div class="col-md-3 col-sm-4 col-xs-4 criteria-radio<%= crypto_class %>">
       <div class="status-chooser">
       <%= f.form_group status_symbol do %>
-        <%= link_to({ anchor: criterion.to_s }) do %>
+        <%= link_to("##{criterion}") do %>
         <%#
                        !!!!!  IMPORTANT  !!!!!
           The functionality below is mirrored in assets/project-form.js


### PR DESCRIPTION
We don't want the status chooser to include the project id, because then we can share the cached results.