### PR TITLE
Reinitialize markdown renderer before each use

### DIFF
--- a/script/benchmark-restart-redcarpet.rb
+++ b/script/benchmark-restart-redcarpet.rb
@@ -28,8 +28,8 @@ REDCARPET_MARKDOWN_PROCESSOR_OPTIONS = {
 text = "# Hello World\nThis is a **test**."
 # The warning we see is processing; creating the renderer is a one-time
 # event that doesn't care about inputs
-RENDERER = Redcarpet::Render::HTML.new(REDCARPET_MARKDOWN_RENDERER_OPTIONS)
-markdown = Redcarpet::Markdown.new(RENDERER, REDCARPET_MARKDOWN_PROCESSOR_OPTIONS)
+renderer = Redcarpet::Render::HTML.new(REDCARPET_MARKDOWN_RENDERER_OPTIONS)
+markdown = Redcarpet::Markdown.new(renderer, REDCARPET_MARKDOWN_PROCESSOR_OPTIONS)
 
 puts "First markdown = #{markdown}\n"
 
@@ -37,5 +37,11 @@ n = 10_000
 Benchmark.bm do |x|
   x.report('Reused: ') { n.times { markdown.render(text) } }
   # Re-create the markdown processor (but not the renderer) on each request
-  x.report('New Instance: ') { n.times { Redcarpet::Markdown.new(RENDERER, REDCARPET_MARKDOWN_PROCESSOR_OPTIONS).render(text) } }
+  x.report('New Instance: ') do
+    n.times do
+      renderer = Redcarpet::Render::HTML.new(REDCARPET_MARKDOWN_RENDERER_OPTIONS)
+      processor = Redcarpet::Markdown.new(renderer, REDCARPET_MARKDOWN_PROCESSOR_OPTIONS)
+      processor.render(text)
+    end
+  end
 end


### PR DESCRIPTION
In incredibly rare (and non-deterministic ways) we have test failures within the markdown processor with this message (the line being referenced is the line that calls the `render` method on the markdown processor):

> NotImplementedError: method 'to_s' called on unexpected
> T_IMEMO object (0x00007fd5c82c83c8 flags=0x8703a)
> app/lib/invoke_redcarpet.rb:245:in 'Redcarpet::Markdown#render'

Noting the T_IMEMO object is surprising; those are Ruby internals. This suggests an object has been moved, which "shouldn't" normally happen. Ruby generally hides all this, especially with its built-in types. However, there is one culprit left at this point: the renderer, which we're reusing. It's possible that while the class isn't being used, it's being compacted in a way that interferes with its underlying C object.

Address this by intantiating a new markdown renderer (as well as a new markdown processor) before each use within our method to do the markdown processing. If a project truly
required 50 markdown renders (unlikely), I estimate that would add 2 milliseconds (to what averages 2 milliseconds) for project#show, and that's a highly unlikely worst case. We're more interested in working correctly and not crashing, so this seems to be a price worth paying.

It's *possible* that this is a test artifact that can't happen in production. However, it's vitally important that our tests be reliable - if a test fails, it needs to be because of possibility of real-world failure. So we'll write the code so it "always works".