### PR TITLE
Optimize user show action

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -189,6 +189,7 @@ class UsersController < ApplicationController
     respond_to :html, :json
     # Paginate the list of user-owned projects.
     # Use "select_needed" to minimize the fields we extract
+    # Note: No need to eager-load user - all projects belong to @user
     @pagy, @projects = pagy(select_needed(@user.projects))
     @pagy_locale = I18n.locale.to_s # Pagy requires a string version
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,10 +18,10 @@
    </aside>
   <div class="col-md-12">
 
-  <% if @user.projects.any? %>
+  <% if @projects.any? %>
     <br><br>
     <h2><%= t '.projects_owned' %></h2>
-    <%= render 'projects/table', projects: @projects %>
+    <%= render 'projects/table', projects: @projects, locale: I18n.locale %>
     <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
   <% end %>
 
@@ -29,14 +29,14 @@
     <br>
     <h2><%= t '.projects_additional_rights' %></h2>
     <br>
-    <%= render 'projects/table', projects: @projects_additional_rights %>
+    <%= render 'projects/table', projects: @projects_additional_rights, locale: I18n.locale %>
   <% end %>
 
   <% if @edit_projects.present? %>
     <br>
     <h2><%= t '.other_projects_edit' %></h2>
     <br>
-    <%= render 'projects/table', projects: @edit_projects %>
+    <%= render 'projects/table', projects: @edit_projects, locale: I18n.locale %>
   <% end %>
 
   <br><br>

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -9,15 +9,13 @@ json.call(
   @user, :id, :name, :nickname, :uid, :provider, :created_at, :updated_at
 )
 # This is an array of the project ids this user owns.
-json.projects @user.projects.pluck(:id)
+# Use ids for efficiency - we need ALL project IDs (not paginated subset)
+json.projects @user.projects.ids
 # Generate { project1.id: ['edit'], project2.id: ['edit'], ...}.
 # We generate this format in case there's more than 1 right in the future.
-# We could use @user.additional_rights.pluck(:id) instead, but we've
-# already calculated it so there's no point in doing it twice.
+# Use map and index_with since @projects_additional_rights is already loaded
 json.additional_rights(
-  @projects_additional_rights.pluck(:id).each_with_object({}) do |p, result|
-    result[p] = ['edit']
-  end
+  @projects_additional_rights.map(&:id).index_with { ['edit'] }
 )
 #
 # current user or admin can see more


### PR DESCRIPTION
This commit fixes several performance issues in UsersController#show and its associated views that were causing unnecessary database queries and memory allocations.

This is part of our effort to optimize the website (especially for common requests), because the website is being being endlessly bombarded by requests for data. Every project refers to at least one user, so information about users is unsurprisingly something that is requested by outsiders.

This commit makes the following changes:

* Fixed N+1 query in users/show.html.erb by using the already-paginated @projects collection instead of @user.projects.any?, which was triggering a separate COUNT query on every request. This eliminates one unnecessary database query per user page view.

* Added missing locale parameter when rendering the projects table partial. The partial's fragment cache key includes locale, but the parameter was not being passed. Now it explicitly passes locale: I18n.locale to all three table renders (owned projects, additional rights projects, and edit projects).

* Optimized JSON view (users/show.json.jbuilder) to use already-loaded collections instead of executing redundant queries. Changed @projects_additional_rights.pluck(:id) to .map(&:id) since the collection is already loaded in memory. Also replaced verbose each_with_object pattern with more idiomatic index_with. Changed @user.projects.pluck(:id) to .ids per Rails best practices.

* Added clarifying comment in UsersController that eager-loading user for @projects is unnecessary since all projects in that collection belong to @user by definition. The @projects_additional_rights and @edit_projects collections still correctly use includes(:user) since they can belong to different users.

These changes reduce database queries by 2 per request (1 COUNT query eliminated, 1 pluck query eliminated) and reduce memory allocations by avoiding unnecessary eager-loading and using more efficient collection methods.

This is purely an optimization. There are no changes to user-visible behavior and all tests pass.


Authored-by: David A. Wheeler <dwheeler@dwheeler.com>