### PR TITLE
Special translation:sync for baseline

### DIFF
--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -5,4 +5,4 @@
 # ignore the conflicts and "sync" again, it will fix this file for you.
 
 ---
-timestamp: 1763742492
+timestamp: 1770401585

--- a/config/locales/translation.de.yml
+++ b/config/locales/translation.de.yml
@@ -52,6 +52,7 @@ de:
       rel="noopener">Nutzungsbedingungen</a>.</small>
     choose_locale: Sprache auswählen
     toggle_navigation: Klappbare Navigation umschalten
+    translation_disclaimer_html:
   account_activations:
     activated: Konto aktiviert!
     failed_activation: Ungültiger Aktivierungslink
@@ -66,6 +67,9 @@ de:
         Als Anti-Spam-Maßnahme müssen Sie %{count} Stunden nach
         der Aktivierung warten, bevor Sie sich anmelden können.
       other: >-
+        Als Anti-Spam-Maßnahme müssen Sie %{count} Stunden nach
+        der Aktivierung warten, bevor Sie sich anmelden können.
+      many: >-
         Als Anti-Spam-Maßnahme müssen Sie %{count} Stunden nach
         der Aktivierung warten, bevor Sie sich anmelden können.
   password_resets:
@@ -414,6 +418,8 @@ de:
       submit_cdla_permissive_20_html:
       new_owner:
       new_owner_repeat:
+      current_owner:
+      ownership_edit_hint:
     form_basics:
       project_name:
         description: Was ist der von Menschen lesbare Name des
@@ -585,12 +591,17 @@ de:
         '0': Passing
         '1': Silber
         '2': Gold
-        baseline-1: 'Baseline Level 1'
-        baseline-1_html: 'Dies sind die Baseline Level 1 Kriterien.'
-        baseline-2: 'Baseline Level 2'
-        baseline-2_html: 'Dies sind die Baseline Level 2 Kriterien.'
-        baseline-3: 'Baseline Level 3'
-        baseline-3_html: 'Dies sind die Baseline Level 3 Kriterien.'
+        baseline-1:
+        baseline-1_html:
+        baseline-2:
+        baseline-2_html:
+        baseline-3:
+        baseline-3_html:
+      got_baseline_badge:
+        description_1:
+        badge_alt:
+        description_2:
+        details_html:
     misc:
       disabled_reminders: >-
         (Fortgeschritten) Inaktivierungserinnerung deaktivieren
@@ -2967,6 +2978,193 @@ de:
           der dynamischen Analyse überprüfen.
       achieve_silver:
         description: Das Projekt MUSS ein Silber-Siegel erreichen.
+    baseline-1:
+      osps_ac_01_01:
+        description:
+        details:
+      osps_ac_02_01:
+        description:
+        details:
+      osps_ac_03_01:
+        description:
+        details:
+      osps_ac_03_02:
+        description:
+        details:
+      osps_br_01_01:
+        description:
+      osps_br_01_02:
+        description:
+      osps_br_03_01:
+        description:
+        details:
+      osps_br_03_02:
+        description:
+        details:
+      osps_br_07_01:
+        description:
+        details:
+      osps_do_01_01:
+        description:
+        details:
+      osps_do_02_01:
+        description:
+        details:
+      osps_gv_02_01:
+        description:
+        details:
+      osps_gv_03_01:
+        description:
+        details:
+      osps_le_02_01:
+        description:
+        details:
+      osps_le_02_02:
+        description:
+        details:
+      osps_le_03_01:
+        description:
+        details:
+      osps_le_03_02:
+        description:
+        details:
+      osps_qa_01_01:
+        description:
+        details:
+      osps_qa_01_02:
+        description:
+        details:
+      osps_qa_02_01:
+        description:
+        details:
+      osps_qa_04_01:
+        description:
+        details:
+      osps_qa_05_01:
+        description:
+        details:
+      osps_qa_05_02:
+        description:
+        details:
+      osps_vm_02_01:
+        description:
+        details:
+    baseline-2:
+      osps_ac_04_01:
+        description:
+        details:
+      osps_br_02_01:
+        description:
+        details:
+      osps_br_04_01:
+        description:
+        details:
+      osps_br_05_01:
+        description:
+        details:
+      osps_br_06_01:
+        description:
+        details:
+      osps_do_06_01:
+        description:
+        details:
+      osps_gv_01_01:
+        description:
+        details:
+      osps_gv_01_02:
+        description:
+        details:
+      osps_gv_03_02:
+        description:
+        details:
+      osps_le_01_01:
+        description:
+        details:
+      osps_qa_03_01:
+        description:
+        details:
+      osps_qa_06_01:
+        description:
+        details:
+      osps_sa_01_01:
+        description:
+        details:
+      osps_sa_02_01:
+        description:
+        details:
+      osps_sa_03_01:
+        description:
+        details:
+      osps_vm_01_01:
+        description:
+        details:
+      osps_vm_03_01:
+        description:
+        details:
+      osps_vm_04_01:
+        description:
+        details:
+    baseline-3:
+      osps_ac_04_02:
+        description:
+        details:
+      osps_br_02_02:
+        description:
+        details:
+      osps_br_07_02:
+        description:
+        details:
+      osps_do_03_01:
+        description:
+        details:
+      osps_do_03_02:
+        description:
+        details:
+      osps_do_04_01:
+        description:
+        details:
+      osps_do_05_01:
+        description:
+        details:
+      osps_gv_04_01:
+        description:
+        details:
+      osps_qa_02_02:
+        description:
+        details:
+      osps_qa_04_02:
+        description:
+        details:
+      osps_qa_06_02:
+        description:
+        details:
+      osps_qa_06_03:
+        description:
+        details:
+      osps_qa_07_01:
+        description:
+        details:
+      osps_sa_03_02:
+        description:
+        details:
+      osps_vm_04_02:
+        description:
+        details:
+      osps_vm_05_01:
+        description:
+        details:
+      osps_vm_05_02:
+        description:
+        details:
+      osps_vm_05_03:
+        description:
+        details:
+      osps_vm_06_01:
+        description:
+        details:
+      osps_vm_06_02:
+        description:
+        details:
   static_pages:
     home:
       badge_program: OpenSSF Best Practices Badge Programm
