### PR TITLE
Add translations 2026-04-10 (automation proposals)

### DIFF
--- a/config/machine_translations/de.yml
+++ b/config/machine_translations/de.yml
@@ -52,6 +52,7 @@ de:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Automatisierungsvorschlag: %{proposed_value}'
       save_and_continue_tooltip: Führt Automatisierung aus, um unbekannte Werte zu füllen
+      automation_hint_html: Sie können Tools und KI-Systeme nutzen, um Änderungen über eine einfache URL vorzuschlagen, z. B. <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. Wie das geht, erfahren Sie in unserem <a href="%{automation_proposals_url}">Automatisierungsvorschlagssystem</a>.
     show:
       section_selector: Abschnitt
       cdla_permissive_20_html: Diese Daten sind unter der <a href="https://cdla.dev/permissive-2-0/" >Community Data License Agreement – Permissive, Version 2.0 (CDLA-Permissive-2.0)</a> verfügbar. Dies bedeutet, dass ein Datenempfänger die Daten mit oder ohne Änderungen weitergeben darf, solange der Datenempfänger den Text dieser Vereinbarung mit den weitergegebenen Daten zur Verfügung stellt. Bitte nennen Sie %{user} und die OpenSSF Best Practices Badge-Mitwirkenden als Urheber.<br><br>

--- a/config/machine_translations/es.yml
+++ b/config/machine_translations/es.yml
@@ -297,6 +297,7 @@ es:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Automatización sugerida: %{proposed_value}'
       save_and_continue_tooltip: Ejecuta la automatización para llenar valores desconocidos
+      automation_hint_html: Puede utilizar herramientas y sistemas de IA para proponer cambios a través de una URL simple, como <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. Consulte nuestro <a href="%{automation_proposals_url}">sistema de propuestas de automatización</a> para saber cómo hacerlo.
     show:
       section_selector: Sección
       edit: Editar

--- a/config/machine_translations/fr.yml
+++ b/config/machine_translations/fr.yml
@@ -49,6 +49,7 @@ fr:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Suggestion de l''automatisation : %{proposed_value}'
       save_and_continue_tooltip: Exécute l'automatisation pour remplir les valeurs inconnues
+      automation_hint_html: Vous pouvez utiliser des outils et des systèmes d'IA pour proposer des modifications via une URL simple, par exemple <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. Consultez notre <a href="%{automation_proposals_url}">système de propositions d'automatisation</a> pour savoir comment procéder.
     show:
       section_selector: Section
       cdla_permissive_20_html: Ces données sont disponibles sous la licence <a href="https://cdla.dev/permissive-2-0/" >Community Data License Agreement – Permissive, Version 2.0 (CDLA-Permissive-2.0)</a>. Cela signifie qu'un destinataire de données peut partager les données, avec ou sans modifications, à condition que le destinataire de données rende disponible le texte de cet accord avec les données partagées. Veuillez créditer %{user} et les contributeurs du badge des meilleures pratiques de la OpenSSF.<br><br>

--- a/config/machine_translations/ja.yml
+++ b/config/machine_translations/ja.yml
@@ -49,6 +49,7 @@ ja:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: '自動化の提案: %{proposed_value}'
       save_and_continue_tooltip: 自動化を実行して不明な値を入力します
+      automation_hint_html: ツールやAIシステムを使って、<tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>のような簡単なURLで変更を提案できます。その方法については、<a href="%{automation_proposals_url}">自動化提案システム</a>をご覧ください。
     show:
       section_selector: セクション
       cdla_permissive_20_html: このデータは、<a href="https://cdla.dev/permissive-2-0/" >Community Data License Agreement – Permissive, Version 2.0 (CDLA-Permissive-2.0)</a>のもとで利用可能です。これは、データ受領者が、データ受領者がこの契約のテキストを共有データとともに利用可能にする限り、変更の有無にかかわらずデータを共有できることを意味します。%{user}およびOpenSSFベストプラクティスバッジのコントリビューターにクレジットを表示してください。<br><br>

--- a/config/machine_translations/pt-BR.yml
+++ b/config/machine_translations/pt-BR.yml
@@ -331,6 +331,7 @@ pt-BR:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Sugestão da automação: %{proposed_value}'
       save_and_continue_tooltip: Executa automação para preencher valores desconhecidos
+      automation_hint_html: Você pode usar ferramentas e sistemas de IA para propor alterações por meio de uma URL simples, como <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. Veja nosso <a href="%{automation_proposals_url}">sistema de propostas de automação</a> para saber como fazer isso.
     show:
       section_selector: Seção
       edit: Editar

