### PR TITLE
Rename config.cache_classes to config.enable_reloading

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.enable_reloading = true
 
   config.public_file_server.enabled = true
   # Do not eager load code on boot.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   # config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.enable_reloading = false
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = false
+  config.enable_reloading = true
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
config.cache_classes was deprecated in Rails 7.2 and replaced by config.enable_reloading (with inverted boolean logic):

- production: cache_classes = true  -> enable_reloading = false
- development: cache_classes = false -> enable_reloading = true
- test: cache_classes = false        -> enable_reloading = true