### PR TITLE
Redcarpet: Implement heap grooming for memory

### DIFF
--- a/test/helpers/projects_helper_test.rb
+++ b/test/helpers/projects_helper_test.rb
@@ -119,7 +119,7 @@ class ProjectsHelperTest < ActionView::TestCase
     result = markdown('<a href="javascript:alert(\'XSS\')">Click</a>')
     # The escaped HTML should be visible but not contain executable javascript:
     # The literal string "javascript:" will appear, but it's escaped and harmless
-    assert_not result.include?('javascript:'), 'HTML should be escaped'
+    assert_not result.include?('<a href="javascript:'), 'HTML should be escaped'
   end
 
   test 'markdown - invalid URI has href stripped' do
@@ -127,8 +127,9 @@ class ProjectsHelperTest < ActionView::TestCase
     # but not executable. Users can see the malformed URL.
     # Negative test (security)
     result = markdown('<a href="ht!tp://bad[url]">Link</a>')
-    # Raw HTML is escaped
-    assert_not result.include?('ht!tp://'), 'Bad link should be escaped'
+    # Either the <a isn't allowed, or it is normally
+    # but the link isn't allowed. What we do *not* want is this:
+    assert_not result.include?('<a href="ht!tp://'), 'No bad link'
   end
 
   test 'markdown - imbalanced HTML tags are escaped' do


### PR DESCRIPTION
Our application suffers from unbounded memory growth, in spite of efforts to prevent it.  Analysis of GC.compact logs shows pages_freed: 0 despite high objects_moved counts.
This is caused by "Page Pinning."

In Ruby’s generational GC, memory is divided into 16KB pages (approx. 400 slots each). For a page to be returned to the OS, every single slot on that page must be empty. Because Redcarpet is a C extension, its objects (T_DATA) are often pinned (unmovable). When these objects are created per-request, they scatter across the heap. A single pinned object acts as an "anchor," preventing the entire 16KB page from being reclaimed, leading to a "Swiss Cheese" heap.

Commonmarker causes the same unbounded memory growth, almost certainly for the same reason.

Our solution: Heap Grooming. We intentionally allocate objects so that they will be better-behaved on the heap.

This commit introduces batch allocation
of markdown-related objects within module InvokeRedcarpet. Instead of allocating Redcarpet pairs on-demand, we pre-allocate a batch of markdown object pairs into a Queue.

Before refilling the queue, we trigger GC.start(immediate_sweep: true). This clears dead slots, allowing the subsequent batch of 100 processors and renderers to be allocated into contiguous memory slots. By allocating 300 slots (Processor + Renderer + Array tuple) sequentially, we effectively saturate specific heap pages with Redcarpet objects.

When a batch is exhausted and the objects fall out of scope, they leave behind entirely empty pages. This should eliminates the "anchor" effect, allowing GC.compact to finally free pages and return memory to the OS. Even if this doesn't happen, this batching will mean that most other pages won't have markdown objects, and thus they'll be releasable.

This change should result in GC.compact having a pages_freed of > 0 instead of 0. More importantly, it should stabilize the memory use (including the Resident Set Size (RSS)) under high load.