@@ -3150,6 +3348,8 @@ de:
     Identification: Identifizierung
     Prerequisites: Voraussetzungen
     FLOSS license: FLOSS-Lizenz
+    Controls:
+    General:
   last_entry: Letzter Übersetzungseintrag
   admin_only: Nur Administratoren.
   criterion_status:
@@ -3301,3 +3501,6 @@ de:
     missing_parameters:
     invalid_parameters:
     error:
+  do_not_translate_this:
+  test_pluralization_only_one:
+    one:

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -40,6 +40,7 @@ es:
     login_html: Iniciar sesión
     footer_text_html:
     toggle_navigation:
+    translation_disclaimer_html:
   admin_only:
   account_activations:
     activated: "¡Cuenta activada!"
@@ -49,6 +50,7 @@ es:
       one:
       few:
       other:
+      many:
   password_resets:
     forgot_password:
     reset_password:
@@ -313,6 +315,8 @@ es:
       submit_cdla_permissive_20_html:
       new_owner:
       new_owner_repeat:
+      current_owner:
+      ownership_edit_hint:
     show:
       edit:
       delete:
@@ -369,12 +373,23 @@ es:
         1_html:
         '2':
         2_html:
+        baseline-1:
+        baseline-1_html:
+        baseline-2:
+        baseline-2_html:
+        baseline-3:
+        baseline-3_html:
       got_badge:
         description_1:
         badge_alt:
         description_2:
         details_html:
         editing_description_html:
+      got_baseline_badge:
+        description_1:
+        badge_alt:
+        description_2:
+        details_html:
     form_basics:
       project_name:
         description:
@@ -953,6 +968,193 @@ es:
         description:
       dynamic_analysis_enable_assertions:
         description:
+    baseline-1:
+      osps_ac_01_01:
+        description:
+        details:
+      osps_ac_02_01:
+        description:
+        details:
+      osps_ac_03_01:
+        description:
+        details:
+      osps_ac_03_02:
+        description:
+        details:
+      osps_br_01_01:
+        description:
+      osps_br_01_02:
+        description:
+      osps_br_03_01:
+        description:
+        details:
+      osps_br_03_02:
+        description:
+        details:
+      osps_br_07_01:
+        description:
+        details:
+      osps_do_01_01:
+        description:
+        details:
+      osps_do_02_01:
+        description:
+        details:
+      osps_gv_02_01:
+        description:
+        details:
+      osps_gv_03_01:
+        description:
+        details:
+      osps_le_02_01:
+        description:
+        details:
+      osps_le_02_02:
+        description:
+        details:
+      osps_le_03_01:
+        description:
+        details:
+      osps_le_03_02:
+        description:
+        details:
+      osps_qa_01_01:
+        description:
+        details:
+      osps_qa_01_02:
+        description:
+        details:
+      osps_qa_02_01:
+        description:
+        details:
+      osps_qa_04_01:
+        description:
+        details:
+      osps_qa_05_01:
+        description:
+        details:
+      osps_qa_05_02:
+        description:
+        details:
+      osps_vm_02_01:
+        description:
+        details:
+    baseline-2:
+      osps_ac_04_01:
+        description:
+        details:
+      osps_br_02_01:
+        description:
+        details:
+      osps_br_04_01:
+        description:
+        details:
+      osps_br_05_01:
+        description:
+        details:
+      osps_br_06_01:
+        description:
+        details:
+      osps_do_06_01:
+        description:
+        details:
+      osps_gv_01_01:
+        description:
+        details:
+      osps_gv_01_02:
+        description:
+        details:
+      osps_gv_03_02:
+        description:
+        details:
+      osps_le_01_01:
+        description:
+        details:
+      osps_qa_03_01:
+        description:
+        details:
+      osps_qa_06_01:
+        description:
+        details:
+      osps_sa_01_01:
+        description:
+        details:
+      osps_sa_02_01:
+        description:
+        details:
+      osps_sa_03_01:
+        description:
+        details:
+      osps_vm_01_01:
+        description:
+        details:
+      osps_vm_03_01:
+        description:
+        details:
+      osps_vm_04_01:
+        description:
+        details:
+    baseline-3:
+      osps_ac_04_02:
+        description:
+        details:
+      osps_br_02_02:
+        description:
+        details:
+      osps_br_07_02:
+        description:
+        details:
+      osps_do_03_01:
+        description:
+        details:
+      osps_do_03_02:
+        description:
+        details:
+      osps_do_04_01:
+        description:
+        details:
+      osps_do_05_01:
+        description:
+        details:
+      osps_gv_04_01:
+        description:
+        details:
+      osps_qa_02_02:
+        description:
+        details:
+      osps_qa_04_02:
+        description:
+        details:
+      osps_qa_06_02:
+        description:
+        details:
+      osps_qa_06_03:
+        description:
+        details:
+      osps_qa_07_01:
+        description:
+        details:
+      osps_sa_03_02:
+        description:
+        details:
+      osps_vm_04_02:
+        description:
+        details:
+      osps_vm_05_01:
+        description:
+        details:
+      osps_vm_05_02:
+        description:
+        details:
+      osps_vm_05_03:
+        description:
+        details:
+      osps_vm_06_01:
+        description:
+        details:
+      osps_vm_06_02:
+        description:
+        details:
   headings:
     Accessibility and internationalization:
     Analysis:
@@ -997,6 +1199,8 @@ es:
     Vulnerability report process: Proceso de informe de vulnerabilidad
     Warning flags: Banderas de advertencia
     Working build system:
+    Controls:
+    General:
   criterion_status:
     Met:
     Unmet:
@@ -1105,3 +1309,6 @@ es:
     missing_parameters:
     invalid_parameters:
     error:
+  do_not_translate_this:
+  test_pluralization_only_one:
+    one:

--- a/config/locales/translation.fr.yml
+++ b/config/locales/translation.fr.yml
@@ -45,6 +45,7 @@ fr:
     account: Compte
     choose_locale: Choisir la langue
     toggle_navigation: Choisir ou non la navigation repliable
+    translation_disclaimer_html:
   sessions:
     login_header: S'identifier
     login_with_github_html: Connectez-vous avec GitHub
