### PR TITLE
Greatly simplify calls to redcarpet

### DIFF
--- a/app/lib/invoke_redcarpet.rb
+++ b/app/lib/invoke_redcarpet.rb
@@ -19,28 +19,7 @@
 # we couldn't accept. A pure-Ruby solution can't work for us,
 # we have to support too many requests.
 
-# So instead, this module implements the following countermeasures
-# to prevent problems:
-#
-# 1. Always re-instantiate the markdown renderer AND processor instances
-# before using them, and thus, each is used only once.
-# The *most* likely cause of the occasional crash, by far,
-# is "junk" data that was left over from a
-# previous execution of the redcarpet markdown processor.
-# This assertion requires a size be 0, and its failure indicates it isn't.
-# Recreating the markdown renderer and processor for each use is aggressive,
-# but doing this has a surprisingly small overhead, as measured
-# by the script/benchmark-restart-redcarpet.rb.
-# Originally I only re-created the markdown processor instance, since
-# that's where the original error reports came from, namely
-# `md->work_bufs[BUFFER_SPAN].size == 0`.
-# The benchmark indicates that if a project section
-# needs 50 markdown renders (an unlikely high number for a project),
-# instantiating a processor each time adds 50*(0.104432-0.010429)/10000
-# = 0.47 milliseconds (0.00047 seconds) in real time for showing a project.
-# However, during testing, we rarely got this non-reproducible message
-# on the line that called the `render` method on the processor instance
-# even though had been created *solely* for this use:
+# We've also occasionally seen this error report:
 # NotImplementedError: method 'to_s' called on unexpected
 # T_IMEMO object (0x00007fd5c82c83c8 flags=0x8703a)
 # app/lib/invoke_redcarpet.rb:245:in 'Redcarpet::Markdown#render'
@@ -60,8 +39,17 @@
 # reclaimed by the Ruby VM for internal bookkeeping. Because the class
 # variable didn't "release" that address, the processor.render call tries
 # to execute C-code against an internal VM structure.
-#
-# It's important that this process reliably work across testing.
+
+# Our earlier efforts to prevent this, by re-creating markdown
+# renderers and processors, and using each pair only once.
+# Originally I only re-created the markdown processor instance, since
+# that's where the original error reports came from, namely
+# `md->work_bufs[BUFFER_SPAN].size == 0`.
+# The benchmark indicates that if a project section
+# needs 50 markdown renders (an unlikely high number for a project),
+# instantiating a processor each time adds 50*(0.104432-0.010429)/10000
+# = 0.47 milliseconds (0.00047 seconds) in real time for showing a project.
+# By itself that didn't eliminate crashes.
 # I modified the benchmark to see the overhead of *also* re-creating
 # the renderer for each markdown process. If again some project display
 # *also* needs 50 markdown renders (an unlikely high number for a project),
@@ -71,104 +59,17 @@
 # Notice that I'm always using "real" time as the conservative answer.
 # Our current "project shows" take around 22msec, so that is a ~10%
 # increase in execution time of our most common request type.
