### PR TITLE
System tests: add/use wait_for_page_load

### DIFF
--- a/test/system/javascript_test.rb
+++ b/test/system/javascript_test.rb
@@ -33,7 +33,7 @@ class JavascriptTest < ApplicationSystemTestCase
 
   test 'Check show/hide Met on show for passing' do
     visit project_path(@project_passing, locale: :en)
-    wait_for_jquery
+    wait_for_page_load
     find('#toggle-expand-all-panels').click
     wait_for_jquery
     assert_selector(:css, '#discussion')
@@ -52,7 +52,7 @@ class JavascriptTest < ApplicationSystemTestCase
 
   test 'Check show/hide Met works for silver' do
     visit project_section_path(@project_passing, 'silver', locale: :en)
-    wait_for_jquery
+    wait_for_page_load
     find('#toggle-expand-all-panels').click
     wait_for_jquery
     assert_selector(:css, '#contribution_requirements')
@@ -76,7 +76,7 @@ class JavascriptTest < ApplicationSystemTestCase
 
     # Visit the baseline-1 edit page directly
     visit "/en/projects/#{@project.id}/baseline-1/edit"
-    wait_for_jquery
+    wait_for_page_load
 
     # Expand all panels to ensure proper initialization
     find('#toggle-expand-all-panels').click

--- a/test/system/login_test.rb
+++ b/test/system/login_test.rb
@@ -77,7 +77,7 @@ class LoginTest < ApplicationSystemTestCase
     click_button('Save (and continue)', match: :first)
     # After routing changes, edit paths now include criteria_level
     assert_equal "/en/projects/#{@project.id}/passing/edit", current_path
-    wait_for_jquery # Wait for page to fully load before checking flash message
+    wait_for_page_load # Wait for page to fully load before checking flash message
     assert has_content? 'Project was successfully updated.'
     # TODO: Get the clicking working again with capybara.
     # Details: If we expand all panels first and dont click this test passes.


### PR DESCRIPTION
Some system tests call wait_for_jquery when they *should* wait for a page load instead. Add a new wait_for_page_load and use it (and *not* wait_for_jquery) after any "visit" of a page.

This makes some system tests more reliable, since
those tests will now be waiting on the correct trigger.