### PR TITLE
Enable env var control over GC sleep timeouts

### DIFF
--- a/lib/gc_compact_thread.rb
+++ b/lib/gc_compact_thread.rb
@@ -66,9 +66,9 @@ module GcCompactThread
   # general here, to maximize the memory we recover.
 
   # Seconds post memory-ok before recheck
-  SLEEP_AFTER_CHECK = (ENV['BADGEAPP_SLEEP_AFTER_CHECK'] || 1 * 60).to_i
+  SLEEP_AFTER_CHECK = (ENV['BADGEAPP_SLEEP_AFTER_CHECK'] || (1 * 60)).to_i
   # Seconds post memory-not-ok before recheck
-  SLEEP_AFTER_COMPACT = (ENV['BADGEAPP_SLEEP_AFTER_COMPACT'] || 20 * 60).to_i
+  SLEEP_AFTER_COMPACT = (ENV['BADGEAPP_SLEEP_AFTER_COMPACT'] || (20 * 60)).to_i
 
   # Repeated check if memory used is more than memsize, and if so, compact.
   # The parameters make testing easier.


### PR DESCRIPTION
Allow environment variables to control GC compaction timing:

- BADGEAPP_SLEEP_AFTER_CHECK: seconds to wait after memory check is okay
  (default: 1 minute = 60s)
- BADGEAPP_SLEEP_AFTER_COMPACT: seconds to wait after compaction
  (default: 20 minutes = 1200s)

This provides production control over GC behavior without code changes.