@@ -402,6 +403,8 @@ fr:
       submit_cdla_permissive_20_html:
       new_owner:
       new_owner_repeat:
+      current_owner:
+      ownership_edit_hint:
     form_basics:
       project_name:
         description: Quel est le nom intelligible du projet ?
@@ -580,12 +583,17 @@ fr:
         '0': Basique
         '1': Argent
         '2': Or
-        baseline-1: 'Baseline Niveau 1'
-        baseline-1_html: 'Ce sont les critères du Baseline Niveau 1.'
-        baseline-2: 'Baseline Niveau 2'
-        baseline-2_html: 'Ce sont les critères du Baseline Niveau 2.'
-        baseline-3: 'Baseline Niveau 3'
-        baseline-3_html: 'Ce sont les critères du Baseline Niveau 3.'
+        baseline-1:
+        baseline-1_html:
+        baseline-2:
+        baseline-2_html:
+        baseline-3:
+        baseline-3_html:
+      got_baseline_badge:
+        description_1:
+        badge_alt:
+        description_2:
+        details_html:
     misc:
       disabled_reminders: >-
         (Avancé) Désactiver le rappel d'inactivité (nous vous
@@ -788,6 +796,9 @@ fr:
         À titre de mesure anti-spam, vous devez attendre %{count}
         heures après l'activation avant de pouvoir vous connecter.
       other: >-
+        À titre de mesure anti-spam, vous devez attendre %{count}
+        heures après l'activation avant de pouvoir vous connecter.
+      many: >-
         À titre de mesure anti-spam, vous devez attendre %{count}
         heures après l'activation avant de pouvoir vous connecter.
   password_resets:
@@ -3096,6 +3107,193 @@ fr:
       achieve_silver:
         description: Le projet DOIT atteindre un badge de niveau
           argent.
+    baseline-1:
+      osps_ac_01_01:
+        description:
+        details:
+      osps_ac_02_01:
+        description:
+        details:
+      osps_ac_03_01:
+        description:
+        details:
+      osps_ac_03_02:
+        description:
+        details:
+      osps_br_01_01:
+        description:
+      osps_br_01_02:
+        description:
+      osps_br_03_01:
+        description:
+        details:
+      osps_br_03_02:
+        description:
+        details:
+      osps_br_07_01:
+        description:
+        details:
+      osps_do_01_01:
+        description:
+        details:
+      osps_do_02_01:
+        description:
+        details:
+      osps_gv_02_01:
+        description:
+        details:
+      osps_gv_03_01:
+        description:
+        details:
+      osps_le_02_01:
+        description:
+        details:
+      osps_le_02_02:
+        description:
+        details:
+      osps_le_03_01:
+        description:
+        details:
+      osps_le_03_02:
+        description:
+        details:
+      osps_qa_01_01:
+        description:
+        details:
+      osps_qa_01_02:
+        description:
+        details:
+      osps_qa_02_01:
+        description:
+        details:
+      osps_qa_04_01:
+        description:
+        details:
+      osps_qa_05_01:
+        description:
+        details:
+      osps_qa_05_02:
+        description:
+        details:
+      osps_vm_02_01:
+        description:
+        details:
+    baseline-2:
+      osps_ac_04_01:
+        description:
+        details:
+      osps_br_02_01:
+        description:
+        details:
+      osps_br_04_01:
+        description:
+        details:
+      osps_br_05_01:
+        description:
+        details:
+      osps_br_06_01:
+        description:
+        details:
+      osps_do_06_01:
+        description:
+        details:
+      osps_gv_01_01:
+        description:
+        details:
+      osps_gv_01_02:
+        description:
+        details:
+      osps_gv_03_02:
+        description:
+        details:
+      osps_le_01_01:
+        description:
+        details:
+      osps_qa_03_01:
+        description:
+        details:
+      osps_qa_06_01:
+        description:
+        details:
+      osps_sa_01_01:
+        description:
+        details:
+      osps_sa_02_01:
+        description:
+        details:
+      osps_sa_03_01:
+        description:
+        details:
+      osps_vm_01_01:
+        description:
+        details:
+      osps_vm_03_01:
+        description:
+        details:
+      osps_vm_04_01:
+        description:
+        details:
+    baseline-3:
+      osps_ac_04_02:
+        description:
+        details:
+      osps_br_02_02:
+        description:
+        details:
+      osps_br_07_02:
+        description:
+        details:
+      osps_do_03_01:
+        description:
+        details:
+      osps_do_03_02:
+        description:
+        details:
+      osps_do_04_01:
+        description:
+        details:
+      osps_do_05_01:
+        description:
+        details:
+      osps_gv_04_01:
+        description:
+        details:
+      osps_qa_02_02:
+        description:
+        details:
+      osps_qa_04_02:
+        description:
+        details:
+      osps_qa_06_02:
+        description:
+        details:
+      osps_qa_06_03:
+        description:
+        details:
+      osps_qa_07_01:
+        description:
+        details:
+      osps_sa_03_02:
+        description:
+        details:
+      osps_vm_04_02:
+        description:
+        details:
+      osps_vm_05_01:
+        description:
+        details:
+      osps_vm_05_02:
+        description:
+        details:
+      osps_vm_05_03:
+        description:
+        details:
+      osps_vm_06_01:
+        description:
+        details:
+      osps_vm_06_02:
+        description:
+        details:
   static_pages:
     home:
       badge_program: Programme de badge des meilleures pratiques
@@ -3270,6 +3468,8 @@ fr:
     Identification: Identification
     Prerequisites: Conditions préalables
     FLOSS license: Licence FLOSS
+    Controls:
+    General:
   last_entry: Dernière entrée de traduction
   admin_only: Admin seulement.
   criterion_status:
@@ -3705,3 +3905,6 @@ fr:
     missing_parameters:
     invalid_parameters:
     error:
+  do_not_translate_this:
+  test_pluralization_only_one:
+    one:

--- a/config/locales/translation.ja.yml
+++ b/config/locales/translation.ja.yml
@@ -49,6 +49,7 @@ ja:
       target="_blank" rel="noopener">利用条件</a>を必ずお読みください。</small>
     choose_locale: 言語を選択する
     toggle_navigation: 折りたたみ可能なナビゲーションを切り替える
