### PR TITLE
Add as=edit query to redirect to project edit page by URL

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -193,6 +193,57 @@ might request.
 
     <img src="https://bestpractices.coreinfrastructure.org/projects/NUMBER/badge" alt="OpenSSF N/A">
 
+*   `GET /en/projects?as=edit&url=MY_URL`
+    `GET /en/projects?as=edit&section=SECTION&url=MY_URL`
+
+    Perform a query for a project with the given URL (repository URL or
+    home page URL) and redirect to its *edit* page.
+    This is intended for external automation tools that know a project's
+    URL but not its numeric ID, and want to propose changes to the
+    badge entry (see
+    [automation-proposals.md](automation-proposals.md) for details
+    on the automation proposals mechanism).
+
+    If a single project matches, the user is redirected (HTTP 302) to:
+
+    ```text
+    /projects/:id/:section/edit?PROPOSAL_PARAMS
+    ```
+
+    Where `:section` is taken from the `section` query parameter
+    (e.g., `passing`, `silver`, `gold`, `baseline-1`),
+    defaulting to `passing` if not provided or invalid.
+    Only the automation-proposal query parameters are forwarded;
+    the consumed parameters (`as`, `url`, `section`, `pq`, `q`) are
+    stripped from the redirect URL.
+
+    The redirect URL intentionally omits the locale prefix, so the
+    application will determine the user's preferred locale and
+    redirect accordingly.
+    If the user is not logged in, they will be prompted to log in
+    (the original URL with all proposal parameters is preserved).
+    If the user is logged in and authorized to edit, they will see
+    the edit form with the proposed values highlighted for review.
+
+    If no project matches, or if multiple projects match, the normal
+    project list is shown instead (same behavior as `as=entry`).
+
+    This returns status 404 (not found) for zero matches
+    only when using `as=badge`; with `as=edit` zero or multiple
+    matches simply fall back to the project list.
+
+    Example proposing that a project's `floss_license` criterion is Met:
+
+    ```text
+    /en/projects?as=edit&floss_license_status=Met&url=https%3A%2F%2Fgithub.com%2FORG%2FPROJECT
+    ```
+
+    Example proposing changes to a specific section (silver):
+
+    ```text
+    /en/projects?as=edit&section=silver&url=https%3A%2F%2Fgithub.com%2FORG%2FPROJECT
+    ```
+
 ## Tiered percentage in OpenSSF Best Practices Badge
 
 The `tiered_percentage` field of a project
@@ -293,6 +344,10 @@ list of projects in the requested format. The "as" parameter changes this:
 *   as=badge : Display the *single* badge for the resulting project.
     If no project matches the criteria, status 404 (not found) is returned.
     If multiple projects match the criteria, status 409 (conflict) is returned.
+*   as=edit : Redirect to the *edit* page for the resulting project.
+    If a single project matches, the user is redirected (302) to the
+    project's edit URL. If no or multiple projects match, the normal
+    project list is shown instead. See below for details.
 *   as=entry : Display the project badge *entry* for the resulting project.
     If no or multiple projects match, the normal project display
     is shown instead.

--- a/docs/automation-proposals.md
+++ b/docs/automation-proposals.md
@@ -265,7 +265,7 @@ the same field.
 
 External tools that want to propose changes should:
 
-1. Know the project's numeric ID and the section to edit.
+1. Know the project's numeric ID (or its URL) and the section to edit.
 2. Construct the URL with the appropriate field names and values.
 3. URL-encode all values (especially spaces, ampersands, and
    special characters).
@@ -284,9 +284,41 @@ External tools that want to propose changes should:
 /en/projects/42/baseline-1/edit?osps_ac_01_01_status=Met&osps_ac_01_01_justification=GitHub+org+enforces+2FA&osps_ac_03_01_status=Met&osps_ac_03_01_justification=Branch+protection+enabled+on+main
 ```
 
+## Looking Up Projects by URL (`as=edit`)
+
+If an external tool knows a project's repository URL or home page URL
+but not its numeric ID, it can use the `as=edit` query on the
+projects index to look up and redirect to the edit page:
+
+```text
+/en/projects?as=edit&url=ENCODED_URL
+/en/projects?as=edit&section=SECTION&url=ENCODED_URL
+```
+
+The `section` parameter selects the badge level to edit
+(e.g., `passing`, `silver`, `baseline-1`); it defaults to `passing`.
+Any additional query parameters (automation proposals) are forwarded
+to the edit page with the consumed parameters (`as`, `url`, `section`,
+`pq`, `q`) stripped.
+
+For example, to propose license detection results for a project
+known only by its repository URL:
+
+```text
+/en/projects?as=edit&floss_license_status=Met&url=https%3A%2F%2Fgithub.com%2FORG%2FPROJECT
+```
+
+If the URL matches exactly one project, the user is redirected
+(HTTP 302) to its edit page. If there are zero or multiple matches,
+the normal project list is shown instead.
+
+See [api.md](api.md) for full details on the `as=edit` query
+parameter and the redirect behavior.
+
 ## Related Documentation
 
-- `docs/api.md` - General documentation on the API
+- `docs/api.md` - General documentation on the API, including the
+  `as=edit` URL lookup for automation proposals.
 - `criteria/criteria.yml` - Metal series criteria definitions.
 - `criteria/baseline_criteria.yml` - Baseline (OSPS) criteria
   definitions.


### PR DESCRIPTION
External automation tools that know a project's repository or home page URL (but not its numeric ID) can now use as=edit to look up the project and redirect to its edit page with automation proposals. The section parameter selects the badge level (default: passing), consumed parameters are stripped, and invalid sections fall back to the default. Zero or multiple matches show the project list.