-# I'm not happy about that. However, this is a worst-case scenario,
-# we only call the markdown processor for harder cases, so this isn't
-# called very often in practice (and when it is, we usually need it).
-#
-# It creates a few objects, too. However, if this is what
-# we must do to make our application reliable, then that's what we'll do.
-#
-# 2. Use a mutex to force redcarpet markdown processing into single-thread use.
-# This is probably unnecessary given point 1. However, since threading is
-# a common mistake in low-level code, by using a mutex we can
-# completely eliminate this as a possible cause. This does mean that threads
-# will need to take turns using this, but each one doesn't take much time,
-# and other threads will have a turn on release, so this seems acceptable.
-#
-# 3. Catch exceptions, and return an escaped version. We don't expect
-# that to catch C assertion failures, but it doesn't hurt to catch
-# other problems just in case they occur. We also log any exceptions we
-# catch, in case that helps find problems.
-#
-# All this overhead isn't *quite* as bad as it seems when you realize that
-# most markdown texts aren't sent to this routine anyway.
-# We separately handle blank text, URL-only text, and
-# "simple" text that doesn't require markdown processing. So only some
-# tests end up requiring the full processor.
-#
-# Given the info we have, we think the problem is left-over uncleared data,
-# so our aggressive approach should *completely* eliminate this problem.
-#
-# None of these aggressive countermeasures can prevent problems if some
-# specific input can cause an *immediate* crash/vulnerability.
-# However, I think that's quite unlikely, for 2 reasons.
-#
-# First, we performed focused fuzz testing on the
-# processor.render(content_str) call, with many efforts. I couldn't find
-# *any* inputs that could produce a problem in one shot.
-# It's true that fuzzing can't guarantee finding a problem, but at least
-# it provides evidence of no further problems.
-#
-# Second, the assertion failure we see is an assertion about
-# the state of the processor *itself* that, in our use case, cannot
-# happen if we re-create the processor each time.
-# Note: redcarpet is a wrapper around the "sundown" parser:
-# https://cocoapods.org/pods/sundown
-# I asked Google Gemini to analyze the source code for this circumstance.
-# It determined that:
-#
-# Based on the source code of the underlying C library (Sundown,
-# wrapped by Redcarpet), the answer is yes: this specific assertion is a
-# "pre-flight" check that occurs at the very beginning of the rendering
-# process.
-# If you re-instantiate the processor for every call, you effectively
-# bypass the conditions that lead to this crash.
-# 1. Reasoning: The "Pre-flight" Check
-# The function sd_markdown_render is the main entry point for the
-# C-level parser. The assertion assert(md->work_bufs[BUFFER_SPAN].size ==
-# 0) is located at the top of this function.
-# Its purpose is to ensure that the Span Buffer—a temporary stack used
-# to parse inline elements like *italics* or [links]—is completely empty
-# before starting. If the size is not zero, it means a previous rendering
-# operation was interrupted or had a logic bug that left "garbage" in
-# the buffer.
-# When it crashes: It crashes the moment you call .render(text), before
-# a single character of the new text has been processed.
-# Why Re-instantiation works: When you call Redcarpet::Markdown.new,
-# the C code allocates a brand-new sd_markdown struct and initializes
-# all buffer sizes to 0. Even if a previous input was "malicious" or
-# "corrupting," that corruption lived in the memory of the old object. By
-# discarding the old object, you discard the corruption.
-# 2. Can a single input cause a crash mid-way?
-# With this specific assertion, no. Because it is at the entry point of
-# the render function, it only checks the state inherited from the last
-# time that specific object was used.
-# The only way a "single input" could trigger this in a fresh object is if
-# you were using recursion -- for example, if a custom renderer's callback
-# (like block_code) called markdown.render again using the same processor
-# instance. In that case, the second (nested) call would see that the first
-# call is currently using the Span Buffer and would trigger the assertion.
-# 3. Source Code Reference
-# You can review the logic in the official Redcarpet GitHub
-# repository. Note that line numbers may shift slightly between versions,
-# but the logic remains in the sd_markdown_render function.
-# Source URL: vmg/redcarpet - ext/redcarpet/markdown.c
-# The specific code block looks like this:
-# C
-# void
-# sd_markdown_render(struct buf *ob, const uint8_t *document, size_t doc_size, struct sd_markdown *md)
-# {
-#    // ... initialization code ...
-#    /* check that the buffers are empty */
-#    assert(md->work_bufs[BUFFER_SPAN].size == 0);
-#    assert(md->work_bufs[BUFFER_DIFF].size == 0);
-#    // ... parsing begins after these checks ...
-# }
-#
-# All of that counters *crashes* but also leads to endless memory growth.
-# If we create *one* new markdown processor and renderer *per* transaction,
-# they end up scattered across Ruby's memory space and being un-reclaimable.
-# So we use heap grooming: we create them in batches.
+
+# However, creating objects each time we want to process markdown meant
+# we had to clean them up later, creating *huge* occasional latencies.
+# We created them in batches and put them in a queue, to try to put them
+# in a place where we could recover them. All of that extra mechanism
+# created huge overhead in efforts to work around bugs in the library.
+# We instead fixed the underlying library, sent our fixes upstream, and plan
+# to use our forked version until upstream is fixed. As a result, we can
+# use the markdown processor in the simple way as intended. Our fixes also
+# raise exceptions (instead of crashing) if certain assertions fail; this
+# lets us log the problem and recreate objects.
 
 module InvokeRedcarpet
   require 'redcarpet'