+    translation_disclaimer_html:
   account_activations:
     activated: アカウントが有効になりました！
     failed_activation: 無効なアクティベーション リンクです
@@ -57,6 +58,7 @@ ja:
       one: スパム対策として、ログインできるまでに、アクティベーション後1時間待つ必要があります。
       few: スパム対策として、ログインできるまでに、アクティベーション後%{count}時間待つ必要があります。
       other: スパム対策として、ログインできるまでに、アクティベーション後%{count}時間待つ必要があります。
+      many: スパム対策として、ログインできるまでに、アクティベーション後%{count}時間待つ必要があります。
   password_resets:
     forgot_password: パスワードを忘れた方はこちら
     reset_password: パスワードをリセットしてください
@@ -287,6 +289,8 @@ ja:
       submit_cdla_permissive_20_html:
       new_owner:
       new_owner_repeat:
+      current_owner:
+      ownership_edit_hint:
     form_basics:
       project_name:
         description: プロジェクトの名前は何ですか？
@@ -369,6 +373,17 @@ ja:
         '0': 合格
         '1': シルバー
         '2': ゴールド
+        baseline-1:
+        baseline-1_html:
+        baseline-2:
+        baseline-2_html:
+        baseline-3:
+        baseline-3_html:
+      got_baseline_badge:
+        description_1:
+        badge_alt:
+        description_2:
+        details_html:
     misc:
       disabled_reminders: >-
         （詳細）非アクティビティ リマインダーを無効にします（このままにしておくことをお勧めします。リマインダーを送信するかどうかを変更するには、プロジェクトエントリーを編集する必要があります。）
@@ -1511,6 +1526,193 @@ ja:
           プロジェクトは、生成するソフトウェアに多くの実行時アサーションを含めるべきであり、動的分析中にそれらのアサーションをチェックするべきです。
       achieve_silver:
         description: プロジェクトは、シルバー レベル バッジを達成しなければなりません。
+    baseline-1:
+      osps_ac_01_01:
+        description:
+        details:
+      osps_ac_02_01:
+        description:
+        details:
+      osps_ac_03_01:
+        description:
+        details:
+      osps_ac_03_02:
+        description:
+        details:
+      osps_br_01_01:
+        description:
+      osps_br_01_02:
+        description:
+      osps_br_03_01:
+        description:
+        details:
+      osps_br_03_02:
+        description:
+        details:
+      osps_br_07_01:
+        description:
+        details:
+      osps_do_01_01:
+        description:
+        details:
+      osps_do_02_01:
+        description:
+        details:
+      osps_gv_02_01:
+        description:
+        details:
+      osps_gv_03_01:
+        description:
+        details:
+      osps_le_02_01:
+        description:
+        details:
+      osps_le_02_02:
+        description:
+        details:
+      osps_le_03_01:
+        description:
+        details:
+      osps_le_03_02:
+        description:
+        details:
+      osps_qa_01_01:
+        description:
+        details:
+      osps_qa_01_02:
+        description:
+        details:
+      osps_qa_02_01:
+        description:
+        details:
+      osps_qa_04_01:
+        description:
+        details:
+      osps_qa_05_01:
+        description:
+        details:
+      osps_qa_05_02:
+        description:
+        details:
+      osps_vm_02_01:
+        description:
+        details:
+    baseline-2:
+      osps_ac_04_01:
+        description:
+        details:
+      osps_br_02_01:
+        description:
+        details:
+      osps_br_04_01:
+        description:
+        details:
+      osps_br_05_01:
+        description:
+        details:
+      osps_br_06_01:
+        description:
+        details:
+      osps_do_06_01:
+        description:
+        details:
+      osps_gv_01_01:
+        description:
+        details:
+      osps_gv_01_02:
+        description:
+        details:
+      osps_gv_03_02:
+        description:
+        details:
+      osps_le_01_01:
+        description:
+        details:
+      osps_qa_03_01:
+        description:
+        details:
+      osps_qa_06_01:
+        description:
+        details:
+      osps_sa_01_01:
+        description:
+        details:
+      osps_sa_02_01:
+        description:
+        details:
+      osps_sa_03_01:
+        description:
+        details:
+      osps_vm_01_01:
+        description:
+        details:
+      osps_vm_03_01:
+        description:
+        details:
+      osps_vm_04_01:
+        description:
+        details:
+    baseline-3:
+      osps_ac_04_02:
+        description:
+        details:
+      osps_br_02_02:
+        description:
+        details:
+      osps_br_07_02:
+        description:
+        details:
+      osps_do_03_01:
+        description:
+        details:
+      osps_do_03_02:
+        description:
+        details:
+      osps_do_04_01:
+        description:
+        details:
+      osps_do_05_01:
+        description:
+        details:
+      osps_gv_04_01:
+        description:
+        details:
+      osps_qa_02_02:
+        description:
+        details:
+      osps_qa_04_02:
+        description:
+        details:
+      osps_qa_06_02:
+        description:
+        details:
+      osps_qa_06_03:
+        description:
+        details:
+      osps_qa_07_01:
+        description:
+        details:
+      osps_sa_03_02:
+        description:
+        details:
+      osps_vm_04_02:
+        description:
+        details:
+      osps_vm_05_01:
+        description:
+        details:
+      osps_vm_05_02:
+        description:
+        details:
+      osps_vm_05_03:
+        description:
+        details:
+      osps_vm_06_01:
+        description:
+        details:
+      osps_vm_06_02:
+        description:
+        details:
   static_pages:
     home:
       badge_program: OpenSSF ベストプラクティス バッジ プログラム
@@ -1629,6 +1831,8 @@ ja:
     Identification: 識別情報
     Prerequisites: 前提要件
     FLOSS license: FLOSSライセンス
+    Controls:
+    General:
   last_entry: 最後の翻訳エントリ
   admin_only: 管理者のみ。
   criterion_status:
@@ -1838,3 +2042,6 @@ ja:
     missing_parameters:
     invalid_parameters:
     error:
+  do_not_translate_this:
+  test_pluralization_only_one:
+    one:

