### PR TITLE
Add daily baseline badge stats to project_stats

### DIFF
--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -56,7 +56,9 @@ RemoveUnusedMethodsInModelsCheck: { except_methods: [
   'User#digest',
   'User#created_since', # Used by daily stamp (rake); doesn't notice
   'User#updated_since', # Used by daily stamp (rake); doesn't notice
-  'Badge#reset_widths!' # Used in tests and after regenerating badge images
+  'Badge#reset_widths!', # Used in tests and after regenerating badge images
+  'ProjectStat#baseline_percent_field_name', # Parallel to percent_field_name
+  'ProjectStat#baseline_percent_field_description' # Parallel to percent_field_description
   ] }
 ReplaceComplexCreationWithFactoryMethodCheck: { attribute_assignment_count: 3 }
 # Disable false positive ReplaceInstanceVariableWithLocalVariableCheck for

--- a/db/migrate/20260212174356_add_baseline_stats_to_project_stats.rb
+++ b/db/migrate/20260212174356_add_baseline_stats_to_project_stats.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Copyright the OpenSSF Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+# Add baseline badge series statistics to project_stats.
+# These track daily progress of projects toward baseline-1/2/3 badges,
+# paralleling the existing metal series stats (percent_1_ge_*, percent_2_ge_*).
+class AddBaselineStatsToProjectStats < ActiveRecord::Migration[7.2]
+  def change
+    # rubocop:disable Rails/SchemaComment
+    change_table :project_stats, bulk: true do |t|
+      # Baseline level 1
+      t.integer :percent_baseline_1_ge_25
+      t.integer :percent_baseline_1_ge_50
+      t.integer :percent_baseline_1_ge_75
+      t.integer :percent_baseline_1_ge_90
+      t.integer :percent_baseline_1_ge_100
+
+      # Baseline level 2
+      t.integer :percent_baseline_2_ge_25
+      t.integer :percent_baseline_2_ge_50
+      t.integer :percent_baseline_2_ge_75
+      t.integer :percent_baseline_2_ge_90
+      t.integer :percent_baseline_2_ge_100
+
+      # Baseline level 3
+      t.integer :percent_baseline_3_ge_25
+      t.integer :percent_baseline_3_ge_50
+      t.integer :percent_baseline_3_ge_75
+      t.integer :percent_baseline_3_ge_90
+      t.integer :percent_baseline_3_ge_100
+    end
+    # rubocop:enable Rails/SchemaComment
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_08_053037) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_12_174356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -60,6 +60,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_08_053037) do
     t.integer "percent_2_ge_50"
     t.integer "percent_2_ge_75"
     t.integer "percent_2_ge_90"
+    t.integer "percent_baseline_1_ge_100"
+    t.integer "percent_baseline_1_ge_25"
+    t.integer "percent_baseline_1_ge_50"
+    t.integer "percent_baseline_1_ge_75"
+    t.integer "percent_baseline_1_ge_90"
+    t.integer "percent_baseline_2_ge_100"
+    t.integer "percent_baseline_2_ge_25"
+    t.integer "percent_baseline_2_ge_50"
+    t.integer "percent_baseline_2_ge_75"
+    t.integer "percent_baseline_2_ge_90"
+    t.integer "percent_baseline_3_ge_100"
+    t.integer "percent_baseline_3_ge_25"
+    t.integer "percent_baseline_3_ge_50"
+    t.integer "percent_baseline_3_ge_75"
+    t.integer "percent_baseline_3_ge_90"
     t.integer "percent_ge_0", null: false
     t.integer "percent_ge_100", null: false
     t.integer "percent_ge_25", null: false

--- a/test/models/project_stat_test.rb
+++ b/test/models/project_stat_test.rb
@@ -30,9 +30,31 @@ class ProjectStatTest < ActiveSupport::TestCase
     assert_equal 9, @project_stat.users
   end
 
+  test 'BADGE_LEVELS has expected minimum size and starting value' do
+    assert_operator ProjectStat::BADGE_LEVELS.count, :>=, 3
+    assert_equal 0, ProjectStat::BADGE_LEVELS.first
+  end
+
+  test 'BASELINE_BADGE_LEVELS has expected minimum size and starting value' do
+    assert_operator ProjectStat::BASELINE_BADGE_LEVELS.count, :>=, 3
+    assert_equal 1, ProjectStat::BASELINE_BADGE_LEVELS.first
+  end
+
   test 'count including fixtures' do
     # This includes the statistic created during setup
     assert_equal 9, ProjectStat.count
+  end
+
+  # Baseline stats should all be 0 since no project fixtures have
+  # baseline percentage values set.
+  test 'baseline stats are all zero with no baseline data' do
+    ProjectStat::BASELINE_BADGE_LEVELS.each do |bl|
+      ProjectStat::STAT_VALUES_GT0.each do |pct|
+        field = :"percent_baseline_#{bl}_ge_#{pct}"
+        assert_equal 0, @project_stat.public_send(field),
+                     "Expected #{field} to be 0"
+      end
+    end
   end
 
   test 'ProjectStat.percent_field_name() works correctly' do
@@ -63,5 +85,38 @@ class ProjectStatTest < ActiveSupport::TestCase
       assert_equal 'Silver Projects, 90%+ to Gold',
                    ProjectStat.percent_field_description('2', 90)
     end
+  end
+
+  test 'ProjectStat.baseline_percent_field_name() works correctly' do
+    assert_equal 'percent_baseline_1_ge_25',
+                 ProjectStat.baseline_percent_field_name(1, 25)
+    assert_equal 'percent_baseline_2_ge_50',
+                 ProjectStat.baseline_percent_field_name(2, 50)
+    assert_equal 'percent_baseline_3_ge_100',
+                 ProjectStat.baseline_percent_field_name(3, 100)
+  end
+
+  test 'ProjectStat.baseline_percent_field_description() works correctly' do
+    I18n.with_locale(:en) do
+      assert_equal 'Baseline Level 1 Projects',
+                   ProjectStat.baseline_percent_field_description(1, 100)
+      assert_equal 'Baseline Level 2 Projects',
+                   ProjectStat.baseline_percent_field_description(2, 100)
+      assert_equal 'Baseline Level 3 Projects',
+                   ProjectStat.baseline_percent_field_description(3, 100)
+      assert_equal '50%+ to Baseline Level 1',
+                   ProjectStat.baseline_percent_field_description(1, 50)
+      assert_equal 'Baseline Level 1 Projects, 75%+ to Baseline Level 2',
+                   ProjectStat.baseline_percent_field_description(2, 75)
+      assert_equal 'Baseline Level 2 Projects, 90%+ to Baseline Level 3',
+                   ProjectStat.baseline_percent_field_description(3, 90)
+    end
+  end
+
+  test 'ProjectStat.baseline_percent_field_description() rejects bad levels' do
+    assert_equal 'Bad baseline level 0',
+                 ProjectStat.baseline_percent_field_description(0, 50)
+    assert_equal 'Bad baseline level 4',
+                 ProjectStat.baseline_percent_field_description(4, 50)
   end
 end


### PR DESCRIPTION
Track progress of projects toward baseline-1/2/3 badges in the project_stats table, paralleling the existing metal series stats.

Adds 15 columns (percent_baseline_{1,2,3}_ge_{25,50,75,90,100}) and computes them daily via the stamp method. Partial percentages (25-90%) are counted independently per level, consistent with metal series. At 100%, all lower baseline levels must also be at 100% since baseline levels lack the built-in prerequisite criteria that metal levels have.

Derives BADGE_LEVELS and BASELINE_BADGE_LEVELS from section name data so adding a new level auto-propagates.