@@ -184,32 +85,6 @@ module InvokeRedcarpet
     no_intra_emphasis: true, autolink: true,
     space_after_headers: true, fenced_code_blocks: true
   }.freeze
-
-  # To counter memory fragmentation, we allocate markdown objects
-  # in batches. We're trying concentrate markdown objects' slots in a
-  # few pages, instead of letting them scatter. Each batch will allocate
-  # (2 markdown objects + 1 array object)* batch size, plus the queue object,
-  # and a slot page can hold 400 objects. We clean up first with GC.start,
-  # so a batch will typically fill 1-2 such pages
-  # instead of letting them scatter.
-  # By concentrating these objects in a few pages,
-  # other pages will be able to move.
-  MARKDOWN_QUEUE_BATCH_SIZE = (ENV['BADGEAPP_MARKDOWN_Q_SIZE'] || 100).to_i
-
-  @markdown_queue = Queue.new
-
-  # Mutex to ensure thread safety.
-  # Redcarpet's C code is not thread-safe, so we use a mutex to ensure
-  # only one thread can use the processor at a time.
-  # We use a global variable because module constants are cleared on reload
-  # in dev/test environments, but this mutex MUST persist across reloads
-  # to maintain thread safety.
-  # rubocop:disable Style/GlobalVars
-  $redcarpet_mutex ||= Mutex.new
-  # rubocop:enable Style/GlobalVars
-
-  # Store the previous content for diagnostic logging
-  @previous_content = nil
 
   # Complain because the processor does not have the expected type
   #
@@ -232,7 +107,7 @@ module InvokeRedcarpet
   # @param previous_content [String, nil] The previously rendered content
   # @return [void]
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-  def self.log_render_error(exception, current_content, previous_content)
+  def self.log_render_error(exception, current_content)
     Rails.logger.error(
       "Redcarpet render failed: #{exception.class} - #{exception.message}"
     )
@@ -240,66 +115,33 @@ module InvokeRedcarpet
       "Redcarpet current content (#{current_content.to_s.length} chars): " \
       "#{current_content.to_s[0..1000].inspect}"
     )
-    if previous_content
-      Rails.logger.error(
-        "Redcarpet previous content (#{previous_content.to_s.length} chars): " \
-        "#{previous_content.to_s[0..1000].inspect}"
-      )
-    end
     return unless exception.backtrace
 
-    Rails.logger.error("Redcarpet backtrace: #{exception.backtrace.first(5).join("\n  ")}")
+    Rails.logger.error("Redcarpet backtrace: #{exception.backtrace.first(10).join("\n  ")}")
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-  # Report markdown stats. GC has a similar function.
-  # We'll probably remove this once we're satisfied we've solved
-  # memory fragmentation problems.
-  def self.report_markdown_info
-    # Extract specific stats
-    # This extracts only specific class info, so it's faster.
-    [Redcarpet::Markdown, Redcarpet::Render::HTML].each do |klass|
-      count = 0
-      total_mem = 0
-      ObjectSpace.each_object(klass) do |o|
-        count += 1
-        total_mem += ObjectSpace.memsize_of(o)
-      end
-      Rails.logger.warn "Redcarpet Markdown queue refilled: #{klass.name}: " \
-                        "Count #{count}, Ruby-Mem: #{total_mem} bytes"
-    end
+  # Create a new markdown processor for our current thread, along with
+  # its associated render object, and store it
+  # as being associated with our current thread.
+  # They can't be shared between threads at the same time, so we'll just
+  # create one for each thread.
+  def self.new_markdown_processor
+    renderer = Redcarpet::Render::HTML.new(REDCARPET_MARKDOWN_RENDERER_OPTS)
+    processor = Redcarpet::Markdown.new(renderer,
+                                        REDCARPET_MARKDOWN_PROCESSOR_OPTS)
+    # Technically we don't need to record the renderer in Thread.current,
+    # since it's referenced by the processor, but doing this *ensures* that
+    # Ruby can see that the renderer is being used (and must not be reclaimed).
+    Thread.current[:markdown_renderer] = renderer
+    # This is the setting that matters - from now on, this thread will use
+    # this markdown processor.
+    Thread.current[:markdown_processor] = processor
+    processor
   end
 