--- a/config/locales/translation.pt-BR.yml
+++ b/config/locales/translation.pt-BR.yml
@@ -40,6 +40,7 @@ pt-BR:
     signup_html:
     login_html:
     footer_text_html:
+    translation_disclaimer_html:
   admin_only:
   account_activations:
     activated:
@@ -48,6 +49,7 @@ pt-BR:
       one:
       few:
       other:
+      many:
     failed_activation:
   password_resets:
     forgot_password:
@@ -317,6 +319,8 @@ pt-BR:
       submit_cdla_permissive_20_html:
       new_owner:
       new_owner_repeat:
+      current_owner:
+      ownership_edit_hint:
     show:
       edit:
       delete:
@@ -342,12 +346,23 @@ pt-BR:
         1_html:
         '2':
         2_html:
+        baseline-1:
+        baseline-1_html:
+        baseline-2:
+        baseline-2_html:
+        baseline-3:
+        baseline-3_html:
       got_badge:
         description_1:
         badge_alt:
         description_2:
         details_html:
         editing_description_html:
+      got_baseline_badge:
+        description_1:
+        badge_alt:
+        description_2:
+        details_html:
     form_basics:
       project_name:
         description:
@@ -871,6 +886,193 @@ pt-BR:
         description:
       dynamic_analysis_enable_assertions:
         description:
+    baseline-1:
+      osps_ac_01_01:
+        description:
+        details:
+      osps_ac_02_01:
+        description:
+        details:
+      osps_ac_03_01:
+        description:
+        details:
+      osps_ac_03_02:
+        description:
+        details:
+      osps_br_01_01:
+        description:
+      osps_br_01_02:
+        description:
+      osps_br_03_01:
+        description:
+        details:
+      osps_br_03_02:
+        description:
+        details:
+      osps_br_07_01:
+        description:
+        details:
+      osps_do_01_01:
+        description:
+        details:
+      osps_do_02_01:
+        description:
+        details:
+      osps_gv_02_01:
+        description:
+        details:
+      osps_gv_03_01:
+        description:
+        details:
+      osps_le_02_01:
+        description:
+        details:
+      osps_le_02_02:
+        description:
+        details:
+      osps_le_03_01:
+        description:
+        details:
+      osps_le_03_02:
+        description:
+        details:
+      osps_qa_01_01:
+        description:
+        details:
+      osps_qa_01_02:
+        description:
+        details:
+      osps_qa_02_01:
+        description:
+        details:
+      osps_qa_04_01:
+        description:
+        details:
+      osps_qa_05_01:
+        description:
+        details:
+      osps_qa_05_02:
+        description:
+        details:
+      osps_vm_02_01:
+        description:
+        details:
+    baseline-2:
+      osps_ac_04_01:
+        description:
+        details:
+      osps_br_02_01:
+        description:
+        details:
+      osps_br_04_01:
+        description:
+        details:
+      osps_br_05_01:
+        description:
+        details:
+      osps_br_06_01:
+        description:
+        details:
+      osps_do_06_01:
+        description:
+        details:
+      osps_gv_01_01:
+        description:
+        details:
+      osps_gv_01_02:
+        description:
+        details:
+      osps_gv_03_02:
+        description:
+        details:
+      osps_le_01_01:
+        description:
+        details:
+      osps_qa_03_01:
+        description:
+        details:
+      osps_qa_06_01:
+        description:
+        details:
+      osps_sa_01_01:
+        description:
+        details:
+      osps_sa_02_01:
+        description:
+        details:
+      osps_sa_03_01:
+        description:
+        details:
+      osps_vm_01_01:
+        description:
+        details:
+      osps_vm_03_01:
+        description:
+        details:
+      osps_vm_04_01:
+        description:
+        details:
+    baseline-3:
+      osps_ac_04_02:
+        description:
+        details:
+      osps_br_02_02:
+        description:
+        details:
+      osps_br_07_02:
+        description:
+        details:
+      osps_do_03_01:
+        description:
+        details:
+      osps_do_03_02:
+        description:
+        details:
+      osps_do_04_01:
+        description:
+        details:
+      osps_do_05_01:
+        description:
+        details:
+      osps_gv_04_01:
+        description:
+        details:
+      osps_qa_02_02:
+        description:
+        details:
+      osps_qa_04_02:
+        description:
+        details:
+      osps_qa_06_02:
+        description:
+        details:
+      osps_qa_06_03:
+        description:
+        details:
+      osps_qa_07_01:
+        description:
+        details:
+      osps_sa_03_02:
+        description:
+        details:
+      osps_vm_04_02:
+        description:
+        details:
+      osps_vm_05_01:
+        description:
+        details:
+      osps_vm_05_02:
+        description:
+        details:
+      osps_vm_05_03:
+        description:
+        details:
+      osps_vm_06_01:
+        description:
+        details:
+      osps_vm_06_02:
+        description:
+        details:
   criteria_overall:
     beginning_header_all:
     beginning_header_0:
@@ -924,6 +1126,8 @@ pt-BR:
     Vulnerability report process:
     Warning flags:
     Working build system:
+    Controls:
+    General:
   criterion_status:
     Met:
     Unmet:
@@ -1017,3 +1221,6 @@ pt-BR:
     missing_parameters:
     invalid_parameters:
     error:
+  do_not_translate_this:
+  test_pluralization_only_one:
+    one:

--- a/config/locales/translation.ru.yml
+++ b/config/locales/translation.ru.yml
@@ -57,6 +57,7 @@ ru:
       rel="noopener">условия использования</a>.</small>
     choose_locale: Выберите язык
     toggle_navigation:
+    translation_disclaimer_html:
   admin_only: Только администратор.
   account_activations:
     activated: Учетная запись активирована!
@@ -72,6 +73,9 @@ ru:
         В связи с защитой от спама вам придется подождать %{count}
         часов после активации, прежде чем вы сможете войти в систему.
       other: >-
+        В связи с защитой от спама вам придется подождать %{count}
+        часов после активации, прежде чем вы сможете войти в систему.
+      many: >-
         В связи с защитой от спама вам придется подождать %{count}
         часов после активации, прежде чем вы сможете войти в систему.
   password_resets:
@@ -509,6 +513,8 @@ ru:
       submit_cdla_permissive_20_html:
       new_owner:
       new_owner_repeat:
