### PR TITLE
Improve how we measure memory

### DIFF
--- a/lib/gc_compact_thread.rb
+++ b/lib/gc_compact_thread.rb
@@ -20,8 +20,8 @@ module GcCompactThread
   module_function
 
   # Regexes to retrieve memory information from /proc/self/status
-  VM_RSS_RE  = /VmRSS:\s+(\d+)/.freeze
-  VM_SWAP_RE = /VmSwap:\s+(\d+)/.freeze
+  VM_RSS_RE  = /VmRSS:\s+(\d+)/
+  VM_SWAP_RE = /VmSwap:\s+(\d+)/
 
   # Calculate compaction statistics.
   # We use .to_f on numerators before dividing, so that if the denominator


### PR DESCRIPTION
We only measure memory once a minute, but since it's part of low-level checking, it makes sense to make it a little more efficient, so let's do that.