### PR TITLE
Use cache no-store, fixes #2644

### DIFF
--- a/test/integration/project_get_test.rb
+++ b/test/integration/project_get_test.rb
@@ -33,7 +33,7 @@ class ProjectGetTest < ActionDispatch::IntegrationTest
     assert_equal('text/html; charset=utf-8', @response.headers['Content-Type'])
     assert_equal(
       # Note that this test *is* seeing the rack middleware result!
-      'private, no-cache',
+      'private, no-store',
       @response.headers['Cache-Control']
     )
 


### PR DESCRIPTION
Sometimes badge images change, but users viewing them on GitHub only see the old version of the badge image.

I investigated and found that
GitHub does their own caching, as documented here: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls

Unfortunately, the GitHub cache system does not correctly implement no-cache. Their docs specifically recommend using cache-control: no-cache instead.

GitHub's caching system *does* let us purge old versions, but we can't purge specific URLs, we have to purge by hash. So for example we have to send a message that says "purge all passing badge images". That's more complicated than simply saying "don't cache, get your data from the authoritative source".

This should fix the issue reported at:
https://github.com/coreinfrastructure/best-practices-badge/issues/2644

This should mean that those who view badge images on GitHub always see the current value.

This will slightly increase the burden on our CDN. However, we already have to ask the CDN "is this current", and the badge images are small, so actually serving the (small) data isn't too bad.