### PR TITLE
Remove no-longer-useful internal cache statements

### DIFF
--- a/app/views/criteria/show.html.erb
+++ b/app/views/criteria/show.html.erb
@@ -1,4 +1,3 @@
-<% cache_frozen [locale, @criteria_level, @details, @rationale, @autofill] do -%>
 <%- internal_level = criteria_level_to_internal(@criteria_level) -%>
 <div class="row">
 <div class="col-xs-12">
@@ -15,4 +14,3 @@
             } -%>
 </div>
 </div>
-<% end # cache -%>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -33,28 +33,26 @@
           <li><%= link_to Icon[:'fa-user-plus'] + t(:signup_html, scope: :layouts), signup_path %></li>
           <li><%= link_to Icon[:'fa-sign-in-alt'] + t(:login_html, scope: :layouts), login_path %></li>
         <% end %>
-        <% cache_frozen [I18n.locale, request.original_fullpath] do %>
-          <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-              <span class="fa fa-language fa-lg" title="<%= t(:choose_locale, scope: :layouts) %>"></span>
-              <b class="caret"></b></a>
-            <ul class="dropdown-menu reverse-dropdown">
-              <% I18n.available_locales.map do |loc| %>
-                <li><a href="<%=
-                  # TODO: This doesn't include the anchor.
-                  force_locale_url(request.original_url, loc)
-                  %>"><%= t("locale_name.#{loc}") %>
-                  <%=
-                    if loc != I18n.locale
-                      '/ ' + t("locale_name.#{loc}", locale: loc)
-                    end
-                  %>
-                  (<%= loc %>)</a>
-                </li>
-              <% end %>
-            </ul>
-          </li>
-        <% end %>
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+            <span class="fa fa-language fa-lg" title="<%= t(:choose_locale, scope: :layouts) %>"></span>
+            <b class="caret"></b></a>
+          <ul class="dropdown-menu reverse-dropdown">
+            <% I18n.available_locales.map do |loc| %>
+              <li><a href="<%=
+                # TODO: This doesn't include the anchor.
+                force_locale_url(request.original_url, loc)
+                %>"><%= t("locale_name.#{loc}") %>
+                <%=
+                  if loc != I18n.locale
+                    '/ ' + t("locale_name.#{loc}", locale: loc)
+                  end
+                %>
+                (<%= loc %>)</a>
+              </li>
+            <% end %>
+          </ul>
+        </li>
       </ul>
 
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,15 +36,12 @@
 <%# https://searchengineland.com/ -%>
 <%# the-ultimate-guide-to-multilingual-and-multiregional-seo-157838 -%>
 <%# We use original_fullpath so that query strings are included. -%>
-<%# Fullpaths and locales are always distinct, so don't need cache name -%>
-<% cache_frozen request.original_fullpath do -%>
 <%   I18n.available_locales.each do |loc| -%>
        <link rel="alternate" hreflang="<%= loc %>" href="<%=
              force_locale_url(request.original_url, loc) %>" />
 <%   end # each locale -%>
        <link rel="alternate" hreflang="x-default" href="<%=
              force_locale_url(request.original_url, nil) %>" />
-<% end # cache of links to "alternates" for each locale -%>
 </head>
 <body>
 <%= render 'layouts/header' -%>


### PR DESCRIPTION
Remove internal cache statements that at one time were helpful, but are now detrimental thanks to overwhelming and endless web crawling.

This application has an internal cache, in particular its fragment cache system. When often-reused items are cached and reused internally, that can *greatly* reduce the load on the system.

However, every cache check must create and use a cache key to see if it's already in the cache. This, by itself,
does memory allocations and takes time. In addition, every cached value must be retrieved often enough to be worth it (else it will use up memory until evicted and take up space better used elsewhere).

I modified the application and created a test script so we could measure cache hits, misses, and allocation overhead to see which requests for a cache are actually useful. Basically, you enable cache profiling (which stores data in tmp/) in the application, and run a stress test like this:

~~~~sh
CACHE_PROFILE=1 rails s
script/memory_stress_test.rb --crawler --duration 2h ~~~~

It's important that the stress test be representative of real data. When we originally set up our cache system, we presumed that we would only occasionlly undergo a web spider, and that most requests would be from users editing their pages (which would focus on specific projects in a specific locale). Today, the site undergoes relentless spidering. This massive change in our typical input profile means that the correct caching strategy has to change too.

Here are the initial results as of 2026-01-29.

~~~~
CACHE REMOVAL CANDIDATES BY SOURCE (least effective first) ================================================================================

1. views/layouts/application.html.erb:40
   Code: <% cache_frozen request.original_fullpath do -%>
   Score: 40.7/100 | Hit rate: 0.0% Hits: 0 (0.0 allocs/hit = overhead cost) Misses: 11254 (533.3 allocs/miss = render cost) Problems: hit rate 0.0% Unique keys: 11254

2. views/projects/_table.html.erb:23
   Code: <% cache_frozen [project, locale], expires_in: 12.hours do %>
   Score: 46.6/100 | Hit rate: 52.1% Hits: 13173 (49.3 allocs/hit = overhead cost) Misses: 12102 (264.0 allocs/miss = render cost) Problems: hit rate 52.1%, 49 allocs/hit (overhead) Unique keys: 19243

3. views/layouts/_header.html.erb:36
   Code: <% cache_frozen [I18n.locale, request.original_fullpath] do %>
   Score: 49.0/100 | Hit rate: 0.0% Hits: 0 (0.0 allocs/hit = overhead cost) Misses: 11263 (951.5 allocs/miss = render cost) Problems: hit rate 0.0% Unique keys: 11263

4. views/criteria/show.html.erb:1
   Code: <% cache_frozen [locale, @criteria_level, @details, @rationale, @autofill] do -%>
   Score: 50.0/100 | Hit rate: 0.0% Hits: 0 (0.0 allocs/hit = overhead cost) Misses: 13 (4524.9 allocs/miss = render cost) Problems: hit rate 0.0%, low samples (13) Unique keys: 13

5. views/criteria/index.html.erb:1
   Code: <% cache_frozen [locale, @details, @rationale, @autofill] do -%>
   Score: 76.8/100 | Hit rate: 99.4% Hits: 269784 (35.0 allocs/hit = overhead cost) Misses: 1557 (376.9 allocs/miss = render cost) Unique keys: 1557

6. views/layouts/_footer.html.erb:1
   Code: <% cache_frozen locale do -%>
   Score: 91.2/100 | Hit rate: 99.7% Hits: 22491 (29.0 allocs/hit = overhead cost) Misses: 63 (7686.5 allocs/miss = render cost) Unique keys: 9

-------------------------------------------------------------------------------- Total source locations: 20, Analyzed: 43339 keys

Score interpretation:
  - Low score + high allocs/hit: expensive overhead, consider removing
  - Low score + low hit rate: cache not being reused, consider removing
  - High allocs/miss: rendering is expensive, cache may still be valuable ~~~~

Basically, items 1, 3, and 4 have hit rates that are basically 0% when we're undergoing a web crawl (as we always are). These items are intended to help a user who is repeatedly editing or reviewing the same page, but such users are so swamped by the web crawling that it's actually detrimental to cache them (we can't know ahead-of-time which is which, so the chances of the cache being useful are too low to be useful).

Removing these caches doesn't remove any functionality. The whole point of caching is to optimize the common case. Now that the "common case" has changed, we must change our caching tactics to match.