### PR TITLE
Use original_fullpath to prevent open redirect

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -290,7 +290,7 @@ class ProjectsController < ApplicationController
   # rubocop:disable Metrics/PerceivedComplexity, Metrics/BlockNesting
   def index
     validated_url = set_valid_query_url
-    if validated_url == request.original_url
+    if validated_url == request.original_fullpath
       retrieve_projects
 
       if params[:as] == 'badge' # Redirect to badge view
@@ -1483,7 +1483,7 @@ class ProjectsController < ApplicationController
   # @return [String] Cleaned URL with valid query parameters only
   def set_valid_query_url
     # Rewrites /projects?q=&status=failing to /projects?status=failing
-    original = request.original_url
+    original = request.original_fullpath
     parsed = Addressable::URI.parse(original)
     return original if parsed.query_values.blank?
 


### PR DESCRIPTION
Method set_valid_query_url only modifies query parameters, never the host or path. This commit changes the code to use
request.original_fullpath (path+query only) instead of request.original_url (full absolute URL) to ensure that redirect_to can never send users to a different origin, eliminating the CodeQL rb/url-redirection false positive with a genuine hardening fix.

This fixes report
https://github.com/coreinfrastructure/best-practices-badge/security/code-scanning/11 While technically a false positive, future changes might have made it a correct report, so let's systemically prevent the vulnerability from *ever* happening.