+      current_owner:
+      ownership_edit_hint:
     show:
       edit: Изменить
       delete: Удалить
@@ -594,6 +600,12 @@ ru:
         '0': Passing
         '1': Silver
         '2': Gold
+        baseline-1:
+        baseline-1_html:
+        baseline-2:
+        baseline-2_html:
+        baseline-3:
+        baseline-3_html:
       got_badge:
         description_1: >-
           Если это ваш проект, пожалуйста, покажите свой значок
@@ -612,6 +624,11 @@ ru:
           вы видите проблему, пожалуйста, <em><a href="mailto:&#99;ii&#45;badges&#45;questions&#45;own&#101;r&#64;lists&#46;coreinfrastructure&#46;or&#103;">отправьте
           электронное письмо</a> </em> или <em><a href="https://github.com/coreinfrastructure/best-practices-badge/issues"
           target="_blank" rel="noopener">опишите проблему в трекере</a></em>.
+      got_baseline_badge:
+        description_1:
+        badge_alt:
+        description_2:
+        details_html:
     form_basics:
       project_name:
         description: Какое у проекта человекочитаемое название?
@@ -2958,6 +2975,193 @@ ru:
           и проверять эти утверждения во время динамического анализа.
       achieve_silver:
         description: Проект ОБЯЗАН получить серебряный значок.
+    baseline-1:
+      osps_ac_01_01:
+        description:
+        details:
+      osps_ac_02_01:
+        description:
+        details:
+      osps_ac_03_01:
+        description:
+        details:
+      osps_ac_03_02:
+        description:
+        details:
+      osps_br_01_01:
+        description:
+      osps_br_01_02:
+        description:
+      osps_br_03_01:
+        description:
+        details:
+      osps_br_03_02:
+        description:
+        details:
+      osps_br_07_01:
+        description:
+        details:
+      osps_do_01_01:
+        description:
+        details:
+      osps_do_02_01:
+        description:
+        details:
+      osps_gv_02_01:
+        description:
+        details:
+      osps_gv_03_01:
+        description:
+        details:
+      osps_le_02_01:
+        description:
+        details:
+      osps_le_02_02:
+        description:
+        details:
+      osps_le_03_01:
+        description:
+        details:
+      osps_le_03_02:
+        description:
+        details:
+      osps_qa_01_01:
+        description:
+        details:
+      osps_qa_01_02:
+        description:
+        details:
+      osps_qa_02_01:
+        description:
+        details:
+      osps_qa_04_01:
+        description:
+        details:
+      osps_qa_05_01:
+        description:
+        details:
+      osps_qa_05_02:
+        description:
+        details:
+      osps_vm_02_01:
+        description:
+        details:
+    baseline-2:
+      osps_ac_04_01:
+        description:
+        details:
+      osps_br_02_01:
+        description:
+        details:
+      osps_br_04_01:
+        description:
+        details:
+      osps_br_05_01:
+        description:
+        details:
+      osps_br_06_01:
+        description:
+        details:
+      osps_do_06_01:
+        description:
+        details:
+      osps_gv_01_01:
+        description:
+        details:
+      osps_gv_01_02:
+        description:
+        details:
+      osps_gv_03_02:
+        description:
+        details:
+      osps_le_01_01:
+        description:
+        details:
+      osps_qa_03_01:
+        description:
+        details:
+      osps_qa_06_01:
+        description:
+        details:
+      osps_sa_01_01:
+        description:
+        details:
+      osps_sa_02_01:
+        description:
+        details:
+      osps_sa_03_01:
+        description:
+        details:
+      osps_vm_01_01:
+        description:
+        details:
+      osps_vm_03_01:
+        description:
+        details:
+      osps_vm_04_01:
+        description:
+        details:
+    baseline-3:
+      osps_ac_04_02:
+        description:
+        details:
+      osps_br_02_02:
+        description:
+        details:
+      osps_br_07_02:
+        description:
+        details:
+      osps_do_03_01:
+        description:
+        details:
+      osps_do_03_02:
+        description:
+        details:
+      osps_do_04_01:
+        description:
+        details:
+      osps_do_05_01:
+        description:
+        details:
+      osps_gv_04_01:
+        description:
+        details:
+      osps_qa_02_02:
+        description:
+        details:
+      osps_qa_04_02:
+        description:
+        details:
+      osps_qa_06_02:
+        description:
+        details:
+      osps_qa_06_03:
+        description:
+        details:
+      osps_qa_07_01:
+        description:
+        details:
+      osps_sa_03_02:
+        description:
+        details:
+      osps_vm_04_02:
+        description:
+        details:
+      osps_vm_05_01:
+        description:
+        details:
+      osps_vm_05_02:
+        description:
+        details:
+      osps_vm_05_03:
+        description:
+        details:
+      osps_vm_06_01:
+        description:
+        details:
+      osps_vm_06_02:
+        description:
+        details:
   headings:
     Accessibility and internationalization: Общедоступность и
       интернационализация
@@ -3003,6 +3207,8 @@ ru:
     Working build system: Рабочая система сборки
     Prerequisites: Предварительные требования
     FLOSS license: Свободная лицензия
+    Controls:
+    General:
   criterion_status:
     Met: Соответствует
     Unmet: Не соответствует
@@ -3178,3 +3384,6 @@ ru:
     missing_parameters:
     invalid_parameters:
     error:
+  do_not_translate_this:
+  test_pluralization_only_one:
+    one:

--- a/config/locales/translation.sw.yml
+++ b/config/locales/translation.sw.yml
@@ -52,6 +52,7 @@ sw:
       target="_blank" rel="noopener">sera ya faragha</a> and <a
       href="https://www.linuxfoundation.org/terms" target="_blank"
       rel="noopener">masharti ya utumiaji</a>. </small>
+    translation_disclaimer_html:
   admin_only: Msimamizi pekee.
   account_activations:
     activated: Akaunti imeamilishwa!
@@ -66,6 +67,9 @@ sw:
         Kwa minajili ya kupambana na barua taka, lazima usubiri
         masaa %{count} baada ya uanzishaji kabla ya kuingia.
       other: >-
