### PR TITLE
Remove unneeded checks:write permission from main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,9 @@ name: CI
 # Limit permissions. See:
 # https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
-# https://github.com/actions/first-interaction/issues/10#issuecomment-1041402989
 # Since we set "permissions", anything unset has access "none".
 permissions:
   contents: read
-  checks: write
 
 # Controls when the action will run. Triggers the workflow on push or pull
 # request events but only for the main branch (formerly the master branch)


### PR DESCRIPTION
No step in this workflow requires checks:write. Removing it eliminates an unnecessary sensitive permission and should bring the Scorecard Token-Permissions score from 9 to 10.

This resolves report
https://github.com/coreinfrastructure/best-practices-badge/security/code-scanning/20