### PR TITLE
Add baseline_update.md and extraction

### DIFF
--- a/docs/baseline_update.md
+++ b/docs/baseline_update.md
@@ -1,0 +1,336 @@
+# Updating the Baseline Criteria
+
+This document explains the steps to update the
+[OpenSSF Open Source Project Security Baseline (OSPS Baseline)](https://baseline.openssf.org/)
+criteria when a new version is published.
+
+The baseline criteria are stored in `criteria/baseline_criteria.yml`.
+When a new version is published, existing criteria may have updated text, and
+new criteria may be added.
+
+When we import the updated baseline criteria,
+updated criteria text with an existing identifier is used immediately
+(these are clarifications and/or minor relaxations).
+New criteria are initially marked `future: true`
+so they are visible in the form (with an "upcoming criterion" label) but do
+not count toward the badge percentage until the transition period ends.
+
+## Step 0: Verify No Current "Future" Criteria
+
+Before starting an update, confirm that no criteria in the current file are
+marked as future. This ensures you are beginning from a stable, fully-active
+baseline before introducing new criteria.
+
+```bash
+grep -c 'future: true' criteria/baseline_criteria.yml
+```
+
+This should print `0`. If it prints a non-zero number, the previous update
+cycle is not yet complete—existing future criteria have not yet been
+activated. Resolve that first (see
+[Removing the "Future" Marking](#removing-the-future-marking) below).
+
+You can also run the validator to confirm the file is internally consistent:
+
+```bash
+rake baseline:validate
+```
+
+## Step 1: Identify the New Baseline Version
+
+Visit <https://baseline.openssf.org/> to find the URL of the new version.
+Version URLs follow the format
+`https://baseline.openssf.org/versions/YYYY-MM-DD`.
+
+Record both the old and new version strings. For example:
+
+- Old version: `2025-10-10` (currently in `criteria/baseline_criteria.yml`
+  under `_metadata.source_url` and in `config/baseline_config.yml`)
+- New version: `2026-02-19` (replace with the actual new date)
+
+## Step 2: Download the Updated Baseline Criteria HTML
+
+Create the `tmp/` directory if it does not exist, then download the new
+version's HTML page:
+
+```bash
+mkdir -p tmp
+curl -s 'https://baseline.openssf.org/versions/YYYY-MM-DD' \
+     -o tmp/baseline_source.html
+```
+
+Replace `YYYY-MM-DD` with the new version date (e.g., `2026-02-19`).
+
+## Step 3: Parse and Extract the Criteria
+
+Run the extraction script to parse the downloaded HTML and produce working
+files in `tmp/`:
+
+```bash
+script/extract_baseline.rb
+```
+
+This reads `tmp/baseline_source.html` and writes:
+
+- `tmp/baseline_extracted.yml` — criteria in the application's YAML format,
+  with `future: true` automatically added to any criterion whose key does not
+  yet exist in `criteria/baseline_criteria.yml`, and `obsolete: true`
+  added to any existing criterion whose key is absent from the new version
+- `tmp/baseline_extracted.json` — same data in JSON (useful for review)
+
+It prints a summary showing how many controls were extracted, how they are
+distributed across maturity levels and categories, and which (if any) keys
+are new or obsolete. Verify the counts look reasonable compared with the
+previous version.
+
+## Step 4: Review and Merge Changes into baseline_criteria.yml
+
+Copy the extracted file over the current criteria file and use `git diff`
+to review what changed:
+
+```bash
+cp tmp/baseline_extracted.yml criteria/baseline_criteria.yml
+git diff criteria/baseline_criteria.yml
+```
+
+The extraction script already annotates the two interesting cases
+automatically and reports them on stdout:
+
+- **New criteria** (not in the previous file): marked `future: true`
+- **Obsolete criteria** (in the previous file but absent from the new
+  upstream version): re-added at their original location with `obsolete: true`
+
+Review the script's output to confirm these lists look reasonable. If the
+number of obsolete criteria is unexpectedly large it likely indicates a
+**failed or partial import** (e.g., the HTML parser missed a section).
+In that case, stop, investigate `tmp/baseline_extracted.yml`, and re-run
+Step 3 before continuing.
+
+The application does not yet act on `obsolete: true`; the flag is recorded
+now so future tooling has something to search for. Do not drop the
+corresponding database columns for obsolete criteria; retained columns cause
+no harm and preserve historical data.
+
+If you do have obsolete data, and want to deploy it that way, you
+should probably modify the forms to show "obsolete" and explain it.
+We haven't done that because it hasn't happened, but we know what to do
+if it does.
+
+Also update the `_metadata` section at the top of
+`criteria/baseline_criteria.yml` to reflect the new version:
+
+```yaml
+_metadata:
+  source: OpenSSF Baseline HTML
+  source_url: https://baseline.openssf.org/versions/YYYY-MM-DD
+  extracted_at: 'YYYY-MM-DDTHH:MM:SS-ZZ:ZZ'
+  auto_generated: true
+  total_controls: NN
+```
+
+## Step 5: Generate and Run a Database Migration (New Criteria Only)
+
+If any new criteria were added in Step 4, their `_status` and
+`_justification` columns do not yet exist in the database. Generate the
+migration:
+
+```bash
+rake baseline:generate_migration
+```
+
+This compares `config/baseline_field_mapping.json` against the current
+database schema and writes a timestamped migration file under
+`db/migrate/`. If the mapping file does not exist yet, it is generated
+from `criteria/baseline_criteria.yml` automatically.
+
+Be sure to `git add` this new migration file.
+
+Update `config/baseline_field_mapping.json` to include the new criteria
+entries if the file was not regenerated automatically, then apply the
+migration:
+
+```bash
+rails db:migrate
+```
+
+If no new criteria were added, skip this step (running
+`rake baseline:generate_migration` will report "No new fields to add").
+
+## Step 6: Update the i18n Translations
+
+Extract the updated `description`, `details`, and placeholder text from
+`criteria/baseline_criteria.yml` into `config/locales/en.yml`:
+
+```bash
+rake baseline:extract_i18n
+```
+
+This replaces the content between the markers
+`# BEGIN BASELINE CRITERIA AUTO-GENERATED` and
+`# END BASELINE CRITERIA AUTO-GENERATED` in `config/locales/en.yml`
+with the current baseline criteria text. All content outside those markers
+is preserved.
+
+## Step 7: Validate the Updated Criteria
+
+Run the validator to confirm that `criteria/baseline_criteria.yml` is valid
+YAML and that `config/baseline_field_mapping.json` (if present) is valid
+JSON:
+
+```bash
+rake baseline:validate
+```
+
+A passing run prints:
+
+```
+✓ Baseline criteria validation passed
+```
+
+Fix any reported errors before continuing.
+
+## Step 8: Restart the Application
+
+Criteria are loaded into `CriteriaHash` and `FullCriteriaHash` at Rails
+startup in `config/initializers/00_criteria_hash.rb`. Changes to
+`criteria/baseline_criteria.yml` or `config/locales/en.yml` do not take
+effect until the application is restarted.
+
+In development:
+
+```bash
+rails s
+```
+
+In production, follow the standard deployment procedure (e.g., restart
+Puma workers).
+
+## Step 9: Verify a Changed Criterion Shows the Updated Text
+
+Open a project's baseline form (e.g., `/en/projects/1/baseline-1`) and
+navigate to a criterion whose text was updated in Step 4. Confirm that the
+form now displays the new description and details text.
+
+Alternatively, check from the Rails console:
+
+```ruby
+Criteria['baseline-1']['osps_xx_nn_nn'].description
+```
+
+Replace `osps_xx_nn_nn` with the key of the changed criterion.
+
+## Step 10: Verify a New Criterion Is Served but Marked "Future"
+
+Open the same baseline form and locate the new criterion. It should be
+visible with the label "(upcoming criterion)" before its description. This
+label is rendered by `app/views/projects/_status_chooser.html.erb` when
+`criterion.future?` returns `true`.
+
+Confirm from the Rails console that the criterion exists but is excluded
+from the active set:
+
+```ruby
+# Should exist:
+Criteria['baseline-1']['osps_xx_nn_nn']
+
+# Should NOT appear in the active list:
+Criteria.active('baseline-1').map(&:name).include?('osps_xx_nn_nn')
+# => false
+```
+
+Replace `osps_xx_nn_nn` with the new criterion's key.
+
+## Step 11: Update the Version Notice Partial
+
+Edit `app/views/projects/_form_baseline_version_notice.html.erb` to
+reflect the transition. During the transition period (after the new criteria
+are deployed but before they are enforced), set `baseline_in_transition` to
+`true` and fill in all three version variables:
+
+```erb
+<%
+  baseline_in_transition   = true
+  baseline_current_version = 'v2025.10.10'
+  baseline_new_version     = 'v2026.02.19'
+  baseline_enforce_date    = '2026-04-01'
+%>
+```
+
+- `baseline_current_version` is the version whose criteria are currently
+  active (the old version, until the enforce date).
+- `baseline_new_version` is the version being adopted (criteria shown as
+  "upcoming").
+- `baseline_enforce_date` is the date (YYYY-MM-DD) when new criteria start
+  counting toward the badge.
+
+When not in transition (steady state), set `baseline_in_transition = false`
+and update `baseline_current_version` to the new version string:
+
+```erb
+<%
+  baseline_in_transition   = false
+  baseline_current_version = 'v2026.02.19'
+  baseline_new_version     = ''
+  baseline_enforce_date    = ''
+%>
+```
+
+The `baseline_new_version` and `baseline_enforce_date` variables are
+ignored when `baseline_in_transition` is `false`.
+
+## Step 12: Perform Machine Translation
+
+After `config/locales/en.yml` has been updated with the new and changed
+criterion text, run automated machine translation to fill in the other
+supported locales:
+
+```bash
+rake translation:all
+```
+
+This iterates over all locales that have untranslated or stale segments
+(i.e., where the English source has changed since the machine translation
+was generated) and translates them using GitHub Copilot. It runs until all
+locales are up to date. Human translations always take precedence over
+machine translations.
+
+You can check translation status before and after with:
+
+```bash
+rake translation:status
+```
+
+## Removing the "Future" Marking
+
+When the enforce date arrives (the date set in `baseline_enforce_date`),
+the criteria that were previously marked `future: true` should become fully
+active. To activate them:
+
+1. Remove `future: true` from each affected criterion in
+   `criteria/baseline_criteria.yml`. If `future: false` was set explicitly,
+   remove that line too (the default is `false`).
+
+2. Run `rake baseline:extract_i18n` to sync any text changes that may have
+   occurred since the criteria were first added.
+
+3. Run `rake baseline:validate` to confirm the file is still valid.
+
+4. Update `app/views/projects/_form_baseline_version_notice.html.erb`:
+   set `baseline_in_transition = false` and update
+   `baseline_current_version` to the now-active version string (see
+   Step 11).
+
+5. Restart the application. The newly activated criteria will be included
+   in `Criteria.active(level)` and will count toward badge percentages.
+
+6. Verify by checking the Rails console:
+
+   ```ruby
+   Criteria.active('baseline-1').map(&:name).include?('osps_xx_nn_nn')
+   # => true
+   ```
+
+## Removing display of obsolete criteria
+
+If there were obsolete criteria, eventually you probably should remove
+them from display.

--- a/script/extract_baseline.rb
+++ b/script/extract_baseline.rb
@@ -26,6 +26,35 @@ controls = parser.parse
 
 puts "Extracted #{controls.length} controls"
 
+# Load existing criteria so new ones can be marked future: true and
+# dropped ones can be re-added with obsolete: true.
+# existing_criteria_data maps criterion key -> { level:, major:, minor:, data: }
+existing_criteria_file = 'criteria/baseline_criteria.yml'
+existing_criteria_data = {}
+if File.exist?(existing_criteria_file)
+  existing_criteria = YAML.safe_load_file(
+    existing_criteria_file,
+    permitted_classes: [Symbol],
+    aliases: true
+  )
+  existing_criteria.each do |level, level_data|
+    next if level == '_metadata'
+
+    level_data.each do |major, major_data|
+      major_data.each do |minor, criteria|
+        criteria.each do |key, data|
+          existing_criteria_data[key] = {
+            level: level, major: major, minor: minor, data: data
+          }
+        end
+      end
+    end
+  end
+  puts "Loaded #{existing_criteria_data.size} existing criterion keys from #{existing_criteria_file}"
+else
+  puts "No existing #{existing_criteria_file}; all criteria will be treated as new"
+end
+
 # Save as JSON for easy review
 json_file = 'tmp/baseline_extracted.json'
 File.write(json_file, JSON.pretty_generate(controls))
@@ -42,6 +71,9 @@ yaml_data = {
   }
 }
 
+new_keys = []
+extracted_keys = controls.pluck(:field_name)
+
 # Group by maturity level
 controls.group_by { |c| c[:maturity_level].first }
         .each do |level, level_controls|
@@ -55,7 +87,10 @@ controls.group_by { |c| c[:maturity_level].first }
     yaml_data[level_key][category]['Controls'] = {}
 
     cat_controls.each do |control|
-      yaml_data[level_key][category]['Controls'][control[:field_name]] = {
+      is_new = !existing_criteria_data.key?(control[:field_name])
+      new_keys << control[:field_name] if is_new
+
+      entry = {
         'category' => 'MUST',
         'description' => control[:requirement],
         'details' => control[:recommendation],
@@ -64,8 +99,25 @@ controls.group_by { |c| c[:maturity_level].first }
         'na_allowed' => true,
         'na_justification_required' => true
       }
+      entry['future'] = true if is_new
+
+      yaml_data[level_key][category]['Controls'][control[:field_name]] = entry
     end
   end
+end
+
+# Re-add criteria dropped from the new version with obsolete: true so they
+# remain findable. We don't act on obsolete criteria yet, but the flag makes
+# future handling straightforward.
+obsolete_keys = existing_criteria_data.keys - extracted_keys
+obsolete_keys.each do |key|
+  info = existing_criteria_data[key]
+  yaml_data[info[:level]] ||= {}
+  yaml_data[info[:level]][info[:major]] ||= {}
+  yaml_data[info[:level]][info[:major]][info[:minor]] ||= {}
+  entry = info[:data].dup
+  entry['obsolete'] = true
+  yaml_data[info[:level]][info[:major]][info[:minor]][key] = entry
 end
 
 yaml_file = 'tmp/baseline_extracted.yml'
@@ -83,6 +135,20 @@ puts "\nSummary by category:"
 controls.group_by { |c| c[:category] }
         .sort.each do |category, cat_controls|
   puts "  #{category}: #{cat_controls.length} controls"
+end
+
+if new_keys.empty?
+  puts "\nNo new criteria (no future: true entries added)"
+else
+  puts "\nNew criteria marked future: true (#{new_keys.length}):"
+  new_keys.each { |key| puts "  #{key}" }
+end
+
+if obsolete_keys.empty?
+  puts "\nNo obsolete criteria (no obsolete: true entries added)"
+else
+  puts "\nObsolete criteria marked obsolete: true (#{obsolete_keys.length}):"
+  obsolete_keys.each { |key| puts "  #{key}" }
 end
 
 puts "\nFirst 3 controls:"


### PR DESCRIPTION
Document the process for updating baseline criteria when a new upstream version is published (docs/baseline_update.md), covering how to download and parse the new version, spot-check the diff, run migrations, update translations, and eventually activate future criteria.

Improve script/extract_baseline.rb to automatically mark new criteria (keys absent from the current file) with future: true, and to re-add criteria dropped from the upstream version with obsolete: true, so both cases are handled without manual YAML editing and remain easy to search for in the future.

Note - we don't currently have any code for *displaying* or *handling* obsolete criteria yet. It's never happened, and we don't know if it ever will. We've written just enough to ensure that if obsolete criteria *do* occur, we capture that information so we correctly deal with it.