+        Kwa minajili ya kupambana na barua taka, lazima usubiri
+        masaa %{count} baada ya uanzishaji kabla ya kuingia.
+      many: >-
         Kwa minajili ya kupambana na barua taka, lazima usubiri
         masaa %{count} baada ya uanzishaji kabla ya kuingia.
     failed_activation: Kiungo batili cha uanzishaji
@@ -373,6 +377,8 @@ sw:
       submit_cdla_permissive_20_html:
       new_owner:
       new_owner_repeat:
+      current_owner:
+      ownership_edit_hint:
     show:
       edit:
       delete:
@@ -398,12 +404,23 @@ sw:
         1_html:
         '2':
         2_html:
+        baseline-1:
+        baseline-1_html:
+        baseline-2:
+        baseline-2_html:
+        baseline-3:
+        baseline-3_html:
       got_badge:
         description_1:
         badge_alt:
         description_2:
         details_html:
         editing_description_html:
+      got_baseline_badge:
+        description_1:
+        badge_alt:
+        description_2:
+        details_html:
     form_basics:
       project_name:
         description:
@@ -1067,6 +1084,193 @@ sw:
         description:
       dynamic_analysis_enable_assertions:
         description:
+    baseline-1:
+      osps_ac_01_01:
+        description:
+        details:
+      osps_ac_02_01:
+        description:
+        details:
+      osps_ac_03_01:
+        description:
+        details:
+      osps_ac_03_02:
+        description:
+        details:
+      osps_br_01_01:
+        description:
+      osps_br_01_02:
+        description:
+      osps_br_03_01:
+        description:
+        details:
+      osps_br_03_02:
+        description:
+        details:
+      osps_br_07_01:
+        description:
+        details:
+      osps_do_01_01:
+        description:
+        details:
+      osps_do_02_01:
+        description:
+        details:
+      osps_gv_02_01:
+        description:
+        details:
+      osps_gv_03_01:
+        description:
+        details:
+      osps_le_02_01:
+        description:
+        details:
+      osps_le_02_02:
+        description:
+        details:
+      osps_le_03_01:
+        description:
+        details:
+      osps_le_03_02:
+        description:
+        details:
+      osps_qa_01_01:
+        description:
+        details:
+      osps_qa_01_02:
+        description:
+        details:
+      osps_qa_02_01:
+        description:
+        details:
+      osps_qa_04_01:
+        description:
+        details:
+      osps_qa_05_01:
+        description:
+        details:
+      osps_qa_05_02:
+        description:
+        details:
+      osps_vm_02_01:
+        description:
+        details:
+    baseline-2:
+      osps_ac_04_01:
+        description:
+        details:
+      osps_br_02_01:
+        description:
+        details:
+      osps_br_04_01:
+        description:
+        details:
+      osps_br_05_01:
+        description:
+        details:
+      osps_br_06_01:
+        description:
+        details:
+      osps_do_06_01:
+        description:
+        details:
+      osps_gv_01_01:
+        description:
+        details:
+      osps_gv_01_02:
+        description:
+        details:
+      osps_gv_03_02:
+        description:
+        details:
+      osps_le_01_01:
+        description:
+        details:
+      osps_qa_03_01:
+        description:
+        details:
+      osps_qa_06_01:
+        description:
+        details:
+      osps_sa_01_01:
+        description:
+        details:
+      osps_sa_02_01:
+        description:
+        details:
+      osps_sa_03_01:
+        description:
+        details:
+      osps_vm_01_01:
+        description:
+        details:
+      osps_vm_03_01:
+        description:
+        details:
+      osps_vm_04_01:
+        description:
+        details:
+    baseline-3:
+      osps_ac_04_02:
+        description:
+        details:
+      osps_br_02_02:
+        description:
+        details:
+      osps_br_07_02:
+        description:
+        details:
+      osps_do_03_01:
+        description:
+        details:
+      osps_do_03_02:
+        description:
+        details:
+      osps_do_04_01:
+        description:
+        details:
+      osps_do_05_01:
+        description:
+        details:
+      osps_gv_04_01:
+        description:
+        details:
+      osps_qa_02_02:
+        description:
+        details:
+      osps_qa_04_02:
+        description:
+        details:
+      osps_qa_06_02:
+        description:
+        details:
+      osps_qa_06_03:
+        description:
+        details:
+      osps_qa_07_01:
+        description:
+        details:
+      osps_sa_03_02:
+        description:
+        details:
+      osps_vm_04_02:
+        description:
+        details:
+      osps_vm_05_01:
+        description:
+        details:
+      osps_vm_05_02:
+        description:
+        details:
+      osps_vm_05_03:
+        description:
+        details:
+      osps_vm_06_01:
+        description:
+        details:
+      osps_vm_06_02:
+        description:
+        details:
   criteria_overall:
     beginning_header_all:
     beginning_header_0:
@@ -1120,6 +1324,8 @@ sw:
     Vulnerability report process:
     Warning flags:
     Working build system:
+    Controls:
+    General:
   criterion_status:
     Met:
     Unmet:
@@ -1213,3 +1419,6 @@ sw:
     missing_parameters:
     invalid_parameters:
     error:
+  do_not_translate_this:
+  test_pluralization_only_one:
+    one:

--- a/config/locales/translation.zh-CN.yml
+++ b/config/locales/translation.zh-CN.yml
@@ -37,6 +37,7 @@ zh-CN:
     account: 帐户
     choose_locale: 选择区域设置
     toggle_navigation: 切换可折叠导航
+    translation_disclaimer_html:
   sessions:
     login_header: 登录
     login_with_github_html: 使用GitHub账户登录
@@ -244,6 +245,8 @@ zh-CN:
       submit_cdla_permissive_20_html:
       new_owner:
       new_owner_repeat:
+      current_owner:
+      ownership_edit_hint:
     form_basics:
       project_name:
         description: 项目的人类可读的名称是什么？
@@ -311,6 +314,17 @@ zh-CN:
         '0': 通过
         '1': 白银
         '2': 黄金
+        baseline-1:
+        baseline-1_html:
+        baseline-2:
+        baseline-2_html:
+        baseline-3:
+        baseline-3_html:
+      got_baseline_badge:
+        description_1:
+        badge_alt:
+        description_2:
+        details_html:
     misc:
       disabled_reminders: "（高级）禁用不活动提醒（我们建议您取消选中此选项）"
       general_comments:
