### PR TITLE
Updates 2026-05-20 per dependabot

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,11 +167,11 @@ GEM
     et-orbi (1.4.0)
       tzinfo
     execjs (2.10.1)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
@@ -227,7 +227,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.19.5)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     kramdown (2.5.2)
       rexml (>= 3.4.4)


### PR DESCRIPTION
Fixes:

* ruby-jwt: Empty-key HMAC bypass; cross-language sibling of CVE-2026-44351 High #139 opened 2 days ago • Detected in jwt (RubyGems) • Gemfile.lock #2812
* faraday: Faraday has a possible incomplete fix for GHSA-33mh-2634-fwr2: protocol-relative URI objects still bypass host scoping. Faraday has a possible incomplete fix for GHSA-33mh-2634-fwr2: protocol-relative URI objects still bypass host scoping Low #138 opened 2 days ago • Detected in faraday (RubyGems) • Gemfile.lock #2810

I doubt either are exploitable in our environment.