--- a/config/machine_translations/ru.yml
+++ b/config/machine_translations/ru.yml
@@ -82,6 +82,7 @@ ru:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Предложение автоматизации: %{proposed_value}'
       save_and_continue_tooltip: Запускает автоматизацию для заполнения неизвестных значений
+      automation_hint_html: Вы можете использовать инструменты и системы ИИ для предложения изменений через простой URL, например <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. Смотрите нашу <a href="%{automation_proposals_url}">систему автоматизированных предложений</a> о том, как это сделать.
     show:
       section_selector: Раздел
       cdla_permissive_20_html: Эти данные доступны по лицензии <a href="https://cdla.dev/permissive-2-0/" >Community Data License Agreement – Permissive, Version 2.0 (CDLA-Permissive-2.0)</a>. Это означает, что получатель данных может распространять данные с изменениями или без них, при условии, что получатель данных предоставляет текст данного соглашения вместе с распространяемыми данными. Пожалуйста, укажите в качестве источника %{user} и участников OpenSSF Best Practices badge.<br><br>

--- a/config/machine_translations/src_en_de.yml
+++ b/config/machine_translations/src_en_de.yml
@@ -52,6 +52,7 @@ en:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Automation suggested: %{proposed_value}'
       save_and_continue_tooltip: Runs automation to fill unknown values
+      automation_hint_html: You can use tools and AI systems to propose changes via a simple URL, such as <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. See our <a href="%{automation_proposals_url}">automation proposals system</a> for how to do that.
     show:
       section_selector: Section
       cdla_permissive_20_html: This data is available under the <a href="https://cdla.dev/permissive-2-0/" >Community Data License Agreement – Permissive, Version 2.0 (CDLA-Permissive-2.0)</a>. This means that a Data Recipient may share the Data, with or without modifications, so long as the Data Recipient makes available the text of this agreement with the shared Data. Please credit %{user} and the OpenSSF Best Practices badge contributors.<br><br>

--- a/config/machine_translations/src_en_es.yml
+++ b/config/machine_translations/src_en_es.yml
@@ -318,6 +318,7 @@ en:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Automation suggested: %{proposed_value}'
       save_and_continue_tooltip: Runs automation to fill unknown values
+      automation_hint_html: You can use tools and AI systems to propose changes via a simple URL, such as <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. See our <a href="%{automation_proposals_url}">automation proposals system</a> for how to do that.
     show:
       section_selector: Section
       edit: Edit

--- a/config/machine_translations/src_en_fr.yml
+++ b/config/machine_translations/src_en_fr.yml
@@ -49,6 +49,7 @@ en:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Automation suggested: %{proposed_value}'
       save_and_continue_tooltip: Runs automation to fill unknown values
+      automation_hint_html: You can use tools and AI systems to propose changes via a simple URL, such as <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. See our <a href="%{automation_proposals_url}">automation proposals system</a> for how to do that.
     show:
       section_selector: Section
       cdla_permissive_20_html: This data is available under the <a href="https://cdla.dev/permissive-2-0/" >Community Data License Agreement – Permissive, Version 2.0 (CDLA-Permissive-2.0)</a>. This means that a Data Recipient may share the Data, with or without modifications, so long as the Data Recipient makes available the text of this agreement with the shared Data. Please credit %{user} and the OpenSSF Best Practices badge contributors.<br><br>

--- a/config/machine_translations/src_en_ja.yml
+++ b/config/machine_translations/src_en_ja.yml
@@ -49,6 +49,7 @@ en:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Automation suggested: %{proposed_value}'
       save_and_continue_tooltip: Runs automation to fill unknown values
+      automation_hint_html: You can use tools and AI systems to propose changes via a simple URL, such as <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. See our <a href="%{automation_proposals_url}">automation proposals system</a> for how to do that.
     show:
       section_selector: Section
       cdla_permissive_20_html: This data is available under the <a href="https://cdla.dev/permissive-2-0/" >Community Data License Agreement – Permissive, Version 2.0 (CDLA-Permissive-2.0)</a>. This means that a Data Recipient may share the Data, with or without modifications, so long as the Data Recipient makes available the text of this agreement with the shared Data. Please credit %{user} and the OpenSSF Best Practices badge contributors.<br><br>

--- a/config/machine_translations/src_en_pt-BR.yml
+++ b/config/machine_translations/src_en_pt-BR.yml
@@ -339,6 +339,7 @@ en:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Automation suggested: %{proposed_value}'
       save_and_continue_tooltip: Runs automation to fill unknown values