@@ -435,6 +449,7 @@ zh-CN:
       one: 作为一种反垃圾邮件措施，您必须在激活后等待一小时才能登录。
       few: 作为一种反垃圾邮件措施，您必须在激活后等待%{count}小时才能登录。
       other: 作为一种反垃圾邮件措施，您必须在激活后等待%{count}小时才能登录。
+      many: 作为一种反垃圾邮件措施，您必须在激活后等待%{count}小时才能登录。
   password_resets:
     forgot_password: 忘记密码
     reset_password: 重设密码
@@ -1258,6 +1273,193 @@ zh-CN:
         description: 项目应该在其生成的软件中包含许多运行时断言，并在动态分析期间检查这些断言。
       achieve_silver:
         description: 该项目必须拥有银级徽章。
+    baseline-1:
+      osps_ac_01_01:
+        description:
+        details:
+      osps_ac_02_01:
+        description:
+        details:
+      osps_ac_03_01:
+        description:
+        details:
+      osps_ac_03_02:
+        description:
+        details:
+      osps_br_01_01:
+        description:
+      osps_br_01_02:
+        description:
+      osps_br_03_01:
+        description:
+        details:
+      osps_br_03_02:
+        description:
+        details:
+      osps_br_07_01:
+        description:
+        details:
+      osps_do_01_01:
+        description:
+        details:
+      osps_do_02_01:
+        description:
+        details:
+      osps_gv_02_01:
+        description:
+        details:
+      osps_gv_03_01:
+        description:
+        details:
+      osps_le_02_01:
+        description:
+        details:
+      osps_le_02_02:
+        description:
+        details:
+      osps_le_03_01:
+        description:
+        details:
+      osps_le_03_02:
+        description:
+        details:
+      osps_qa_01_01:
+        description:
+        details:
+      osps_qa_01_02:
+        description:
+        details:
+      osps_qa_02_01:
+        description:
+        details:
+      osps_qa_04_01:
+        description:
+        details:
+      osps_qa_05_01:
+        description:
+        details:
+      osps_qa_05_02:
+        description:
+        details:
+      osps_vm_02_01:
+        description:
+        details:
+    baseline-2:
+      osps_ac_04_01:
+        description:
+        details:
+      osps_br_02_01:
+        description:
+        details:
+      osps_br_04_01:
+        description:
+        details:
+      osps_br_05_01:
+        description:
+        details:
+      osps_br_06_01:
+        description:
+        details:
+      osps_do_06_01:
+        description:
+        details:
+      osps_gv_01_01:
+        description:
+        details:
+      osps_gv_01_02:
+        description:
+        details:
+      osps_gv_03_02:
+        description:
+        details:
+      osps_le_01_01:
+        description:
+        details:
+      osps_qa_03_01:
+        description:
+        details:
+      osps_qa_06_01:
+        description:
+        details:
+      osps_sa_01_01:
+        description:
+        details:
+      osps_sa_02_01:
+        description:
+        details:
+      osps_sa_03_01:
+        description:
+        details:
+      osps_vm_01_01:
+        description:
+        details:
+      osps_vm_03_01:
+        description:
+        details:
+      osps_vm_04_01:
+        description:
+        details:
+    baseline-3:
+      osps_ac_04_02:
+        description:
+        details:
+      osps_br_02_02:
+        description:
+        details:
+      osps_br_07_02:
+        description:
+        details:
+      osps_do_03_01:
+        description:
+        details:
+      osps_do_03_02:
+        description:
+        details:
+      osps_do_04_01:
+        description:
+        details:
+      osps_do_05_01:
+        description:
+        details:
+      osps_gv_04_01:
+        description:
+        details:
+      osps_qa_02_02:
+        description:
+        details:
+      osps_qa_04_02:
+        description:
+        details:
+      osps_qa_06_02:
+        description:
+        details:
+      osps_qa_06_03:
+        description:
+        details:
+      osps_qa_07_01:
+        description:
+        details:
+      osps_sa_03_02:
+        description:
+        details:
+      osps_vm_04_02:
+        description:
+        details:
+      osps_vm_05_01:
+        description:
+        details:
+      osps_vm_05_02:
+        description:
+        details:
+      osps_vm_05_03:
+        description:
+        details:
+      osps_vm_06_01:
+        description:
+        details:
+      osps_vm_06_02:
+        description:
+        details:
   static_pages:
     home:
       badge_program: OpenSSF 最佳实践徽章计划
@@ -1378,6 +1580,8 @@ zh-CN:
     Identification: 识别
     Prerequisites: 先决条件
     FLOSS license: FLOSS许可证
+    Controls:
+    General:
   last_entry: 最后翻译条目
   admin_only: 仅限管理员。
   criterion_status:
@@ -1509,3 +1713,6 @@ zh-CN:
     missing_parameters:
     invalid_parameters:
     error:
+  do_not_translate_this:
+  test_pluralization_only_one:
+    one:


### PR DESCRIPTION
This is the result of a special `rake translation:sync` after we'd added baseline levels 2 and 3.
Human translators now have many more segments for translation.

That's an overwhelming task, so we'll use machine translations when the humans haven't had a chance to do the translation. The machine translators have been provided the most relevant human translations as a guide, and will continue to receive that guidance in the future. This incrases the likelihood of consistent terminology. Machine translators are better at some languages than others. They tend to do especially badly at Swahili. However, we have a large number of segments in Swahili, which will help the overall quality to some extent.

Status will change over time, of course.
As of this moment, here is the translation status
as reported by `rake translation:status`:

~~~~
Translation Status:
------------------------------------------------------------
fr       Human:  736  Machine:  159  Missing:    7
de       Human:  670  Machine:  225  Missing:    7
ja       Human:  736  Machine:  165  Missing:    1
zh-CN    Human:  690  Machine:  211  Missing:    1
pt-BR    Human:   21  Machine:  879  Missing:    2
es       Human:   79  Machine:  821  Missing:    2
ru       Human:  665  Machine:  236  Missing:    1
sw       Human:  179  Machine:  722  Missing:    1
~~~~