-  # Refill queue of markdown renderer & processor
-  # rubocop:disable Metrics/MethodLength
-  def self.refill_queue
-    # First, clear the deck (this doesn't *compact*)
-    Rails.logger.warn("Redcarpet - running GC.start to fill a queue batch size #{MARKDOWN_QUEUE_BATCH_SIZE}")
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    # The "Stop the World" pause happens here
-    GC.start(full_mark: true, immediate_sweep: true)
-    # Calculate elapsed time
-    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    duration_ms = ((end_time - start_time) * 1000).round(2)
-    Rails.logger.warn("Redcarpet - running GC.start took #{duration_ms}ms ")
-
-    # Use a simple loop to minimize creating intermediate Enumerator objects
-    i = 0
-    while i < MARKDOWN_QUEUE_BATCH_SIZE
-      renderer = Redcarpet::Render::HTML.new(REDCARPET_MARKDOWN_RENDERER_OPTS)
-      processor = Redcarpet::Markdown.new(renderer,
-                                          REDCARPET_MARKDOWN_PROCESSOR_OPTS)
-      # We queue the processor and renderer together, to ensure they're
-      # used together. If we discard the renderer without discarding the
-      # processor, the internal link from the processor could cause a crash
-      @markdown_queue << [processor, renderer]
-      i += 1
-    end
-    report_markdown_info
-  end
-  # rubocop:enable Metrics/MethodLength
-
-  # Invoke Redcarpet to render markdown content with comprehensive error handling
+  # Invoke Redcarpet to render markdown content
+  # with comprehensive error handling.
   #
   # This method wraps the Redcarpet call in defensive measures.
   # On error, it logs diagnostic info and either returns HTML-escaped content
@@ -311,7 +153,7 @@ module InvokeRedcarpet
   # @param force_exception [Exception, nil] For testing: inject an exception
   # @return [ActiveSupport::SafeBuffer] HTML-safe rendered output
   #
-  # rubocop:disable Rails/OutputSafety, Style/GlobalVars, Metrics/MethodLength
+  # rubocop:disable Rails/OutputSafety, Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
   def self.invoke_and_sanitize(
     content,
@@ -319,62 +161,46 @@ module InvokeRedcarpet
     force_exception: nil,
     force_bad_type: false
   )
-    # Use mutex to ensure only one thread uses Redcarpet at a time
-    # This is probably over-protective; we'll probably reduce this once
-    # we're confident other problems are solved, but until everything works
-    # well, we want to eliminate threading as a potential issue.
-    $redcarpet_mutex.synchronize do
-      # If we're out of pre-created processors and renderers, get a new batch
-      refill_queue if @markdown_queue.empty?
+    # Get this thread's markdown processor, creating it if necessary
+    processor = Thread.current[:markdown_processor] || new_markdown_processor
 
-      # Use a new markdown renderer and processor on *each* use,
-      # so we *know* it has pristine state. We'll presume that there's
-      # one available since we just refilled it.
-      # Rubocop is *correctly* pointing out that we never use the
-      # "renderer" value. What rubocop *cannot* know is that the processor's
-      # C implementation has an internal pointer to the renderer object.
-      # We *ensure* that the renderer never disappears, while the processor
-      # object is alive, by assigning the renderer to a Ruby variable.
-      # When this method ends, both will no longer be referenced and never
-      # be used again.
-      # rubocop:disable Lint/UselessAssignment
-      processor, renderer = @markdown_queue.pop
-      # rubocop:enable Lint/UselessAssignment
+    # For testing: inject a bad type to test type checking
+    processor = [] if force_bad_type
 
-      # For testing: inject a bad type to test type checking
-      processor = [] if force_bad_type
+    # Check processor type (catches some Rails class reloading issues)
+    # Warning: Rails class reloading can invalidate cached instances,
+    # causing "wrong argument type"
+    # errors even though is_a? checks pass against stale class definitions
+    processor_bad_type(processor) unless processor.is_a?(Redcarpet::Markdown)
 