+      automation_hint_html: You can use tools and AI systems to propose changes via a simple URL, such as <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. See our <a href="%{automation_proposals_url}">automation proposals system</a> for how to do that.
     show:
       section_selector: Section
       edit: Edit

--- a/config/machine_translations/src_en_ru.yml
+++ b/config/machine_translations/src_en_ru.yml
@@ -86,6 +86,7 @@ en:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Automation suggested: %{proposed_value}'
       save_and_continue_tooltip: Runs automation to fill unknown values
+      automation_hint_html: You can use tools and AI systems to propose changes via a simple URL, such as <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. See our <a href="%{automation_proposals_url}">automation proposals system</a> for how to do that.
     show:
       section_selector: Section
       cdla_permissive_20_html: This data is available under the <a href="https://cdla.dev/permissive-2-0/" >Community Data License Agreement – Permissive, Version 2.0 (CDLA-Permissive-2.0)</a>. This means that a Data Recipient may share the Data, with or without modifications, so long as the Data Recipient makes available the text of this agreement with the shared Data. Please credit %{user} and the OpenSSF Best Practices badge contributors.<br><br>

--- a/config/machine_translations/src_en_sw.yml
+++ b/config/machine_translations/src_en_sw.yml
@@ -186,6 +186,7 @@ en:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Automation suggested: %{proposed_value}'
       save_and_continue_tooltip: Runs automation to fill unknown values
+      automation_hint_html: You can use tools and AI systems to propose changes via a simple URL, such as <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. See our <a href="%{automation_proposals_url}">automation proposals system</a> for how to do that.
     show:
       section_selector: Section
       edit: Edit

--- a/config/machine_translations/src_en_zh-CN.yml
+++ b/config/machine_translations/src_en_zh-CN.yml
@@ -49,6 +49,7 @@ en:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Automation suggested: %{proposed_value}'
       save_and_continue_tooltip: Runs automation to fill unknown values
+      automation_hint_html: You can use tools and AI systems to propose changes via a simple URL, such as <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. See our <a href="%{automation_proposals_url}">automation proposals system</a> for how to do that.
     show:
       section_selector: Section
       cdla_permissive_20_html: This data is available under the <a href="https://cdla.dev/permissive-2-0/" >Community Data License Agreement – Permissive, Version 2.0 (CDLA-Permissive-2.0)</a>. This means that a Data Recipient may share the Data, with or without modifications, so long as the Data Recipient makes available the text of this agreement with the shared Data. Please credit %{user} and the OpenSSF Best Practices badge contributors.<br><br>

--- a/config/machine_translations/sw.yml
+++ b/config/machine_translations/sw.yml
@@ -182,6 +182,7 @@ sw:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 'Otomatiki ilipendekeza: %{proposed_value}'
       save_and_continue_tooltip: Inaendesha automation kujaza thamani zisizojulikana
+      automation_hint_html: Unaweza kutumia zana na mifumo ya AI kupendekeza mabadiliko kupitia URL rahisi, kama vile <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>. Angalia <a href="%{automation_proposals_url}">mfumo wetu wa mapendekezo ya otomatiki</a> kwa jinsi ya kufanya hivyo.
     show:
       section_selector: Sehemu
       edit: Hariri

--- a/config/machine_translations/zh-CN.yml
+++ b/config/machine_translations/zh-CN.yml
@@ -49,6 +49,7 @@ zh-CN:
         divergent_justification_part: " %{justification}"
         divergent_proposed_value: 自动化建议：%{proposed_value}
       save_and_continue_tooltip: 运行自动化以填充未知值
+      automation_hint_html: 您可以使用工具和AI系统通过简单的URL提交变更建议，例如 <tt>https://%{badge_hostname}/%{app_locale}/projects/%{project_id}/choose/edit?osps_ac_01_01_status=Met&amp;osps_ac_01_01_justification=GitHub+enforced</tt>。请参阅我们的<a href="%{automation_proposals_url}">自动化提案系统</a>，了解具体操作方法。
     show:
       section_selector: 部分
       cdla_permissive_20_html: 该数据可在<a href="https://cdla.dev/permissive-2-0/" >社区数据许可协议 – 许可性，版本 2.0 (CDLA-Permissive-2.0)</a>下获取。这意味着数据接收方可以共享数据，无论是否经过修改，只要数据接收方在共享数据时提供本协议文本。请注明%{user}和OpenSSF最佳实践徽章贡献者。<br><br>


### PR DESCRIPTION
This adds, just before the "save" button, information on automation proposals with an example. This will make it *much* more obvious that this is a way to provide data to us.