### PR TITLE
Make entry_locale description text bold to match other fields

### DIFF
--- a/app/views/projects/_form_basics.html.erb
+++ b/app/views/projects/_form_basics.html.erb
@@ -38,7 +38,7 @@
 
             <% unless view_only %>
               <div class="hidable-text-entry">
-                <%= t('projects.form_basics.entry_locale.description') %>
+                <span><label><%= t('projects.form_basics.entry_locale.description') %></label></span>
                 <%= render(partial: "details", locals: {
                            criterion: "entry_locale",
                            details: t('projects.form_basics.entry_locale.details')


### PR DESCRIPTION
Wrap the entry_locale description text in <span><label>...</label></span> to match the styling convention used by other fields in the form.

Other fields use f.label which generates a <label> element that gets bold styling from Bootstrap/CSS. For entry_locale, we can't use f.label (it would generate an unwanted 'Entry locale' label), so we manually wrap the descriptive text in a <label> tag to get the same styling.

This makes 'What language is used for this badge entry's description and justifications?' appear bold like other field prompts.