-      # Check processor type (catches some Rails class reloading issues)
-      # Warning: Rails class reloading can invalidate cached instances,
-      # causing "wrong argument type"
-      # errors even though is_a? checks pass against stale class definitions
-      processor_bad_type(processor) unless processor.is_a?(Redcarpet::Markdown)
+    # Defensive measure: ensure content is a string
+    content_str = content.to_s
 
-      # Defensive measure: ensure content is a string
-      content_str = content.to_s
+    # For testing: inject an exception to test exception handling
+    raise force_exception if force_exception
 
-      # For testing: inject an exception to test exception handling
-      raise force_exception if force_exception
+    # Try to render the markdown
+    result = processor.render(content_str)
 
-      # Try to render the markdown
-      result = processor.render(content_str)
+    # The markdown processor, as configured, will generate safe results.
+    # Without this operation html links, italics, etc. won't work.
+    result.html_safe
+  rescue StandardError => e # This also captures RuntimeError
+    # Log comprehensive diagnostic information
+    log_render_error(e, content)
 
-      # Success! Store this content for next error's diagnostic
-      @previous_content = content_str
+    # Force recreation of the renderer and markdown processor objects, since
+    # something has gone wrong with the current pair.
+    Thread.current[:markdown_processor] = nil
+    Thread.current[:markdown_renderer] = nil
 
-      result.html_safe
-    rescue StandardError => e
-      # Log comprehensive diagnostic information
-      log_render_error(e, content, @previous_content)
+    # Re-raise (for testing)
+    raise if raise_on_error
 
-      # Either re-raise (for testing) or return escaped content (for production)
-      raise if raise_on_error
-
-      # Return HTML-escaped content as fallback
-      # Not perfect, but provides safe output to caller
-      ERB::Util.html_escape(content.to_s).html_safe
-    end
+    # Return HTML-escaped content as fallback
+    # Not perfect, but provides safe output to caller
+    ERB::Util.html_escape(content.to_s).html_safe
   end
-  # rubocop:enable Rails/OutputSafety, Style/GlobalVars, Metrics/MethodLength
+  # rubocop:enable Rails/OutputSafety, Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
 end

--- a/test/lib/invoke_redcarpet_test.rb
+++ b/test/lib/invoke_redcarpet_test.rb
@@ -26,16 +26,6 @@ class InvokeRedcarpetTest < ActiveSupport::TestCase
     assert result.html_safe?
   end
 
-  test 'invoke_and_sanitize stores previous content on success' do
-    InvokeRedcarpet.invoke_and_sanitize('first content')
-    previous = InvokeRedcarpet.instance_variable_get(:@previous_content)
-    assert_equal 'first content', previous
-
-    InvokeRedcarpet.invoke_and_sanitize('second content')
-    previous = InvokeRedcarpet.instance_variable_get(:@previous_content)
-    assert_equal 'second content', previous
-  end
-
   test 'invoke_and_sanitize with force_bad_type raises TypeError' do
     error =
       assert_raises(TypeError) do
@@ -86,26 +76,6 @@ class InvokeRedcarpetTest < ActiveSupport::TestCase
                                                  raise_on_error: false,
                                                  force_exception: test_error)
     assert_equal '*test*', result # Lightly escaped
-  end
-
-  test 'invoke_and_sanitize handles error when previous content exists' do
-    # First, do a successful render to set @previous_content
-    InvokeRedcarpet.invoke_and_sanitize('previous successful content')
-
-    # Verify previous content was stored
-    assert_equal 'previous successful content',
-                 InvokeRedcarpet.instance_variable_get(:@previous_content)
-
-    # Now force an exception - this exercises the log_render_error path
-    # with previous_content set.
-    test_error = RuntimeError.new('Simulated error')
-    result = InvokeRedcarpet.invoke_and_sanitize('current *failing* <script> content',
-                                                 raise_on_error: false,
-                                                 force_exception: test_error)
-
-    # Verify it returned escaped content as fallback
-    assert_equal 'current *failing* &lt;script&gt; content', result
-    assert result.html_safe?
   end
 end
 # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
Now that we've fixed problems in the underlying gem, vastly simplify how we call it. Instead of building a markdown and renderer object each time, and aggressively sweeping memory, simply create a markdown and renderer object once per thread and reuse them. We can capture exceptions with higher confidence that we'll really catch the result.

We still include several checking mechanisms and catch exceptions, so even if things go badly, we can generally recover.