### PR TITLE
Fix license_location forced-unmet when GitHub returns 404 (issue #2818)

### DIFF
--- a/app/lib/github_content_access.rb
+++ b/app/lib/github_content_access.rb
@@ -21,19 +21,27 @@ class GithubContentAccess
   # linuxfoundation/cii-best-practices-badge/contents
   # We use the Octokit gem to simplify access.
 
+  EMPTY = [].freeze
+
   # Given a filename, reply with information about it.
   # - For files (type='file') this is a hash of data
   #   Fields include: name, path, size, html_url.
   # - For directories (type='dir') this is an iterable set of hashes;
   #   each hash represents a filesystem object (see above)
-  def get_info(filename)
+  # The GitHub contents API returns 404 in several situations:
+  # private repos accessed without auth (GitHub returns 404, not 403, to
+  # avoid revealing that the repo exists), deleted repos, and occasionally
+  # transient errors. Note: empty repos return 409 Conflict, not 404.
+  #
+  # @param not_found_result [Object] value to return when the GitHub API
+  #   returns 404. Defaults to EMPTY (a frozen []) so callers can iterate
+  #   safely. Pass nil when the caller needs to distinguish a successful
+  #   (possibly empty) scan from an inaccessible repo.
+  def get_info(filename, not_found_result: EMPTY)
     @octokit_client = @octokit_client_factory.call if @octokit_client.nil?
     @octokit_client.contents @fullname, path: filename
   rescue Octokit::NotFound
-    # Empty repositories return 404 from the GitHub contents API.
-    # Return an empty array so callers iterate over zero entries
-    # instead of crashing.
-    []
+    not_found_result
   end
 
   # Get the actual content of a file (not just metadata).

--- a/app/lib/repo_files_examine_detective.rb
+++ b/app/lib/repo_files_examine_detective.rb
@@ -29,19 +29,22 @@ class RepoFilesExamineDetective < Detective
   # Contribution should be longer to be considered useful.
   CONTRIBUTION_MIN_SIZE = 100
 
+  EMPTY = [].freeze
+
   # Given an enumeration of fso info hashes, return the fso info for files
   # that match the regex name pattern and are at least minimum_size in length.
+  # Returns EMPTY when @top_level is nil (GitHub API returned 404).
   def files_named(name_pattern, minimum_size)
-    @top_level.select do |fso|
+    @top_level&.select do |fso|
       fso['type'] == 'file' && fso['name'].match(name_pattern) &&
         fso['size'] >= minimum_size
-    end
+    end || EMPTY
   end
 
   # Return first entry iff there's a top-level directory matching name_pattern;
   # if not found, returns nil
   def directory_named(name_pattern)
-    @top_level.find do |fso|
+    @top_level&.find do |fso|
       fso['type'] == 'dir' && fso['name'].match(name_pattern)
     end
   end
@@ -95,8 +98,9 @@ class RepoFilesExamineDetective < Detective
 
     @results = {}
 
-    # Top_level is iterable, contains a hash with name, size, type (file|dir).
-    @top_level = repo_files.get_info('/')
+    # nil when GitHub returns 404 (empty/private/deleted repo, transient error);
+    # an array of fso hashes when the scan succeeded.
+    @top_level = repo_files.get_info('/', not_found_result: nil)
 
     # TODO: Look in subdirectories.
 
@@ -140,11 +144,19 @@ class RepoFilesExamineDetective < Detective
   end
 
   # Check for license files and set both metal and baseline criteria
+  # rubocop:disable Metrics/MethodLength
   def check_license_files
+    # Use forced confidence (5) for UNMET only when @top_level is non-empty,
+    # confirming we actually scanned the repo and found no license file.
+    # An empty @top_level may mean the GitHub API returned 404 for reasons
+    # other than genuine absence (empty repo, private repo accessed without
+    # auth, transient failure) — in those cases low confidence avoids
+    # overriding a valid user-set "Met" value with a spurious "Unmet".
+    unmet_confidence = @top_level.nil? ? 1 : 5
     determine_results(
       :license_location_status,
       /\A([A-Za-z0-9]+-)?(license|copying)(\.md|\.txt)?\Z/i,
-      NONTRIVIAL_MIN_SIZE, 'license location', confidence: { unmet: 5 }
+      NONTRIVIAL_MIN_SIZE, 'license location', confidence: { unmet: unmet_confidence }
     )
 
     # If there's a LICENSES directory, then license_location probably met.
@@ -156,6 +168,7 @@ class RepoFilesExamineDetective < Detective
 
     set_baseline_license_status
   end
+  # rubocop:enable Metrics/MethodLength
 
   # Set baseline license-file-presence criteria if license location is met
   # rubocop:disable Metrics/MethodLength
@@ -167,8 +180,9 @@ class RepoFilesExamineDetective < Detective
         explanation: I18n.t('detectives.repo_files.license_found')
       }
     else
+      license_confidence = @results[:license_location_status][:confidence]
       @results[:osps_le_03_01_status] = {
-        value: CriterionStatus::UNMET, confidence: 5,
+        value: CriterionStatus::UNMET, confidence: license_confidence,
         explanation: I18n.t('detectives.repo_files.license_not_found')
       }
       @results[:osps_le_03_02_status] = {

--- a/app/lib/subdir_file_contents_detective.rb
+++ b/app/lib/subdir_file_contents_detective.rb
@@ -56,15 +56,23 @@ class SubdirFileContentsDetective < Detective
     nil
   end
 
+  # Fetch and decode the content of a single file entry.
+  # Returns nil when get_info returns 404 ([] or nil) or the entry has no content.
+  def fetch_file_content(repo_files, fso)
+    file_entry = repo_files.get_info(fso['path'])
+    return if file_entry.blank? || file_entry.is_a?(Array)
+    return if file_entry['content'].blank?
+
+    Base64.decode64(file_entry['content'])
+  end
+
   def match_file_content(repo_files, folder, patterns, description)
     files = repo_files.get_info(folder)
     files = files.select { |f| match_fso?(f, 'file', patterns[:file]) }
-    files.select do |fso|
-      patterns[:contents].each do |pattern|
-        file_entry = repo_files.get_info(fso['path'])
-        content = Base64.decode64(file_entry['content'])
-        return met_result description if content.match?(pattern)
-      end
+    files.each do |fso|
+      content = fetch_file_content(repo_files, fso)
+      next if content.nil?
+      return met_result description if patterns[:contents].any? { |p| content.match?(p) }
     end
     unmet_result description
   end

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -83,11 +83,11 @@ end
 # Do a quick check of Ruby syntax, takes only ~2 sec in most cases
 desc 'Check for ruby syntax problems on **.rb files modified last 7 days'
 task :ruby_syntax do
-  # Exclude temporary files beginning with comma.
+  # Exclude temporary files beginning with comma and files under temp/.
   # The `ruby -c` command only checks one file, so re-invoke for each file.
   # Do checks in parallel to speed results.
   puts 'Checking ruby syntax in files modified in the last 7 days...'
-  sh 'find . -name "*.rb" ! -name ",*" -mtime -7 -print0 | ' \
+  sh 'find . -name "*.rb" ! -name ",*" ! -path "./temp/*" -mtime -7 -print0 | ' \
      'xargs -0 -L 1 -P $(nproc) ruby -c > /dev/null'
 end
 

--- a/test/unit/lib/github_content_access_test.rb
+++ b/test/unit/lib/github_content_access_test.rb
@@ -26,13 +26,18 @@ class GithubContentAccessTest < ActiveSupport::TestCase
     end
   end
 
-  test 'get_info returns empty array when repo is empty (Octokit::NotFound)' do
+  test 'get_info returns empty array by default when repo returns NotFound' do
     access = GithubContentAccess.new(
       'owner/empty-repo', proc { MockOctokitEmpty.new }
     )
-    result = access.get_info('/')
+    assert_equal [], access.get_info('/')
+  end
 
-    assert_equal [], result
+  test 'get_info returns nil when not_found_result: nil and repo returns NotFound' do
+    access = GithubContentAccess.new(
+      'owner/empty-repo', proc { MockOctokitEmpty.new }
+    )
+    assert_nil access.get_info('/', not_found_result: nil)
   end
 
   test 'get_info returns contents normally for non-empty repo' do

--- a/test/unit/lib/repo_files_examine_detective_test.rb
+++ b/test/unit/lib/repo_files_examine_detective_test.rb
@@ -9,7 +9,7 @@ require 'test_helper'
 class RepoFilesExamineDetectiveTest < ActiveSupport::TestCase
   # Mock the file request system.
   class MockRepoFilesLicenses
-    def get_info(_pattern)
+    def get_info(_pattern, **)
       [
         {
           name: 'LICENSES', type: 'dir', html_url: './LICENSES/'
@@ -20,15 +20,53 @@ class RepoFilesExamineDetectiveTest < ActiveSupport::TestCase
     @octokit_client = true # anything other than nil
   end
 
-  # Mock repo_files that simulates an empty GitHub repo.
-  # GithubContentAccess#get_info returns [] for empty repos.
+  # Mock repo_files that simulates a 404 (empty repo, private repo, etc.).
+  # Mirrors GithubContentAccess#get_info behaviour: returns not_found_result,
+  # which is nil when the detective passes not_found_result: nil.
   class MockEmptyRepoFiles
     def blank?
       false
     end
 
-    def get_info(_path)
-      []
+    def get_info(_path, not_found_result: [])
+      not_found_result
+    end
+  end
+
+  # Mock repo with a LICENSE file at root (common layout).
+  class MockRepoFilesLicenseFile
+    def get_info(_pattern, **)
+      [
+        {
+          name: 'LICENSE', type: 'file', size: 11_340, html_url: './LICENSE'
+        }.with_indifferent_access
+      ]
+    end
+  end
+
+  # Mock repo with BOTH a LICENSE file AND a LICENSES/ directory (REUSE-style),
+  # matching the layout that triggered issue #2818 (e.g. camelot-os/sentry-kernel).
+  class MockRepoFilesLicenseBoth
+    def get_info(_pattern, **)
+      [
+        {
+          name: 'LICENSE', type: 'file', size: 11_340, html_url: './LICENSE'
+        }.with_indifferent_access,
+        {
+          name: 'LICENSES', type: 'dir', html_url: './LICENSES/'
+        }.with_indifferent_access
+      ]
+    end
+  end
+
+  # Mock a non-empty repo that has files but no license (README only).
+  class MockRepoFilesNoLicense
+    def get_info(_pattern, **)
+      [
+        {
+          name: 'README.md', type: 'file', size: 500, html_url: './README.md'
+        }.with_indifferent_access
+      ]
     end
   end
 
@@ -44,6 +82,22 @@ class RepoFilesExamineDetectiveTest < ActiveSupport::TestCase
     assert_equal CriterionStatus::UNMET, results[:release_notes_status][:value]
   end
 
+  test 'empty repo does not force license unmet (confidence below override threshold)' do
+    # An empty @top_level may mean API failure, private repo, or transient 404 —
+    # not necessarily genuine absence of a license. Use low confidence so we do
+    # NOT override a user-set "Met" value with a spurious automated "Unmet".
+    repo_files = MockEmptyRepoFiles.new
+    results = RepoFilesExamineDetective.new.analyze(nil, repo_files: repo_files)
+
+    assert_equal CriterionStatus::UNMET, results[:license_location_status][:value]
+    assert_operator results[:license_location_status][:confidence], :<,
+                    Chief::CONFIDENCE_OVERRIDE,
+                    'Empty @top_level must NOT produce a forced (>= CONFIDENCE_OVERRIDE) unmet result'
+    assert_operator results[:osps_le_03_01_status][:confidence], :<,
+                    Chief::CONFIDENCE_OVERRIDE,
+                    'osps_le_03_01_status must not be forced when API result is ambiguous'
+  end
+
   test 'LICENSES directory probably has licenses' do
     file_mock = MockRepoFilesLicenses.new
     results = RepoFilesExamineDetective.new.analyze(nil, repo_files: file_mock)
@@ -52,5 +106,39 @@ class RepoFilesExamineDetectiveTest < ActiveSupport::TestCase
     assert results[:license_location_status].key?(:value)
     assert results[:license_location_status][:value] == CriterionStatus::MET
     assert results[:license_location_status][:confidence] == 3
+  end
+
+  test 'LICENSE file at repo root is detected as met' do
+    file_mock = MockRepoFilesLicenseFile.new
+    results = RepoFilesExamineDetective.new.analyze(nil, repo_files: file_mock)
+
+    assert results.key?(:license_location_status)
+    assert_equal CriterionStatus::MET, results[:license_location_status][:value]
+  end
+
+  test 'LICENSE file with LICENSES directory (REUSE-style) is detected as met' do
+    # Regression test for issue #2818: projects using REUSE (LICENSES/ dir) AND
+    # a top-level LICENSE file must be detected as met. The LICENSES/ directory
+    # must not downgrade or interfere with the file-based MET result.
+    file_mock = MockRepoFilesLicenseBoth.new
+    results = RepoFilesExamineDetective.new.analyze(nil, repo_files: file_mock)
+
+    assert results.key?(:license_location_status)
+    assert_equal CriterionStatus::MET, results[:license_location_status][:value]
+  end
+
+  test 'non-empty repo without any license file uses forced unmet confidence' do
+    # When the API returns repo contents but we find no license, we can assert
+    # with high (forced) confidence that the license criterion is unmet.
+    file_mock = MockRepoFilesNoLicense.new
+    results = RepoFilesExamineDetective.new.analyze(nil, repo_files: file_mock)
+
+    assert_equal CriterionStatus::UNMET, results[:license_location_status][:value]
+    assert_operator results[:license_location_status][:confidence], :>=,
+                    Chief::CONFIDENCE_OVERRIDE,
+                    'Non-empty repo with no license should use forced confidence'
+    assert_operator results[:osps_le_03_01_status][:confidence], :>=,
+                    Chief::CONFIDENCE_OVERRIDE,
+                    'osps_le_03_01_status should be forced when API confirmed no license'
   end
 end

--- a/test/unit/lib/subdir_file_contents_detective_test.rb
+++ b/test/unit/lib/subdir_file_contents_detective_test.rb
@@ -6,6 +6,7 @@
 
 require 'test_helper'
 
+# rubocop:disable Metrics/ClassLength
 class SubdirFileContentsDetectiveTest < ActiveSupport::TestCase
   def setup
     super
@@ -61,8 +62,33 @@ class SubdirFileContentsDetectiveTest < ActiveSupport::TestCase
     end
   end
 
+  test 'file fetch returning 404 does not crash' do
+    # Regression test: get_info returns [] when a listed file subsequently
+    # returns 404 (race condition or transient error). Must return UNMET
+    # rather than raising on Base64.decode64(nil).
+    mock_repo_files = Object.new
+    mock_repo_files.define_singleton_method(:blank?) { false }
+    mock_repo_files.define_singleton_method(:get_info) do |path|
+      case path
+      when '/'
+        [{ 'name' => 'docs', 'type' => 'dir' }]
+      when 'docs'
+        [{ 'name' => 'guide.md', 'type' => 'file', 'path' => 'docs/guide.md' }]
+      else
+        [] # file fetch returns 404
+      end
+    end
+
+    results = SubdirFileContentsDetective.new.analyze(
+      @evidence, repo_files: mock_repo_files
+    )
+
+    assert results.key?(:documentation_basics_status)
+    assert_equal CriterionStatus::UNMET, results[:documentation_basics_status][:value]
+  end
+
   test 'empty repo returns unmet results without crashing' do
-    # GithubContentAccess#get_info returns [] for empty repos
+    # GithubContentAccess#get_info returns [] for empty/inaccessible repos
     mock_repo_files = Object.new
     mock_repo_files.define_singleton_method(:blank?) { false }
     mock_repo_files.define_singleton_method(:get_info) { |_path| [] }
@@ -107,3 +133,4 @@ class SubdirFileContentsDetectiveTest < ActiveSupport::TestCase
     assert_equal CriterionStatus::UNMET, dbs[:value]
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/test/vcr_cassettes/unit_test_subdir_file_contents_detective.yml
+++ b/test/vcr_cassettes/unit_test_subdir_file_contents_detective.yml
@@ -67,7 +67,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents//","documentation_url":"https://developer.github.com/v3/#http-redirects"}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 11 Feb 2020 17:13:03 GMT
 - request:
     method: get
@@ -134,7 +134,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Tue, 11 Feb 2020 17:13:03 GMT
 - request:
     method: get
@@ -208,7 +208,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '[{"name":".circleci","path":".circleci","sha":"7666618b7822e586c13412f0ec861116806630da","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.circleci?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/.circleci","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/7666618b7822e586c13412f0ec861116806630da","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.circleci?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/7666618b7822e586c13412f0ec861116806630da","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/.circleci"}},{"name":".env","path":".env","sha":"da64cf5e8c70a6cd6dae055746c21507cecbf3cc","size":419,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.env?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.env","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/da64cf5e8c70a6cd6dae055746c21507cecbf3cc","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/.env","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.env?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/da64cf5e8c70a6cd6dae055746c21507cecbf3cc","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.env"}},{"name":".eslintignore","path":".eslintignore","sha":"08c095bc04752863b15d22b73de41e8009194bfa","size":461,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.eslintignore?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.eslintignore","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/08c095bc04752863b15d22b73de41e8009194bfa","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/.eslintignore","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.eslintignore?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/08c095bc04752863b15d22b73de41e8009194bfa","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.eslintignore"}},{"name":".eslintrc","path":".eslintrc","sha":"d645181cb5f79269ccaa68d620516f68d24b0fd8","size":2912,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.eslintrc?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.eslintrc","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/d645181cb5f79269ccaa68d620516f68d24b0fd8","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/.eslintrc","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.eslintrc?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/d645181cb5f79269ccaa68d620516f68d24b0fd8","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.eslintrc"}},{"name":".fasterer.yml","path":".fasterer.yml","sha":"b9d162bedb8a0baef27fc8466bcfd996f3215c08","size":55,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.fasterer.yml?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.fasterer.yml","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/b9d162bedb8a0baef27fc8466bcfd996f3215c08","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/.fasterer.yml","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.fasterer.yml?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/b9d162bedb8a0baef27fc8466bcfd996f3215c08","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.fasterer.yml"}},{"name":".gitignore","path":".gitignore","sha":"9ba8557312084504e2219a7dbee16153d1cf2ede","size":866,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.gitignore?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.gitignore","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/9ba8557312084504e2219a7dbee16153d1cf2ede","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/.gitignore","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.gitignore?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/9ba8557312084504e2219a7dbee16153d1cf2ede","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.gitignore"}},{"name":".pryrc","path":".pryrc","sha":"f68dff77909f27d3787f3b72183b77b9b711db06","size":42,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.pryrc?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.pryrc","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/f68dff77909f27d3787f3b72183b77b9b711db06","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/.pryrc","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.pryrc?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/f68dff77909f27d3787f3b72183b77b9b711db06","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.pryrc"}},{"name":".rubocop.yml","path":".rubocop.yml","sha":"f9860657897367fe2c57fe21ffc21865c2a93cda","size":2346,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.rubocop.yml?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.rubocop.yml","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/f9860657897367fe2c57fe21ffc21865c2a93cda","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/.rubocop.yml","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.rubocop.yml?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/f9860657897367fe2c57fe21ffc21865c2a93cda","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.rubocop.yml"}},{"name":".ruby-version","path":".ruby-version","sha":"ec1cf33c3f6e22d5833bed6199c520a9ee20a0fa","size":6,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.ruby-version?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.ruby-version","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/ec1cf33c3f6e22d5833bed6199c520a9ee20a0fa","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/.ruby-version","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.ruby-version?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/ec1cf33c3f6e22d5833bed6199c520a9ee20a0fa","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.ruby-version"}},{"name":".slugignore","path":".slugignore","sha":"264993865a3fb9d00ec603e236d987a7dc5f4f5e","size":99,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.slugignore?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.slugignore","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/264993865a3fb9d00ec603e236d987a7dc5f4f5e","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/.slugignore","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/.slugignore?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/264993865a3fb9d00ec603e236d987a7dc5f4f5e","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/.slugignore"}},{"name":"AUTHORS","path":"AUTHORS","sha":"d8c9e4faeda8cc1ce06a1ec85081fab25a3a30a9","size":46,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/AUTHORS?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/AUTHORS","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/d8c9e4faeda8cc1ce06a1ec85081fab25a3a30a9","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/AUTHORS","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/AUTHORS?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/d8c9e4faeda8cc1ce06a1ec85081fab25a3a30a9","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/AUTHORS"}},{"name":"CHANGELOG.md","path":"CHANGELOG.md","sha":"8da08ae99122a5fb007abe13cf3464fee339f81e","size":3208,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/CHANGELOG.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/CHANGELOG.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/8da08ae99122a5fb007abe13cf3464fee339f81e","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/CHANGELOG.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/CHANGELOG.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/8da08ae99122a5fb007abe13cf3464fee339f81e","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/CHANGELOG.md"}},{"name":"CODE_OF_CONDUCT.md","path":"CODE_OF_CONDUCT.md","sha":"acf18717c293e7853c0de9172113d0cd42cb0230","size":1430,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/CODE_OF_CONDUCT.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/CODE_OF_CONDUCT.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/acf18717c293e7853c0de9172113d0cd42cb0230","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/CODE_OF_CONDUCT.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/CODE_OF_CONDUCT.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/acf18717c293e7853c0de9172113d0cd42cb0230","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/CODE_OF_CONDUCT.md"}},{"name":"CONTRIBUTING.md","path":"CONTRIBUTING.md","sha":"516b61161984f324f6ab143eac27f9394c2e0801","size":42828,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/CONTRIBUTING.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/CONTRIBUTING.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/516b61161984f324f6ab143eac27f9394c2e0801","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/CONTRIBUTING.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/CONTRIBUTING.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/516b61161984f324f6ab143eac27f9394c2e0801","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/CONTRIBUTING.md"}},{"name":"CREDITS","path":"CREDITS","sha":"776e0dc54023515874a43958406e19fe04788759","size":1193,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/CREDITS?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/CREDITS","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/776e0dc54023515874a43958406e19fe04788759","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/CREDITS","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/CREDITS?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/776e0dc54023515874a43958406e19fe04788759","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/CREDITS"}},{"name":"Gemfile","path":"Gemfile","sha":"4ba34040018366e30cb00f0014fd8083ffc738f5","size":5741,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/Gemfile?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/Gemfile","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/4ba34040018366e30cb00f0014fd8083ffc738f5","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/Gemfile","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/Gemfile?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/4ba34040018366e30cb00f0014fd8083ffc738f5","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/Gemfile"}},{"name":"Gemfile.lock","path":"Gemfile.lock","sha":"b3085b631131fd5da1059b4e3e4273bc722e469d","size":13179,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/Gemfile.lock?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/Gemfile.lock","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/b3085b631131fd5da1059b4e3e4273bc722e469d","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/Gemfile.lock","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/Gemfile.lock?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/b3085b631131fd5da1059b4e3e4273bc722e469d","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/Gemfile.lock"}},{"name":"LICENSE","path":"LICENSE","sha":"0ea5d58c323ece1442f8c388a7f58a9dd17fb24c","size":1162,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/LICENSE?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/LICENSE","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/0ea5d58c323ece1442f8c388a7f58a9dd17fb24c","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/LICENSE","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/LICENSE?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/0ea5d58c323ece1442f8c388a7f58a9dd17fb24c","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/LICENSE"}},{"name":"LICENSE.spdx","path":"LICENSE.spdx","sha":"83d605963c657b9981a5342c087d6453c8818699","size":221,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/LICENSE.spdx?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/LICENSE.spdx","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/83d605963c657b9981a5342c087d6453c8818699","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/LICENSE.spdx","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/LICENSE.spdx?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/83d605963c657b9981a5342c087d6453c8818699","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/LICENSE.spdx"}},{"name":"NEWS","path":"NEWS","sha":"a158c21d9daff86f21bf089342d0d8d332a35b1c","size":18,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/NEWS?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/NEWS","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/a158c21d9daff86f21bf089342d0d8d332a35b1c","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/NEWS","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/NEWS?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/a158c21d9daff86f21bf089342d0d8d332a35b1c","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/NEWS"}},{"name":"Procfile","path":"Procfile","sha":"a56155d4717eb216377a619522bb0a85f25d4a95","size":91,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/Procfile?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/Procfile","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/a56155d4717eb216377a619522bb0a85f25d4a95","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/Procfile","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/Procfile?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/a56155d4717eb216377a619522bb0a85f25d4a95","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/Procfile"}},{"name":"README.md","path":"README.md","sha":"eceb6990bed40ff052ac08f5b3a3a959a875e5cc","size":11063,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/README.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/README.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/eceb6990bed40ff052ac08f5b3a3a959a875e5cc","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/README.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/README.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/eceb6990bed40ff052ac08f5b3a3a959a875e5cc","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/README.md"}},{"name":"Rakefile","path":"Rakefile","sha":"7e56a6a63077b78775d46d06bbba61f852ed0f81","size":282,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/Rakefile?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/Rakefile","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/7e56a6a63077b78775d46d06bbba61f852ed0f81","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/Rakefile","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/Rakefile?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/7e56a6a63077b78775d46d06bbba61f852ed0f81","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/Rakefile"}},{"name":"SECURITY.md","path":"SECURITY.md","sha":"0b3d76d69c522cd1d1334cda4ac3f3e5843d7940","size":493,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/SECURITY.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/SECURITY.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/0b3d76d69c522cd1d1334cda4ac3f3e5843d7940","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/SECURITY.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/SECURITY.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/0b3d76d69c522cd1d1334cda4ac3f3e5843d7940","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/SECURITY.md"}},{"name":"app","path":"app","sha":"7da2bc2699432b228b7be8205463de5edfbbe270","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/app?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/app","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/7da2bc2699432b228b7be8205463de5edfbbe270","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/app?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/7da2bc2699432b228b7be8205463de5edfbbe270","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/app"}},{"name":"bin","path":"bin","sha":"3f4746ab0329252966f43ac33c844469ff52e9b2","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/bin?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/bin","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/3f4746ab0329252966f43ac33c844469ff52e9b2","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/bin?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/3f4746ab0329252966f43ac33c844469ff52e9b2","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/bin"}},{"name":"codecov.yml","path":"codecov.yml","sha":"5fb056c0b2e7bde12807e87388bbaebd60e3edba","size":504,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/codecov.yml?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/codecov.yml","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/5fb056c0b2e7bde12807e87388bbaebd60e3edba","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/codecov.yml","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/codecov.yml?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/5fb056c0b2e7bde12807e87388bbaebd60e3edba","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/codecov.yml"}},{"name":"compute-criteria-stats","path":"compute-criteria-stats","sha":"635f3cc0086e2c25f821b5f2a03b3ac9154b3683","size":2161,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/compute-criteria-stats?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/compute-criteria-stats","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/635f3cc0086e2c25f821b5f2a03b3ac9154b3683","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/compute-criteria-stats","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/compute-criteria-stats?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/635f3cc0086e2c25f821b5f2a03b3ac9154b3683","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/compute-criteria-stats"}},{"name":"config.ru","path":"config.ru","sha":"61c04e13f9c4949dc8945b730f17520124e357d6","size":184,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/config.ru?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/config.ru","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/61c04e13f9c4949dc8945b730f17520124e357d6","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/config.ru","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/config.ru?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/61c04e13f9c4949dc8945b730f17520124e357d6","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/config.ru"}},{"name":"config","path":"config","sha":"4aa12013e11d84a36bb19473f887b5a5184d043c","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/config?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/config","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/4aa12013e11d84a36bb19473f887b5a5184d043c","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/config?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/4aa12013e11d84a36bb19473f887b5a5184d043c","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/config"}},{"name":"criteria","path":"criteria","sha":"91b863ad2b14b846efa579049b31305bc80eee4a","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/criteria?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/criteria","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/91b863ad2b14b846efa579049b31305bc80eee4a","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/criteria?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/91b863ad2b14b846efa579049b31305bc80eee4a","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/criteria"}},{"name":"db","path":"db","sha":"13ed3e79b750e7a7a462f7ae6b697399cf6bd293","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/db?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/db","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/13ed3e79b750e7a7a462f7ae6b697399cf6bd293","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/db?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/13ed3e79b750e7a7a462f7ae6b697399cf6bd293","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/db"}},{"name":"doc","path":"doc","sha":"bfa3954732b0f14c7cb52721c4e866a9a2b1f813","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/doc","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/bfa3954732b0f14c7cb52721c4e866a9a2b1f813","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/bfa3954732b0f14c7cb52721c4e866a9a2b1f813","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/doc"}},{"name":"dockerfiles","path":"dockerfiles","sha":"87202ce97cc3a8554bfb71c518d7783b06c14de1","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/dockerfiles?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/dockerfiles","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/87202ce97cc3a8554bfb71c518d7783b06c14de1","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/dockerfiles?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/87202ce97cc3a8554bfb71c518d7783b06c14de1","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/dockerfiles"}},{"name":"favicon","path":"favicon","sha":"9cccaf61fb64e05d26fcd180980f6c48004007cf","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/favicon?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/favicon","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/9cccaf61fb64e05d26fcd180980f6c48004007cf","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/favicon?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/9cccaf61fb64e05d26fcd180980f6c48004007cf","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/favicon"}},{"name":"gen_markdown.rb","path":"gen_markdown.rb","sha":"d3cd6ff3ffa5fcaaf8cb40bf88eec99f5cea5f60","size":2696,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/gen_markdown.rb?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/gen_markdown.rb","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/d3cd6ff3ffa5fcaaf8cb40bf88eec99f5cea5f60","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/gen_markdown.rb","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/gen_markdown.rb?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/d3cd6ff3ffa5fcaaf8cb40bf88eec99f5cea5f60","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/gen_markdown.rb"}},{"name":"ignore-termerr","path":"ignore-termerr","sha":"f373cc9d51b5c5f9d9c12051bfbbadb99767508a","size":657,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/ignore-termerr?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/ignore-termerr","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/f373cc9d51b5c5f9d9c12051bfbbadb99767508a","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/ignore-termerr","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/ignore-termerr?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/f373cc9d51b5c5f9d9c12051bfbbadb99767508a","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/ignore-termerr"}},{"name":"install-badge-dev-env","path":"install-badge-dev-env","sha":"e5e8b300751dbc8e6d80bc01b320386ca0b157de","size":13818,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/install-badge-dev-env?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/install-badge-dev-env","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/e5e8b300751dbc8e6d80bc01b320386ca0b157de","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/install-badge-dev-env","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/install-badge-dev-env?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/e5e8b300751dbc8e6d80bc01b320386ca0b157de","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/install-badge-dev-env"}},{"name":"lib","path":"lib","sha":"3d333e9c72c3dfff87b86fea35f224d34e7d923a","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/lib?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/lib","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/3d333e9c72c3dfff87b86fea35f224d34e7d923a","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/lib?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/3d333e9c72c3dfff87b86fea35f224d34e7d923a","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/lib"}},{"name":"log","path":"log","sha":"29a422c19251aeaeb907175e9b3219a9bed6c616","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/log?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/log","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/29a422c19251aeaeb907175e9b3219a9bed6c616","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/log?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/29a422c19251aeaeb907175e9b3219a9bed6c616","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/log"}},{"name":"public","path":"public","sha":"ca90088c1b8afca3a9b053f714cfd19ac07f382a","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/public?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/public","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/ca90088c1b8afca3a9b053f714cfd19ac07f382a","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/public?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/ca90088c1b8afca3a9b053f714cfd19ac07f382a","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/public"}},{"name":"raw-bad-passwords-lowercase.txt.gz","path":"raw-bad-passwords-lowercase.txt.gz","sha":"2b72149708deef8bcd4781eff345f7922dbd21a7","size":294278,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/raw-bad-passwords-lowercase.txt.gz?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/raw-bad-passwords-lowercase.txt.gz","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/2b72149708deef8bcd4781eff345f7922dbd21a7","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/raw-bad-passwords-lowercase.txt.gz","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/raw-bad-passwords-lowercase.txt.gz?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/2b72149708deef8bcd4781eff345f7922dbd21a7","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/raw-bad-passwords-lowercase.txt.gz"}},{"name":"script","path":"script","sha":"32bdf41654d3761ff202a1fd48a79ccbb78d5dc4","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/script?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/script","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/32bdf41654d3761ff202a1fd48a79ccbb78d5dc4","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/script?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/32bdf41654d3761ff202a1fd48a79ccbb78d5dc4","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/script"}},{"name":"test","path":"test","sha":"3a2d1b32f5a65ab83f95d37caca02ae0ecb14633","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/test?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/test","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/3a2d1b32f5a65ab83f95d37caca02ae0ecb14633","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/test?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/3a2d1b32f5a65ab83f95d37caca02ae0ecb14633","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/test"}},{"name":"update-ruby","path":"update-ruby","sha":"1b407cd25e05ca91f8179f1653f0c4ab39c443ae","size":1250,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/update-ruby?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/update-ruby","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/1b407cd25e05ca91f8179f1653f0c4ab39c443ae","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/update-ruby","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/update-ruby?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/1b407cd25e05ca91f8179f1653f0c4ab39c443ae","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/update-ruby"}},{"name":"vendor","path":"vendor","sha":"8084e8e04d510cc28321f30a9646477cc50c235c","size":0,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/vendor?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/vendor","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/8084e8e04d510cc28321f30a9646477cc50c235c","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/vendor?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/trees/8084e8e04d510cc28321f30a9646477cc50c235c","html":"https://github.com/coreinfrastructure/best-practices-badge/tree/master/vendor"}}]'
-    http_version: 
+    http_version:
   recorded_at: Tue, 11 Feb 2020 17:13:03 GMT
 - request:
     method: get
@@ -277,7 +277,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc","documentation_url":"https://developer.github.com/v3/#http-redirects"}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 11 Feb 2020 17:13:03 GMT
 - request:
     method: get
@@ -351,7 +351,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '[{"name":"INSTALL.md","path":"doc/INSTALL.md","sha":"42538ae55e05882d382bc4d8a7a09ed854cb233c","size":14555,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/INSTALL.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/INSTALL.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/42538ae55e05882d382bc4d8a7a09ed854cb233c","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/INSTALL.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/INSTALL.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/42538ae55e05882d382bc4d8a7a09ed854cb233c","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/INSTALL.md"}},{"name":"Makefile","path":"doc/Makefile","sha":"647e7e8a410ac61ae3b6216aa28416a07dd5a3fd","size":630,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/Makefile?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/Makefile","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/647e7e8a410ac61ae3b6216aa28416a07dd5a3fd","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/Makefile","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/Makefile?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/647e7e8a410ac61ae3b6216aa28416a07dd5a3fd","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/Makefile"}},{"name":"api.md","path":"doc/api.md","sha":"5f130db7cb43f8af3a814efd327d1b405719aeb7","size":17651,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/api.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/api.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/5f130db7cb43f8af3a814efd327d1b405719aeb7","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/api.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/api.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/5f130db7cb43f8af3a814efd327d1b405719aeb7","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/api.md"}},{"name":"assurance-case-implementation.odg","path":"doc/assurance-case-implementation.odg","sha":"041b8454275ae7a715ce9676ec52ab7192868353","size":27189,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case-implementation.odg?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case-implementation.odg","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/041b8454275ae7a715ce9676ec52ab7192868353","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/assurance-case-implementation.odg","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case-implementation.odg?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/041b8454275ae7a715ce9676ec52ab7192868353","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case-implementation.odg"}},{"name":"assurance-case-implementation.png","path":"doc/assurance-case-implementation.png","sha":"f5d594a72663db4c9662dc30ec9aabf8889dba5a","size":389042,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case-implementation.png?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case-implementation.png","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/f5d594a72663db4c9662dc30ec9aabf8889dba5a","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/assurance-case-implementation.png","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case-implementation.png?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/f5d594a72663db4c9662dc30ec9aabf8889dba5a","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case-implementation.png"}},{"name":"assurance-case-lifecycle.odg","path":"doc/assurance-case-lifecycle.odg","sha":"672082a44357553ede9e35956130a6e159e3cd12","size":26747,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case-lifecycle.odg?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case-lifecycle.odg","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/672082a44357553ede9e35956130a6e159e3cd12","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/assurance-case-lifecycle.odg","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case-lifecycle.odg?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/672082a44357553ede9e35956130a6e159e3cd12","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case-lifecycle.odg"}},{"name":"assurance-case-lifecycle.png","path":"doc/assurance-case-lifecycle.png","sha":"8512a9e27fa5de3a0b713cf7bc30fdf6aa55f154","size":383840,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case-lifecycle.png?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case-lifecycle.png","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/8512a9e27fa5de3a0b713cf7bc30fdf6aa55f154","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/assurance-case-lifecycle.png","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case-lifecycle.png?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/8512a9e27fa5de3a0b713cf7bc30fdf6aa55f154","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case-lifecycle.png"}},{"name":"assurance-case-other-lifecycle.odg","path":"doc/assurance-case-other-lifecycle.odg","sha":"b0a56dc2c22890e82e41a3c0252a7cbcf0f91a73","size":16673,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case-other-lifecycle.odg?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case-other-lifecycle.odg","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/b0a56dc2c22890e82e41a3c0252a7cbcf0f91a73","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/assurance-case-other-lifecycle.odg","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case-other-lifecycle.odg?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/b0a56dc2c22890e82e41a3c0252a7cbcf0f91a73","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case-other-lifecycle.odg"}},{"name":"assurance-case-other-lifecycle.png","path":"doc/assurance-case-other-lifecycle.png","sha":"df34bb2d7954af53e1fb6f8567a02988813ccdc3","size":160662,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case-other-lifecycle.png?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case-other-lifecycle.png","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/df34bb2d7954af53e1fb6f8567a02988813ccdc3","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/assurance-case-other-lifecycle.png","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case-other-lifecycle.png?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/df34bb2d7954af53e1fb6f8567a02988813ccdc3","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case-other-lifecycle.png"}},{"name":"assurance-case.odg","path":"doc/assurance-case.odg","sha":"3bfa62fdb0ac0a077e3449fc65efd1d3da40462e","size":22509,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case.odg?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case.odg","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/3bfa62fdb0ac0a077e3449fc65efd1d3da40462e","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/assurance-case.odg","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case.odg?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/3bfa62fdb0ac0a077e3449fc65efd1d3da40462e","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case.odg"}},{"name":"assurance-case.png","path":"doc/assurance-case.png","sha":"7dcd4f050875c5f4a3c0effe523a2798ca11b071","size":290962,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case.png?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case.png","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/7dcd4f050875c5f4a3c0effe523a2798ca11b071","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/assurance-case.png","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/assurance-case.png?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/7dcd4f050875c5f4a3c0effe523a2798ca11b071","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/assurance-case.png"}},{"name":"background.md","path":"doc/background.md","sha":"3242f8ead38193af8cabe59be662bf6f87211531","size":80222,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/background.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/background.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/3242f8ead38193af8cabe59be662bf6f87211531","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/background.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/background.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/3242f8ead38193af8cabe59be662bf6f87211531","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/background.md"}},{"name":"best-practices.py","path":"doc/best-practices.py","sha":"f62d63fb1adfc8a35b2a9d6fe8ccbe831588dac0","size":2507,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/best-practices.py?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/best-practices.py","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/f62d63fb1adfc8a35b2a9d6fe8ccbe831588dac0","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/best-practices.py","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/best-practices.py?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/f62d63fb1adfc8a35b2a9d6fe8ccbe831588dac0","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/best-practices.py"}},{"name":"compute-criteria-2017-02-06.txt","path":"doc/compute-criteria-2017-02-06.txt","sha":"ff4282a7bbc13db1238e69aa3624e609df6568fe","size":6019,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/compute-criteria-2017-02-06.txt?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/compute-criteria-2017-02-06.txt","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/ff4282a7bbc13db1238e69aa3624e609df6568fe","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/compute-criteria-2017-02-06.txt","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/compute-criteria-2017-02-06.txt?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/ff4282a7bbc13db1238e69aa3624e609df6568fe","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/compute-criteria-2017-02-06.txt"}},{"name":"compute-criteria-2017-09-06.txt","path":"doc/compute-criteria-2017-09-06.txt","sha":"b6fdacb59376d6ed9ae35ca04d8473bfd1b15c05","size":6000,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/compute-criteria-2017-09-06.txt?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/compute-criteria-2017-09-06.txt","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/b6fdacb59376d6ed9ae35ca04d8473bfd1b15c05","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/compute-criteria-2017-09-06.txt","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/compute-criteria-2017-09-06.txt?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/b6fdacb59376d6ed9ae35ca04d8473bfd1b15c05","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/compute-criteria-2017-09-06.txt"}},{"name":"compute-criteria-2019-03-07.txt","path":"doc/compute-criteria-2019-03-07.txt","sha":"1e669725d270738d2d1973605f8bf4f87281e4ef","size":6106,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/compute-criteria-2019-03-07.txt?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/compute-criteria-2019-03-07.txt","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/1e669725d270738d2d1973605f8bf4f87281e4ef","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/compute-criteria-2019-03-07.txt","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/compute-criteria-2019-03-07.txt?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/1e669725d270738d2d1973605f8bf4f87281e4ef","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/compute-criteria-2019-03-07.txt"}},{"name":"criteria-footer.markdown","path":"doc/criteria-footer.markdown","sha":"aabd77fb1a03c8a9fcb3b21d6d3a7bfe1cfa4491","size":6313,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/criteria-footer.markdown?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/criteria-footer.markdown","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/aabd77fb1a03c8a9fcb3b21d6d3a7bfe1cfa4491","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/criteria-footer.markdown","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/criteria-footer.markdown?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/aabd77fb1a03c8a9fcb3b21d6d3a7bfe1cfa4491","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/criteria-footer.markdown"}},{"name":"criteria-header.markdown","path":"doc/criteria-header.markdown","sha":"8d495744ed5a77943bfa92922b82f88289610970","size":8398,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/criteria-header.markdown?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/criteria-header.markdown","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/8d495744ed5a77943bfa92922b82f88289610970","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/criteria-header.markdown","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/criteria-header.markdown?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/8d495744ed5a77943bfa92922b82f88289610970","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/criteria-header.markdown"}},{"name":"criteria.md","path":"doc/criteria.md","sha":"0fb27eb80e45d8dbd8346a869abbf70dee41e6c0","size":73400,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/criteria.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/criteria.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/0fb27eb80e45d8dbd8346a869abbf70dee41e6c0","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/criteria.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/criteria.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/0fb27eb80e45d8dbd8346a869abbf70dee41e6c0","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/criteria.md"}},{"name":"dawnscanner.md","path":"doc/dawnscanner.md","sha":"f28f2e3b40496794d275dafad455ec2eaa3f4598","size":4509,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/dawnscanner.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/dawnscanner.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/f28f2e3b40496794d275dafad455ec2eaa3f4598","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/dawnscanner.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/dawnscanner.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/f28f2e3b40496794d275dafad455ec2eaa3f4598","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/dawnscanner.md"}},{"name":"dco.txt","path":"doc/dco.txt","sha":"716561d5d28268525c9f1837572e79a44577ff92","size":1422,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/dco.txt?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/dco.txt","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/716561d5d28268525c9f1837572e79a44577ff92","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/dco.txt","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/dco.txt?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/716561d5d28268525c9f1837572e79a44577ff92","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/dco.txt"}},{"name":"dependency_decisions.yml","path":"doc/dependency_decisions.yml","sha":"7400e560252395d58bcad729eeb7ce46ef62e835","size":15834,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/dependency_decisions.yml?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/dependency_decisions.yml","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/7400e560252395d58bcad729eeb7ce46ef62e835","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/dependency_decisions.yml","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/dependency_decisions.yml?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/7400e560252395d58bcad729eeb7ce46ef62e835","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/dependency_decisions.yml"}},{"name":"design.md","path":"doc/design.md","sha":"4a94140632935dfaeabc3e1028e27711f616dd53","size":22212,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/design.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/design.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/4a94140632935dfaeabc3e1028e27711f616dd53","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/design.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/design.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/4a94140632935dfaeabc3e1028e27711f616dd53","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/design.md"}},{"name":"design.odg","path":"doc/design.odg","sha":"d6511274422a27a6b94a1b716f0e78651b30f208","size":63614,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/design.odg?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/design.odg","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/d6511274422a27a6b94a1b716f0e78651b30f208","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/design.odg","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/design.odg?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/d6511274422a27a6b94a1b716f0e78651b30f208","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/design.odg"}},{"name":"design.png","path":"doc/design.png","sha":"da6eaefb9825420e975eca02b630ac57794611e0","size":450271,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/design.png?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/design.png","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/da6eaefb9825420e975eca02b630ac57794611e0","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/design.png","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/design.png?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/da6eaefb9825420e975eca02b630ac57794611e0","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/design.png"}},{"name":"governance.md","path":"doc/governance.md","sha":"b39aa01dc93e9cabc04dde93c8b5b68b1d75e5b6","size":4766,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/governance.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/governance.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/b39aa01dc93e9cabc04dde93c8b5b68b1d75e5b6","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/governance.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/governance.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/b39aa01dc93e9cabc04dde93c8b5b68b1d75e5b6","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/governance.md"}},{"name":"implementation.md","path":"doc/implementation.md","sha":"034b47ce9b8c30ef05ec606ecb9c2ba30a334939","size":50782,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/implementation.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/implementation.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/034b47ce9b8c30ef05ec606ecb9c2ba30a334939","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/implementation.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/implementation.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/034b47ce9b8c30ef05ec606ecb9c2ba30a334939","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/implementation.md"}},{"name":"markdown-urls","path":"doc/markdown-urls","sha":"6d3f2cf9a65b7deba224a8b723049d0b9090d357","size":32,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/markdown-urls?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/markdown-urls","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/6d3f2cf9a65b7deba224a8b723049d0b9090d357","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/markdown-urls","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/markdown-urls?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/6d3f2cf9a65b7deba224a8b723049d0b9090d357","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/markdown-urls"}},{"name":"nyc-2016.md","path":"doc/nyc-2016.md","sha":"a82ca7d420932fae89e2a075e1e1804cf5d6639c","size":11027,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/nyc-2016.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/nyc-2016.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/a82ca7d420932fae89e2a075e1e1804cf5d6639c","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/nyc-2016.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/nyc-2016.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/a82ca7d420932fae89e2a075e1e1804cf5d6639c","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/nyc-2016.md"}},{"name":"other.md","path":"doc/other.md","sha":"3dce61d2e32ac826bfa3850befe179a634b57c76","size":82640,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/other.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/other.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/3dce61d2e32ac826bfa3850befe179a634b57c76","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/other.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/other.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/3dce61d2e32ac826bfa3850befe179a634b57c76","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/other.md"}},{"name":"requirements.md","path":"doc/requirements.md","sha":"2a5bc7b709f27385f393fc13e241054ff0d667c6","size":7264,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/requirements.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/requirements.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/2a5bc7b709f27385f393fc13e241054ff0d667c6","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/requirements.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/requirements.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/2a5bc7b709f27385f393fc13e241054ff0d667c6","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/requirements.md"}},{"name":"roadmap.md","path":"doc/roadmap.md","sha":"2864dd180c25058c625056b10bb22c5feebc09db","size":2540,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/roadmap.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/roadmap.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/2864dd180c25058c625056b10bb22c5feebc09db","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/roadmap.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/roadmap.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/2864dd180c25058c625056b10bb22c5feebc09db","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/roadmap.md"}},{"name":"security.md","path":"doc/security.md","sha":"8a2ec82bb7d806981c6d706663dd1dbccfa1c742","size":155124,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/security.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/security.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/8a2ec82bb7d806981c6d706663dd1dbccfa1c742","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/security.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/security.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/8a2ec82bb7d806981c6d706663dd1dbccfa1c742","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/security.md"}},{"name":"self.json","path":"doc/self.json","sha":"460fe4be877a91000ec51c111becf1a76edb44f5","size":12616,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/self.json?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/self.json","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/460fe4be877a91000ec51c111becf1a76edb44f5","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/self.json","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/self.json?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/460fe4be877a91000ec51c111becf1a76edb44f5","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/self.json"}},{"name":"test-coverage-criteria.md","path":"doc/test-coverage-criteria.md","sha":"8076c92516bd519c2b84aa437e9ba81776dfd598","size":10070,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/test-coverage-criteria.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/test-coverage-criteria.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/8076c92516bd519c2b84aa437e9ba81776dfd598","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/test-coverage-criteria.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/test-coverage-criteria.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/8076c92516bd519c2b84aa437e9ba81776dfd598","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/test-coverage-criteria.md"}},{"name":"test-markdown.md","path":"doc/test-markdown.md","sha":"b0ed077b635a743b45f30f3c5ca7e9a3b2d48837","size":473,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/test-markdown.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/test-markdown.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/b0ed077b635a743b45f30f3c5ca7e9a3b2d48837","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/test-markdown.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/test-markdown.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/b0ed077b635a743b45f30f3c5ca7e9a3b2d48837","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/test-markdown.md"}},{"name":"testing.md","path":"doc/testing.md","sha":"ed1b2e89d5384e6008927f9a9d5265fb0722baaf","size":9246,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/testing.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/testing.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/ed1b2e89d5384e6008927f9a9d5265fb0722baaf","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/testing.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/testing.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/ed1b2e89d5384e6008927f9a9d5265fb0722baaf","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/testing.md"}},{"name":"vetting.md","path":"doc/vetting.md","sha":"6b9cacd46ccbad365e9c6ebcfcbdf6b2d65e0253","size":7400,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/vetting.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/vetting.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/6b9cacd46ccbad365e9c6ebcfcbdf6b2d65e0253","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/vetting.md","type":"file","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/vetting.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/6b9cacd46ccbad365e9c6ebcfcbdf6b2d65e0253","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/vetting.md"}}]'
-    http_version: 
+    http_version:
   recorded_at: Tue, 11 Feb 2020 17:13:03 GMT
 - request:
     method: get
@@ -420,7 +420,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/INSTALL.md","documentation_url":"https://developer.github.com/v3/#http-redirects"}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 11 Feb 2020 17:13:03 GMT
 - request:
     method: get
@@ -494,6 +494,5667 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"name":"INSTALL.md","path":"doc/INSTALL.md","sha":"42538ae55e05882d382bc4d8a7a09ed854cb233c","size":14555,"url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/INSTALL.md?ref=master","html_url":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/INSTALL.md","git_url":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/42538ae55e05882d382bc4d8a7a09ed854cb233c","download_url":"https://raw.githubusercontent.com/coreinfrastructure/best-practices-badge/master/doc/INSTALL.md","type":"file","content":"IyBJbnN0YWxsYXRpb24gYW5kIHF1aWNrIHN0YXJ0IGluc3RydWN0aW9ucwoK\nPCEtLSBTUERYLUxpY2Vuc2UtSWRlbnRpZmllcjogKE1JVCBPUiBDQy1CWS0z\nLjArKSAtLT4KCkhlcmUgaXMgaG93IHRvIGluc3RhbGwgdGhlICJCYWRnZUFw\ncCIgd2ViIGFwcGxpY2F0aW9uLCBmb3IgZWl0aGVyIGEgZGV2ZWxvcG1lbnQK\nZW52aXJvbm1lbnQgb3IgZm9yIGRlcGxveW1lbnQuCk9uIG1vc3Qgc3lzdGVt\ncyB0aGlzIGlzIGEgZmFpcmx5IHF1aWNrIGFuZCBwYWlubGVzcyBwcm9jZXNz\nLgpXZSBhbHNvIHByb3ZpZGUgaW5mb3JtYXRpb24gb24gaG93IHRvIHF1aWNr\nbHkgZ2V0IHN0YXJ0ZWQgc28geW91CmNhbiAqZG8qIHNvbWV0aGluZy4KCldl\nIHByb3ZpZGUgYSBzaW1wbGUgc2NyaXB0IHRoYXQgZG9lcyB0aGUgd29yaywg\nYW5kIHdlIGVtcGhhc2l6ZSB1c2luZwp3aWRlbHktdXNlZCB0b29scyBkZXNp\nZ25lZCBmb3IgdGhlIHB1cnBvc2UuCk91ciBpbnN0YWxsYXRpb24gYXBwcm9h\nY2ggaW5zdGFsbHMgYSBzcGVjaWZpYyB2ZXJzaW9uIG9mIFJ1YnkgYW5kIHNw\nZWNpZmljCnZlcnNpb25zIG9mIHRoZSBSdWJ5IGdlbXMgdGhhdCBCYWRnZUFw\ncCB1c2VzIChpbmNsdWRpbmcgdGhlIG9uZXMgaW4gUmFpbHMpLgpUaGUgd2Vi\nIGFwcGxpY2F0aW9uIGlzIGltcGxlbWVudGVkIHdpdGggUnVieSBvbiBSYWls\ncy4KSW4gZGV2ZWxvcG1lbnQgd2Ugc3RvcmUgZGF0YSBpbiBTUUxpdGU7CnRo\nZSBwcm9kdWN0aW9uIHN5c3RlbSBzdG9yZXMgdGhlIGRhdGEgaW4gUG9zdGdy\nZXMuCgojIyBEZXZlbG9wbWVudCBlbnZpcm9ubWVudCBwcmVyZXF1aXNpdGVz\nCgpZb3UgbmVlZCBhIHdvcmtpbmcgSW50ZXJuZXQgY29ubmVjdGlvbiB0byBk\nb3dubG9hZCBldmVyeXRoaW5nIHRvIGluc3RhbGwuCgpZb3UgbmVlZCBhIFVu\naXgtbGlrZSBzeXN0ZW0uClRoaXMgaW5jbHVkZXMgYSBnZW5lcmFsLXB1cnBv\nc2UgTGludXggZGlzdHJpYnV0aW9uCihlLmcuLCBVYnVudHUsIEZlZG9yYSwg\nRGViaWFuLCBSZWQgSGF0IEVudGVycHJpc2UgTGludXgsIG9yIFN1U0UpIG9y\nIE1hY09TLgpJZiB5b3UncmUgdXNpbmcgV2luZG93cywgaW5zdGFsbCB2aXJ0\ndWFsIG1hY2hpbmUgc29mdHdhcmUgKHN1Y2ggYXMgVmlydHVhbEJveCkKYW5k\nIGluc3RhbGwgTGludXggb24gYSB2aXJ0dWFsIG1hY2hpbmUuCldlIGRvIG5v\ndCBleHBlY3QgV2luZG93cyB0byB3b3JrIGRpcmVjdGx5LgoKTWFrZSBzdXJl\nIHlvdXIgc3lzdGVtIGhhcyB1cC10by1kYXRlIHBhY2thZ2VzLgpGb3IgZXhh\nbXBsZSwgb24gVWJ1bnR1IGFuZCBEZWJpYW4sIHJ1biB0aGlzOgoKfn5+fgpz\ndWRvIGFwdC1nZXQgdXBkYXRlICYmIHN1ZG8gYXB0LWdldCB1cGdyYWRlCn5+\nfn4KCklmIHlvdSB1c2UgYSB2aXJ0dWFsIG1hY2hpbmUgZm9yIGRldmVsb3Bt\nZW50LCBtYXhpbWl6ZSBpdHMgbWVtb3J5LgpJdCB3aWxsIHJ1biBpbiBsZXNz\nIG1lbW9yeSwgYW5kIGluIHBhcnRpY3VsYXIgdGhlIHByb2R1Y3Rpb24gdmVy\nc2lvbiB1c2VzIGxlc3MuCkhvd2V2ZXIsIHdlIGVuYWJsZSBtYW55IG1vbml0\nb3JpbmcgdG9vbHMgZHVyaW5nIGRldmVsb3BtZW50IGFuZCB0aGV5IGNvbnN1\nbWUgYQpsb3Qgb2YgbWVtb3J5LgoKU29tZSBvcmdhbml6YXRpb25zIHVzZSBh\nbiBTU0wvVExTIGludGVyY2VwdGlvbiBwcm94eSwgd2hpY2ggaW50ZXJjZXB0\ncyBhbGwKU1NML1RMUyB0cmFmZmljLgpJZiB5b3UgbXVzdCB3b3JrIHdpdGgg\ndGhvc2UsIGFuZCB5b3UgYXJlIHdpbGxpbmcgdG8gY29tcGxldGVseSB0cnVz\ndCB0aGF0IHByb3h5LAp0aGVuIHlvdSBuZWVkIHRvIGRvd25sb2FkIGFuZCBp\nbnN0YWxsIHRoYXQgcHJveHkncyBjZXJ0aWZpY2F0ZXMuCkUuRy4sIHRvIGlu\nc3RhbGwgdGhlbSBvbiBVYnVudHUsIHdoZW4geW91ciBjdXJyZW50IGRpcmVj\ndG9ydHkgaGFzIHRoZQpjZXJ0aWZpY2F0ZXMgYXMgLmNydCBmaWxlcywgcnVu\nIHRoaXM6Cgp+fn5+c2gKIyBPTkxZIGRvIHRoaXMgaWYgeW91IGhhdmUgYW4g\nU1NML1RMUyBpbnRlcmNlcHRpb24gcHJveHkgYW5kIGFyZSB1c2luZyBVYnVu\ndHUKc3VkbyBiYXNoCmNhPS91c3Ivc2hhcmUvY2EtY2VydGlmaWNhdGVzCnRp\ncD10bHMtaW50ZXJjZXB0aW9uLXByb3h5Cm1rZGlyIC1wICRjYS8kdGlwCmNw\nICouY3J0ICRjYS8kdGlwCmNkICRjYQpscyAkdGlwLyogPj4gL2V0Yy9jYS1j\nZXJ0aWZpY2F0ZXMuY29uZgp1cGRhdGUtY2EtY2VydGlmaWNhdGVzCmV4aXQg\nIyBFbmQgInN1ZG8gYmFzaCIKfn5+fgoKSWYgeW91J3JlIHVzaW5nIE1hY09T\nLCB5b3UgbmVlZCB0byBpbnN0YWxsIEhvbWVicmV3CihpdCBwcm92aWRlcyB0\naGUgcGFja2FnZSBtYW5hZ2VyIGNvbW1hbmQgPHR0PmJyZXc8L3R0PikuClNl\nZSA8aHR0cDovL2JyZXcuc2gvPiBmb3IgaW5zdGFsbGF0aW9uIGluc3RydWN0\naW9ucy4gQXMgcmVwb3J0ZWQgYnkKPHR0PmJyZXcgZG9jdG9yPC90dD4sIHlv\ndSBzaG91bGQgYWxzbyBkbyB0aGUgZm9sbG93aW5nCihpZiBpdCBpc24ndCBh\nbHJlYWR5IHRoZXJlKSBzbyB0aGF0IHVwZGF0ZWQgcHJvZ3JhbXMgZnJvbSBi\ncmV3IHRha2UgcHJlY2VkZW5jZToKCn5+fn5zaAplY2hvICJleHBvcnQgUEFU\nSD0vdXNyL2xvY2FsL2JpbjokUEFUSCIgPj4gfi8uYmFzaF9wcm9maWxlICAj\nIE1hY09TIGJyZXcKfn5+fgoKWW91IGFsc28gbmVlZCBhIHZlcnNpb24gb2Yg\nZ2l0IGluc3RhbGxlZC4KSWYgeW91IGRvbid0IGFscmVhZHkgaGF2ZSBpdCBz\nZXQgdXAsIGluc3RhbGwgaXQgdXNpbmcgeW91ciBzeXN0ZW0gaW5zdGFsbGF0\naW9uCnRvb2xzLCBlLmcuLCBhdCB0aGUgY29tbWFuZCBsaW5lOgoKKiA8a2Jk\nPnN1ZG8gYXB0LWdldCBpbnN0YWxsIGdpdDwva2JkPiAoRGViaWFuLCBVYnVu\ndHUpCiogPGtiZD55dW0gaW5zdGFsbCBnaXQ8L2tiZD4gKFJlZCBIYXQgRW50\nZXJwcmlzZSBMaW51eCwgQ2VudE9TLCBvbGRlciBGZWRvcmEpCiogPGtiZD5k\nbmYgaW5zdGFsbCBnaXQ8L2tiZD4gKG5ld2VyIEZlZG9yYSkKKiA8a2JkPmVt\nZXJnZSBpbnN0YWxsIGdpdDwva2JkPiAoR2VudG9vKQoqIDxrYmQ+YnJldyBp\nbnN0YWxsIGdpdDwva2JkPiAoTWFjT1MpCgpBbHNvLCBpbnN0YWxsIENocm9t\nZS4KSXQncyBub3QgbmVlZGVkIHRvICpydW4qIHRoZSBzb2Z0d2FyZSwgYnV0\nIGl0J3MgdXNlZCBmb3IgdmFyaW91cyBoZWFkbGVzcyB0ZXN0cwpzbyB5b3Ug\nbmVlZCBpdCB0byBydW4gc29tZSBhdXRvbWF0ZWQgdGVzdHMuClRoZSBlYXN5\nIHdheSB0byBkbyB0aGlzIGlzIHRvIGRvd25sb2FkIGl0IGZyb20KPGh0dHBz\nOi8vd3d3Lmdvb2dsZS5jb20vY2hyb21lPi4KSWYgeW91IGRvbid0IGluc3Rh\nbGwgQ2hyb21lLCBhbmQgeW91IHRyeSB0byBydW4gdGhlIHRlc3RzLCB0aGUg\ndGVzdCBzdWl0ZQp3aWxsIGludGVybmFsbHkgdHJ5IHRvIHJ1biBgcmFrZSB1\ncGRhdGVfY2hyb21lZHJpdmVyYCBhbmQgeW91IHdpbGwKc2VlIG9kZCBlcnJv\nciBtZXNzYWdlcyBzdWNoIGFzIGBBcmd1bWVudEVycm9yOiB3cm9uZyBmaXJz\ndCBhcmd1bWVudGAsCmFuIGVycm9yIGluIGBsaWIvdGFza3MvZGVmYXVsdC5y\nYWtlYCwgZXJyb3JzIGZyb20gYnVuZGxlLCBhbmQgYSByZXBvcnQKdGhhdCB0\naGUgZXJyb3IgaXMgZnJvbSBgVGFza3M6IFRPUCA9PiBkZWZhdWx0ID0+IHVw\nZGF0ZV9jaHJvbWVkcml2ZXJgLgoKIyMgRm9ya2luZyB0aGUgcmVwbwoKWW91\nJ2xsIG5vdyBuZWVkIHRvIGZvcmsgdGhlIHJlcG8gb24gR2l0SHViLgpbR2l0\nSHViJ3MgaW5zdHJ1Y3Rpb25zIG9uIGZvcmtpbmcgYSByZXBvXShodHRwczov\nL2hlbHAuZ2l0aHViLmNvbS9hcnRpY2xlcy9mb3JrLWEtcmVwby8pCmRlc2Ny\naWJlIHRoaXMgaW4gZ2VuZXJhbC4KCkluIG91ciBjYXNlLCB1c2UgeW91ciB3\nZWIgYnJvd3NlciB0byB2aWV3CjxodHRwczovL2dpdGh1Yi5jb20vY29yZWlu\nZnJhc3RydWN0dXJlL2Jlc3QtcHJhY3RpY2VzLWJhZGdlPiwKbG9nIGluIHRv\nIHlvdXIgYWNjb3VudCAob3IgY3JlYXRlIG9uZSksIGFuZCBjbGljayBvbiB0\naGUgIkZvcmsiIGJ1dHRvbiBvbiB0aGUKdG9wIHJpZ2h0LiAgT24gSW4gdGhl\nIHJpZ2h0IHNpZGViYXIgb2YgeW91ciBuZXcgZm9yaydzIHJlcG9zaXRvcnkg\ncGFnZSwKY2xpY2sgb24gdGhlICJ0byBjbGlwYm9hcmQiIHN5bWJvbCB0byBj\nb3B5IHRoZSBjbG9uZSBVUkwgZm9yIHlvdXIgZm9yay4KCk5vdyBnbyBiYWNr\nIHRvIHlvdXIgc3lzdGVtLCB0eXBlIDx0dD5naXQgY2xvbmU8L3R0PiwgYSBz\ncGFjZSwgcGFzdGUgdGhlIGNsb25lClVSTCBmb3IgeW91ciBmb3JrLCBhbmQg\ncHJlc3MgPGtiZD5FbnRlcjwva2JkPiB0byBkb3dubG9hZCB0aGUgZm9yay4K\nT25jZSBpdCdzIGRvbmUsIGNoYW5nZSBpbnRvIHRoZSBuZXdseS1jcmVhdGVk\nIGRpcmVjdG9yeToKCn5+fn5zaApjZCBjaWktYmVzdC1wcmFjdGljZXMtYmFk\nZ2UKfn5+fgoKIyMgSW5zdGFsbGluZyB0aGUgZGV2ZWxvcG1lbnQgZW52aXJv\nbm1lbnQKCldlIHByb3ZpZGUgYSBzaW1wbGUgc2hlbGwgc2NyaXB0IHRoYXQg\nc2hvdWxkIGluc3RhbGwgYWxsIHRoZSBuZWNlc3NhcnkKdG9vbHMgYW5kIGxp\nYnJhcmllcy4KU28gYXQgdGhlIGNvbW1hbmQgbGluZSBqdXN0IHJ1bjoKCn5+\nfn5zaAouL2luc3RhbGwtYmFkZ2UtZGV2LWVudgp+fn5+CgpUaGlzIHdpbGwg\nYXV0b21hdGljYWxseSBjcmVhdGUgYSBkYXRhYmFzZSBhbmQgc2VlZCBpdCB3\naXRoIGR1bW15IGRhdGEKKGJ5IHJ1bm5pbmcgInJha2UgZGI6c2V0dXAiKS4K\nCklmIHRoYXQgZmFpbHMsIHNlZSB0aGUgc2VjdGlvbiBsYXRlciBvbiAiV2hh\ndCBkb2VzIGluc3RhbGwtYmFkZ2UtZGV2LWVudiBkbz8iCnRvIG1hbnVhbGx5\nIGRvIHdoYXQgaXQncyB0cnlpbmcgdG8gZG8uCklmIGl0IGRvZXNuJ3Qgd29y\naywgcGF0Y2hlcyB3ZWxjb21lLgoKIyMgVGVsbGluZyBnaXQgd2hvIHlvdSBh\ncmUKClRoZSBpbnN0YWxsYXRpb24gd2lsbCBhc2sgeW91IGZvciB5b3VyIGZ1\nbGwgbmFtZSBhbmQgZW1haWwgYWRkcmVzcwppZiBnaXQgZG9lcyBub3QgYWxy\nZWFkeSBoYXZlIHRoZW0gc2V0LgpUaGlzIGlzIHVzZWQgdG8KW3NldCB1cCBH\naXRdKGh0dHBzOi8vaGVscC5naXRodWIuY29tL2FydGljbGVzL3NldC11cC1n\naXQvKQpzbyBpdCB3aWxsIGNvcnJlY3RseSByZWNvcmQgd2hvIHlvdSBhcmUu\nClBsZWFzZSB1c2UgeW91ciBvd24gbmFtZSBhbmQgZW1haWwgYWRkcmVzcy4K\nCllvdSBjYW4gY2hhbmdlIHRoZXNlIGxhdGVyIHVzaW5nOgoKfn5+fnNoCmdp\ndCBjb25maWcgLS1nbG9iYWwgdXNlci5uYW1lICJZT1VSIE5BTUUiCmdpdCBj\nb25maWcgLS1nbG9iYWwgdXNlci5lbWFpbCAiWU9VUiBFTUFJTCBBRERSRVNT\nIgp+fn5+CgojIyBTdGFydGluZyB0aGUgc2VydmVyIGxvY2FsbHkKCk9uY2Ug\neW91ciBkZXZlbG9wbWVudCBlbnZpcm9ubWVudCBpcyByZWFkeSwgeW91IGNh\nbiBydW4gdGhlIGFwcGxpY2F0aW9uIHdpdGg6Cgp+fn5+CnJhaWxzIHMKfn5+\nfgoKVGhpcyB3aWxsIGF1dG9tYXRpY2FsbHkgc2V0IHVwIHdoYXQgaXQgbmVl\nZHMgdG8sIGFuZCB0aGVuIHJ1biB0aGUKd2ViIGFwcGxpY2F0aW9uLiAgWW91\nIGNhbiBwcmVzcyBjb250cm9sLUMgYXQgYW55IHRpbWUgdG8gc3RvcCBpdC4K\nCiMjIEFjY2Vzc2luZyB0aGUgbG9jYWwgc2VydmVyCgpOb3cgc3RhcnQgdXAg\neW91ciBsb2NhbCB3ZWIgYnJvd3NlciBhbmQgaGF2ZSBpdCBvcGVuICJodHRw\nOi8vbG9jYWxob3N0OjMwMDAiLgpPbiBMaW51eC1saWtlIHN5c3RlbXMsIHlv\ndSBjYW4gZG8gdGhpcyBieSBydW5uaW5nIHRoaXMgb24gYSBjb21tYW5kIGxp\nbmU6Cgp+fn5+CnhkZy1vcGVuIGh0dHA6Ly9sb2NhbGhvc3Q6MzAwMAp+fn5+\nCgpXaXRoaW4gdGhlIHdlYiBicm93c2VyIHlvdSBjYW4gY2xpY2sgb24gInNp\nZ24gaW4iIHRvIGNyZWF0ZSBhIG5ldyBhY291bnQsCmFuZCAibG9nIGluIiBs\nYXRlciBhZnRlciB5b3UndmUgY3JlYXRlZCBhbiBhY2NvdW50LgpZb3UgY2Fu\nIGFsc28gY3JlYXRlIHlvdXIgb3duIHByb2plY3RzLgoKIyMgR2l2aW5nIHlv\ndXJzZWxmIGFkbWluIHByaXZpbGVnZXMKCklmIHlvdSdyZSBtYWludGFpbmlu\nZyBpdCBsb2NhbGx5LCB5b3UgbWlnaHQgd2FudCB0byBnaXZlIHlvdXIgYWNj\nb3VudAphZG1pbiBwcml2aWxlZ2VzLiAgRmlyc3QsIG5vdGUgdGhlIHVzZXIg\naWQgb2YgeW91ciBhY2NvdW50CihpdCdzIHRoZSBudW1iZXIgYWZ0ZXIgIi91\nc2Vycy8iIGluIHRoZSBVUkwgd2hlbiB5b3UgZGlzcGxheSB5b3VyIG93biBw\ncm9maWxlKS4KWW91IGNhbiBkbyB0aGlzIGJ5IHJ1bm5pbmcgdGhpcyAocmVw\nbGFjaW5nIFlPVVJfVVNFUl9JRCB3aXRoIHRoZSBudW1iZXIpOgoKfn5+fgpy\nYWlscyBkYgpVUERBVEUgdXNlcnMgU0VUIHJvbGUgPSAnYWRtaW4nIHdoZXJl\nIGlkID0gWU9VUl9VU0VSX0lEIDsKfn5+fgoKUHJlc3MgY29udHJvbC1EIHRv\nIGV4aXQgInJhaWxzIGRiIi4KCiMjIEV4cGxvcmluZwoKVXNlcnMgbm9ybWFs\nbHkgaW50ZXJhY3Qgd2l0aCB0aGUgd2ViIGludGVyZmFjZS4KSW4gc29tZSBj\nYXNlcyB5b3UgbWF5IGZpbmQgaXQgaGVscGZ1bCB0bwppbnRlcmFjdCBkaXJl\nY3RseSB3aXRoIHRoZSBzb2Z0d2FyZSBhbmQgZXhhbWluZSBpdHMgc3RhdGUu\nClRoZXJlIGFyZSBzZXZlcmFsIGVhc3kgd2F5czogcmFpbHMgZGIgKFNRTCks\nIHJhaWxzIGNvbnNvbGUsIGFuZCAiYnllYnVnIi4KCkZvciBtb3JlIGFib3V0\nIGhvdyB0aGUgcHJvZ3JhbSBpcyBzdHJ1Y3R1cmVkLCBhbmQgb3RoZXIgaGlu\ndHMsIHNlZSB0aGUKW2ltcGxlbWVudGF0aW9uXShpbXBsZW1lbnRhdGlvbi5t\nZCkgaW5mb3JtYXRpb24uCgojIyMgUmFpbHMgZGIKClVzZSAicmFpbHMgZGIi\nIHRvIGludGVyYWN0IGRpcmVjdGx5IHdpdGggdGhlIGRhdGFiYXNlLiBFLkcu\nOgoKfn5+fgpyYWlscyBkYgpTRUxFQ1QgaWQsbmFtZSBGUk9NIHVzZXJzIFdI\nRVJFIGlkIDwgNTsKU0VMRUNUIGlkLG5hbWUgRlJPTSBwcm9qZWN0cyBXSEVS\nRSBpZCA8IDU7Cn5+fn4KClRoZSBmaWxlICJkYi9zY2hlbWEucmIiIGRlc2Ny\naWJlcyB0aGUgZGF0YWJhc2Ugc2NoZW1hLgoKIyMjIFJhaWxzIGNvbnNvbGUK\nClRoZSAicmFpbHMgY29uc29sZSIgY2FuIGJlIGEgY29udmVuaWVudCB3YXkg\ndG8gYWNjZXNzIHN0YXRlOwppdCBzdGFydHMgYSBSdWJ5IGVudmlyb25tZW50\nIHdpdGggUmFpbHMgbG9hZGVkLgoKSGVyZSBpcyBhIHNhbXBsZToKCn5+fn4K\ncmFpbHMgY29uc29sZQoKcCA9IFByb2plY3QubmV3CiMgU2V0IHZhbHVlcyBm\nb3IgcHJvamVjdCB0byBldmFsdWF0ZS4gIFdlJ2xsIGV4YW1pbmUgb3VyIG93\nbiBwcm9qZWN0LgpwWzpyZXBvX3VybF0gPSAnaHR0cHM6Ly9naXRodWIuY29t\nL2NvcmVpbmZyYXN0cnVjdHVyZS9iZXN0LXByYWN0aWNlcy1iYWRnZScKcFs6\naG9tZXBhZ2VfdXJsXSA9ICdodHRwczovL2dpdGh1Yi5jb20vY29yZWluZnJh\nc3RydWN0dXJlL2Jlc3QtcHJhY3RpY2VzLWJhZGdlJwojIFNldHVwIGNoaWVm\nIHRvIGFuYWx5emUgdGhpbmdzOgpuZXdfY2hpZWYgPSBDaGllZi5uZXcocCwg\ncHJvYyB7IE9jdG9raXQ6OkNsaWVudC5uZXcgfSkKIyBBc2sgY2hpZWYgdG8g\nZmluZCBwcm9iYWJsZSB2YWx1ZXM6CnJlc3VsdHMgPSBuZXdfY2hpZWYuYXV0\nb2ZpbGwKcmVzdWx0cy5rZXlzCnJlc3VsdHNbOm5hbWVdCn5+fn4KCiMjIyBi\neWVidWcKCllvdSBjYW4gaW5zZXJ0ICJieWVidWciIGFueXdoZXJlIGluIHRo\nZSBjb2RlLgpXaGVuIHRoYXQgcnVucywgdGhlIHByb2dyYW0gc3RvcHMgYW5k\nIHByb3ZpZGVzIGFuIGludGVyYWN0aXZlCmNvbW1hbmQgZW52aXJvbm1lbnQg\nd2hpY2ggbGV0cyB5b3UgZXhlY3V0ZSBjb21tYW5kcwooc3VjaCBhcyBzaG93\naW5nIHlvdSB2YXJpb3VzIHN0YXRlcykuCgojIyBDb250cmlidXRpbmcgaW4g\nZ2VuZXJhbAoKU2VlIFtDT05UUklCVVRJTkcubWRdKC4uL0NPTlRSSUJVVElO\nRy5tZCkgZm9yIGluZm9ybWF0aW9uIG9uIGhvdyB0byBjb250cmlidXRlCmNo\nYW5nZXMuCgojIyBEZXBsb3ltZW50IGluc3RydWN0aW9ucwoKVGhpcyBpcyBk\nZXNpZ25lZCB0byBiZSBlYXNpbHkgZGVwbG95ZWQgc2ltcGx5IGJ5IGRvaW5n\nIGEgImdpdCBwdXNoIgp0byBhbiBhcHByb3ByaWF0ZSBkZXN0aW5hdGlvbi4K\nCkF0IHRoaXMgcG9pbnQsIGEgZGVwbG95bWVudCBpcyBhdXRvbWF0aWNhbGx5\nIGRvbmUgdG8gYSBzdGFnaW5nIHN5c3RlbSBvbmNlCml0J3MgY2hlY2tlZCBp\nbnRvIHRoZSByZXBvc2l0b3J5IG9uIHRoZSBtYXN0ZXIgYnJhbmNoLgoKIyMg\nU2VlIGFsc28KClNlZSB0aGUgc2VwYXJhdGUgIltiYWNrZ3JvdW5kXSguL2Jh\nY2tncm91bmQubWQpIiBhbmQgIltjcml0ZXJpYV0oLi9jcml0ZXJpYS5tZCki\nCnBhZ2VzIGZvciBtb3JlIGluZm9ybWF0aW9uLgoKIyMgV2hhdCBkb2VzIGlu\nc3RhbGwtYmFkZ2UtZGV2LWVudiBkbz8KClRoZSBpbnN0YWxsLWJhZGdlLWRl\ndi1lbnYgc2NyaXB0IHRyaWVzIHRvIGluc3RhbGwgYWxsIChtaXNzaW5nKSB0\nb29scyBhbmQKbGlicmFyaWVzLiAgWW91IGNhbiByZS1ydW4gaXQgYWdhaW4g\naWYgc29tZXRoaW5nIGdvdCBjb3JydXB0ZWQuCgojIyMgSW5zdGFsbGluZyBz\neXN0ZW0gdG9vbHMKCkZpcnN0LCBpdCB0cmllcyB0byBhdXRvbWF0aWNhbGx5\nIGRldGVjdCB5b3VyIHN5c3RlbSBwYWNrYWdlIG1hbmFnZW1lbnQgdG9vbAoo\nZS5nLiwgYXB0LWdldCwgeXVtLCBkbmYsIG9yIGJyZXcpLAphbmQgdGhlbiB0\ncmllcyB0byBpbnN0YWxsIHNvbWUga2V5IHRvb2xzIGlmIHRoZXkncmUgbm90\nIGFscmVhZHkgdGhlcmU6CgoqIGdpdCwgdG8gZ2V0IHNvbWUgb2YgdGhlIHBy\nb2dyYW1zIHdlIHVzZS4KICBJbnN0YWxsaW5nIGdpdCB3aWxsIGFsc28gaW5z\ndGFsbCBzb21lIGxpYnJhcmllcyBzdWNoIGFzCiAgY3VybCwgemxpYiwgb3Bl\nbnNzbCwgZXhwYXQsIGFuZCBsaWJpY29udi4KKiBSdWJ5ICh2ZXJzaW9uIDEu\nOS4zIG9yIG5ld2VyKSwgdG8gYm9vdHN0cmFwIGluc3RhbGxpbmcgdGhlIFJ1\nYnkgd2UnbGwgdXNlCiogU1FMaXRlMyBkYXRhYmFzZSBzeXN0ZW0sIHVzZWQg\naW4gZGV2ZWxvcG1lbnQgZm9yIGRhdGEgc3RvcmFnZQoqIEMgY29tcGlsZXIg\nYW5kIGJhc2ljIGxpYnJhcmllcyBmb3IgcmVidWlsZGluZyBydWJ5LgogIElu\nc3RhbGwgYSBzYW5lIEMgY29tcGlsZXIgc3VjaCBhcyBnY2Mgb3IgY2xhbmcu\nCgpTZWUgdGhlIFtydWJ5LWJ1aWxkIHN1Z2dlc3RlZCBidWlsZCBlbnZpcm9u\nbWVudF0oaHR0cHM6Ly9naXRodWIuY29tL3NzdGVwaGVuc29uL3J1YnktYnVp\nbGQvd2lraSNzdWdnZXN0ZWQtYnVpbGQtZW52aXJvbm1lbnQpCmZvciBob3cg\ndG8gZG8gaW5zdGFsbCB0aGUgb3RoZXIgcmVxdWlyZWQgY29tcG9uZW50cy4K\nVGhlIHNjcmlwdCBpbnN0YWxscyBnY2MuCgpJdCB0aGVuIG5vcm1hbGx5IGlu\nc3RhbGxzIFtyYmVudl0oaHR0cHM6Ly9naXRodWIuY29tL3NzdGVwaGVuc29u\nL3JiZW52KS4KU2VlIHRoZQpbcmJlbnYgYmFzaWMgZ2l0aHViIGNoZWNrb3V0\nXShodHRwczovL2dpdGh1Yi5jb20vc3N0ZXBoZW5zb24vcmJlbnYjYmFzaWMt\nZ2l0aHViLWNoZWNrb3V0KQppbnN0cnVjdGlvbnMgZm9yIG9uZSBhcHByb2Fj\naCBmb3IgaW5zdGFsbGluZyByYmVudi4KVGhlIHJiZW52IHRvb2wgbGV0cyB5\nb3Ugc2VsZWN0IGEgc3BlY2lmaWMgdmVyc2lvbiBvZiBSdWJ5LCBhbmQgZnJv\nbSB0aGVyZSwKc2VsZWN0IHNwZWNpZmljIHZlcnNpb25zIG9mIG90aGVyIGxp\nYnJhcmllcy4KQW4gYWx0ZXJuYXRpdmUgd2F5IHRvIHNlbGVjdCBzcGVjaWZp\nYyB2ZXJzaW9ucyBpcyB0byB1c2UgcnZtLApidXQgdGhhdCBhcHByb2FjaCBp\ncyBub3QgZG9jdW1lbnRlZCBoZXJlLgoKSXQgYWxzbyBhZGRzIGFuICJ1cHN0\ncmVhbSIgcmVtb3RlIHNvIHRoYXQgeW91IGNhbiBlYXNpbHkgdHJhY2sgaXQ6\nCgp+fn5+c2gKZ2l0IHJlbW90ZSBhZGQgdXBzdHJlYW0gaHR0cHM6Ly9naXRo\ndWIuY29tL2NvcmVpbmZyYXN0cnVjdHVyZS9iZXN0LXByYWN0aWNlcy1iYWRn\nZS5naXQKfn5+fgoKPCEtLSBJZiB5b3UgaGF2ZSBlZGl0IHJpZ2h0cywgZG8g\ndGhpcyBpbnN0ZWFkOgpnaXQgY2xvbmUgPGh0dHBzOi8vZ2l0aHViLmNvbS9j\nb3JlaW5mcmFzdHJ1Y3R1cmUvYmVzdC1wcmFjdGljZXMtYmFkZ2UuZ2l0Pgpj\nZCBjaWktYmVzdC1wcmFjdGljZXMtYmFkZ2UKLS0+CgojIyMgSW5zdGFsbGlu\nZyB0aGUgcHJvamVjdCBlbnZpcm9ubWVudAoKRm9yIGRldmVsb3BtZW50IHdl\nIGZpeCB0aGUgdmVyc2lvbiBvZiBSdWJ5IGF0IHRoZSB2ZXJzaW9uIHNwZWNp\nZmllZCBpbiBgLnJ1YnktdmVyc2lvbmAuIFBsZWFzZSBjaGVjayB0aGF0IGZp\nbGUgYW5kIHVzZSB0aGF0IHZlcnNpb24gaW4gdGhlIHN0ZXBzIGJlbG93LgpX\nZSBhbHNvIG5lZWQgdG8gaW5zdGFsbCBhIG51bWJlciBvZiBnZW1zIChpbmNs\ndWRpbmcgdGhlIG9uZXMgaW4gUmFpbHMpOwp3ZSB3aWxsIGluc3RhbGwgdGhl\nIHZlcnNpb25zIHNwZWNpZmllZCBpbiBHZW1maWxlLmxvY2suCldlIHdpbGwg\nZG8gY29tcGxldGVseSBzZXBhcmF0ZSBwZXItcHJvamVjdCBHZW0gaW5zdGFs\nbHMsCnRvIHByZXZlbnQgcG90ZW50aWFsIGludGVyZmVyZW5jZSBpc3N1ZXMg\naW4gdGhlIGRldmVsb3BtZW50IGVudmlyb25tZW50LgpIZXJlJ3MgYSB3YXkg\ndG8gZG8gdGhhdC4KV2UgcHJlc3VtZSB0aGF0IHlvdXIgY3VycmVudCBkaXJl\nY3RvcnkgaXMgdGhlIHRvcCBkaXJlY3Rvcnkgb2YgdGhlIHByb2plY3QsCmFr\nYSBjaWktYmVzdC1wcmFjdGljZXMtYmFkZ2UuCgp+fn5+CiMgRm9yY2UgaW5z\ndGFsbCBSdWJ5IDIuMy4xIHVzaW5nIHJiZW52OgpyYmVudiBpbnN0YWxsIDIu\nMy4xCnJiZW52IGxvY2FsIDIuMy4xICMgSW4gdGhpcyBkaXJlY3RvcnkgQU5E\nIEJFTE9XLCB1c2UgUnVieSAyLjMuMSBpbnN0ZWFkLgoKIyBUaGlzIG1ha2Vz\nICJidW5kbGUgLi4uIiB1c2UgcmJlbnYncyB2ZXJzaW9uIG9mIFJ1Ynk6Cmdp\ndCBjbG9uZSBnaXQ6Ly9naXRodWIuY29tL2NhcnNvbXlyL3JiZW52LWJ1bmRs\nZXIuZ2l0IH4vLnJiZW52L3BsdWdpbnMvYnVuZGxlcgoKZ2VtIHNvdXJjZXMg\nLS1hZGQgaHR0cHM6Ly9ydWJ5Z2Vtcy5vcmcgICMgRW5zdXJlIHlvdSdyZSBn\nZXR0aW5nIGdlbXMgaGVyZQpnZW0gaW5zdGFsbCBidW5kbGVyICAjIEluc3Rh\nbGwgdGhlICJidW5kbGVyIiBnZW0gcGFja2FnZSBtYW5hZ2VyLgpyYmVudiBy\nZWhhc2gKYnVuZGxlIGluc3RhbGwgICAgICAgIyBJbnN0YWxsIGdlbXMgd2Ug\ndXNlIGluIEdlbWZpbGUubG9jaywgaW5jbHVkaW5nIFJhaWxzCnJha2UgZGI6\nc2V0dXAgICAgICAgICMgU2V0dXAgZGF0YWJhc2UgYW5kIHNlZWQgaXQgd2l0\naCBkdW1teSBkYXRhCn5+fn4KCiMjIyBnaXQgaW50ZWdyaXR5CgpQZXIgYSBy\nZWNvbW1lbmRhdGlvbiBhYm91dCBnaXQgaW50ZWdyaXR5IGJ5IEVyaWMgTXlo\ncmUsIHdlIGZvcmNlCmdpdCB0byBjaGVjayB0aGUgaW50ZWdyaXR5IG9mIGlu\nY29taW5nIGRhdGEgdXNpbmc6Cgp+fn5+CmdpdCBjb25maWcgLS1nbG9iYWwg\ndHJhbnNmZXIuZnNja29iamVjdHMgdHJ1ZQpnaXQgY29uZmlnIC0tZ2xvYmFs\nIGZldGNoLmZzY2tvYmplY3RzIHRydWUKfn5+fgoKIyMjIENvbnNlcXVlbmNl\ncyBvZiBvdXIgaW5zdGFsbCBhcHByb2FjaAoKU29tZSBkb2N1bWVudHMgYWJv\ndXQgUmFpbHMgd2lsbCB0ZWxsIHlvdSB0byBleGVjdXRlICJiaW4vcmFrZSIg\naW5zdGVhZCBvZgoicmFrZSIgb3IgdG8gdXNlICJidW5kbGUgZXhlYyAuLi4i\nIHRvIGV4ZWN1dGUgcHJvZ3JhbXMuClVzaW5nIHJiZW52LWJ1bmRsZXIgKGFi\nb3ZlKSBlbGltaW5hdGVzIHRoZSBuZWVkIGZvciB0aGF0LgpXaGlsZSAiYnVu\nZGxlIGV4ZWMuLi4iIG9yICJiaW4vLi4uIiBhcmUgd2lkZWx5IHVzZWQsIHRo\nZXkgYXJlIGFsc28KZXh0cmVtZWx5IGVycm9yLXByb25lIHVzZXIgaW50ZXJm\nYWNlczsgaWYgeW91IGZvcmdldCB0aGUgcHJlZml4ZXMsCnRoZW4gaXQgY2Fu\nICphcHBlYXIqIHRvIHdvcmsgeWV0IHN1YnRseSBkbyB0aGUgd3JvbmcgdGhp\nbmcuClVzaW5nIHJiZXYtYnVuZGxlciBtZWFucyB0aGF0IHRoZSAqZWFzeSog\nd2F5IGlzIHRoZSAqY29ycmVjdCogd2F5LgpBIHZpdGFsbHkgaW1wb3J0YW50\nIHdheSB0byBwcmV2ZW50IGRlZmVjdHMgaXMgdG8gbWFrZSB0aGUgKmVhc3kq\nIHdheQp0aGUgKmNvcnJlY3QqIHdheS4KCllvdSBjYW4gdXNlICJidW5kbGUg\nb3V0ZGF0ZWQiIHRvIHNob3cgdGhlIGdlbXMgdGhhdCBhcmUgb3V0ZGF0ZWQ7\nCmJlIHN1cmUgdG8gdGVzdCBhZnRlciB1cGRhdGluZyBhbnkgZ2Vtcy4KCiMj\nIFRlc3RpbmcgdGhlIGluc3RhbGxlciBzY3JpcHQKCkl0IG1heSBiZSB1c2Vm\ndWwgdG8gb2NjYXNpb25hbGx5IHRlc3QgdGhhdCBvdXIgaW5zdGFsbGVyIHNj\ncmlwdCBpcyB3b3JraW5nCmFzIGV4cGVjdGVkLiAgV2UgaGF2ZSBhIGJyYW5j\naCBzZXQgdXAgb24gR2l0SHViIHdoaWNoIGlzIGNvbmZpZ3VyZWQgdG8gZG8g\nanVzdAp0aGF0LCB0ZXN0LWRldi1pbnN0YWxsLiAgSW4gb3JkZXIgdG8gdGVz\ndCB0aGUgaW5zdGFsbCBzY3JpcHQsIHlvdSBtdXN0IGhhdmUKd3JpdGUgcHJp\ndmVsZWdlcyB0byB0aGUgR2l0SHViIGdpdCByZXBvc2l0b3J5LiAgSWYgeW91\nIGRvLCB5b3UgY2FuIHRyaWdnZXIgYQp0ZXN0IGJ5IHJ1bm5pbmcKCn5+fn4K\ncmFrZSB0ZXN0X2Rldl9pbnN0YWxsCn5+fn4KClRoaXMgY29tbWFuZCB3aWxs\nIG1lcmdlIHRoZSBjdXJyZW50IG1hc3RlciBicmFuY2ggaW50byBvdXIgdGVz\ndCBicmFuY2ggd2hpbGUKY29uc2VydmluZyBvdXIgY3VzdG9tIGNpcmNsZS55\nbWwgZm9yIHRlc3Rpbmcgb3VyIGluc3RhbGwgc2NyaXB0IGFuZCB0aGVuIHB1\nc2gKdGhlc2UgY2hhbmdlcyB0byBHaXRIdWIuIFRoaXMgd2lsbCB0cmlnZ2Vy\nIGEgQ2lyY2xlQ0kgYnVpbGQgd2hpY2ggd2lsbCB0ZXN0CnRoZSBpbnN0YWxs\nIHNjcmlwdC4KCiMjIFVuaW5zdGFsbGluZyB0aGUgQmFkZ2UgYXBwJ3MgZGV2\nZWxvcG1lbnQgZW52aXJvbm1lbnQKCkluIG9yZGVyIHRvIGNvbXBsZXRlbHkg\ncmVtb3ZlIHRoZSBCYWRnZSBhcHAsIHBlcmZvcm0gdGhlIGZvbGxvd2luZyBz\ndGVwczoKCjEuICBSZW1vdmUgdGhlIGRhdGFiYXNlIGVudHJpZXMgQmFkZ2Ug\nYXBwLiAgVGhpcyBjYW4gYmUgZG9uZSBieSBydW5uaW5nCiAgICAicmFrZSBk\nYjpkcm9wICYmIFJBSUxTX0VOVj10ZXN0IHJha2UgZGI6ZHJvcCIKCjIuICBS\nZW1vdmUgdGhlIGNpaS1iZXN0LXByYWN0aWNlcy1iYWRnZSBkaXJlY3Rvcnku\nIChXQVJOSU5HOiBUaGlzIHdpbGwgcmVtb3ZlCiAgICBhbnkgYW5kIGFsbCBs\nb2NhbCBicmFuY2hlcyB0aGF0IGhhdmUgbm90IGJlZW4gcHVzaGVkIHRvIHlv\ndXIgcmVtb3RlIGdpdAogICAgcmVwb3NpdG9yeS4KCjMuICAoT3B0aW9uYWwp\nIElmIHlvdSBkbyBub3QgdXNlIHJiZW52IGZvciBhbnkgb3RoZXIgYXBwbGlj\nYXRpb25zIGFuZCB3b3VsZAogICAgbGlrZSB0byByZW1vdmUgaXQsIHlvdSBj\nYW4gY28gc28gYnkgZmlyc3QgcmVtb3ZpbmcgdGhlIGRpcmVjdG9yeToKICAg\nIGAkSE9NRS8ucmJlbnZgLiAgIEZpbmFsbHkgcmVtb3ZlIHRoZSBhbnkgbGlu\nZXMgbWF0Y2hpbmcgInJiZW52IiBmcm9tIGFueQogICAgc2hlbGwgc3RhcnR1\ncCBmaWxlcy4KCllvdSBjYW4gZmluZCBsaW5lcyBtYXRjaGluZyAicmJlbnYi\nIGluIHNoZWxsIHN0YXJ0dXAgZmlsZXMKd2l0aCB0aGUgZm9sbG93aW5nIHNo\nZWxsIGNvbW1hbmQ6Cgp+fn5+c2gKZ3JlcCByYmVudiB+Ly5iYXNocmMgfi8u\nYmFzaF9wcm9maWxlIH4vLnpzaHJjIC9ldGMvcHJvZmlsZSAvZXRjL3Byb2Zp\nbGUuZC8qCn5+fn4KCiMjIFNlZSBhbHNvCgpQcm9qZWN0IHBhcnRpY2lwYXRp\nb24gYW5kIGludGVyZmFjZToKCiogW0NPTlRSSUJVVElORy5tZF0oLi4vQ09O\nVFJJQlVUSU5HLm1kKSAtIEhvdyB0byBjb250cmlidXRlIHRvIHRoaXMgcHJv\namVjdAoqIFtJTlNUQUxMLm1kXShJTlNUQUxMLm1kKSAtIEhvdyB0byBpbnN0\nYWxsL3F1aWNrIHN0YXJ0CiogW2dvdmVybmFuY2UubWRdKGdvdmVybmFuY2Uu\nbWQpIC0gSG93IHRoZSBwcm9qZWN0IGlzIGdvdmVybmVkCiogW3JvYWRtYXAu\nbWRdKHJvYWRtYXAubWQpIC0gT3ZlcmFsbCBkaXJlY3Rpb24gb2YgdGhlIHBy\nb2plY3QKKiBbYmFja2dyb3VuZC5tZF0oYmFja2dyb3VuZC5tZCkgLSBCYWNr\nZ3JvdW5kIHJlc2VhcmNoCiogW2FwaV0oYXBpLm1kKSAtIEFwcGxpY2F0aW9u\nIFByb2dyYW1taW5nIEludGVyZmFjZSAoQVBJKSwgaW5jLiBkYXRhIGRvd25s\nb2FkcwoKQ3JpdGVyaWE6CgoqIFtjcml0ZXJpYS5tZF0oY3JpdGVyaWEubWQp\nIC0gQ3JpdGVyaWEgZm9yICJwYXNzaW5nIiBiYWRnZQoqIFtvdGhlci5tZF0o\nb3RoZXIubWQpIC0gQ3JpdGVyaWEgZm9yIG90aGVyIGJhZGdlcyAoc2lsdmVy\nIGFuZCBnb2xkKQoKRGV2ZWxvcG1lbnQgcHJvY2Vzc2VzIGFuZCBzZWN1cml0\neToKCiogW3JlcXVpcmVtZW50cy5tZF0ocmVxdWlyZW1lbnRzLm1kKSAtIFJl\ncXVpcmVtZW50cyAod2hhdCdzIGl0IHN1cHBvc2VkIHRvIGRvPykKKiBbZGVz\naWduLm1kXShkZXNpZ24ubWQpIC0gQXJjaGl0ZWN0dXJhbCBkZXNpZ24gaW5m\nb3JtYXRpb24KKiBbaW1wbGVtZW50YXRpb24ubWRdKGltcGxlbWVudGF0aW9u\nLm1kKSAtIEltcGxlbWVudGF0aW9uIG5vdGVzCiogW3Rlc3RpbmcubWRdKHRl\nc3RpbmcubWQpIC0gSW5mb3JtYXRpb24gb24gdGVzdGluZwoqIFtzZWN1cml0\neS5tZF0oc2VjdXJpdHkubWQpIC0gV2h5IGl0J3MgYWRlcXVhdGVseSBzZWN1\ncmUgKGFzc3VyYW5jZSBjYXNlKQo=\n","encoding":"base64","_links":{"self":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/contents/doc/INSTALL.md?ref=master","git":"https://api.github.com/repos/coreinfrastructure/best-practices-badge/git/blobs/42538ae55e05882d382bc4d8a7a09ed854cb233c","html":"https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/INSTALL.md"}}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 11 Feb 2020 17:13:04 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/Makefile
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '219'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/Makefile
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4997'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '3'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DABE:2FAFF6:AA8090:275DF31:6A15FB8E
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/Makefile","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:10 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/Makefile
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4996'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '4'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DABF:267AE8:AE655D:2864E78:6A15FB8E
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:10 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/api.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '217'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/api.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4995'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '5'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAC0:3216DE:AF9F6E:2895BED:6A15FB8E
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/api.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:11 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/api.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4994'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '6'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAC1:302338:AE2A3F:284EB6C:6A15FB8F
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:11 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/assurance-case-implementation.odg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '244'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/assurance-case-implementation.odg
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4993'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '7'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAC2:159756:BB83AA:2B94F65:6A15FB8F
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/assurance-case-implementation.odg","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:11 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/assurance-case-implementation.odg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4992'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '8'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAC3:302338:AE2CD2:284F500:6A15FB8F
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:11 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/assurance-case-implementation.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '244'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/assurance-case-implementation.png
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4991'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '9'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAC4:2FAFF6:AA88A7:275FDE8:6A15FB8F
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/assurance-case-implementation.png","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:11 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/assurance-case-implementation.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4990'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '10'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAC5:1EFEAD:C7B7F2:2D66DB6:6A15FB8F
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:11 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/assurance-case-lifecycle.odg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '239'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/assurance-case-lifecycle.odg
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4989'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '11'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAC6:29DED:B82B65:2B35CA2:6A15FB8F
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/assurance-case-lifecycle.odg","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:11 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/assurance-case-lifecycle.odg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4988'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '12'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAC7:13F34A:B1FF39:28F23CE:6A15FB8F
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:12 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/assurance-case-lifecycle.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '239'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/assurance-case-lifecycle.png
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4987'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '13'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAC8:120676:AFE741:28C2C68:6A15FB90
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/assurance-case-lifecycle.png","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:12 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/assurance-case-lifecycle.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4986'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '14'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAC9:2FAFF6:AA8F43:276160D:6A15FB90
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:12 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/assurance-case-other-lifecycle.odg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '245'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/assurance-case-other-lifecycle.odg
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4985'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '15'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DACA:31EF60:ACF767:27FF9E4:6A15FB90
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/assurance-case-other-lifecycle.odg","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:12 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/assurance-case-other-lifecycle.odg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4984'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '16'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DACB:2E20E5:B16170:2915879:6A15FB90
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:12 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/assurance-case-other-lifecycle.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '245'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/assurance-case-other-lifecycle.png
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4983'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '17'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DACC:1D3252:AC9808:2815EBC:6A15FB90
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/assurance-case-other-lifecycle.png","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:12 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/assurance-case-other-lifecycle.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4982'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '18'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DACD:2E20E5:B164DD:2916451:6A15FB90
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:12 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/assurance-case.odg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '229'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/assurance-case.odg
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4981'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '19'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DACE:1D1402:BAA0AD:2A6C299:6A15FB90
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/assurance-case.odg","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:13 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/assurance-case.odg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4980'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '20'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DACF:1EFEAD:C7C707:2D6A434:6A15FB91
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:13 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/assurance-case.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '229'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/assurance-case.png
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4979'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '21'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAD0:278BA6:B0BC6F:28E57EB:6A15FB91
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/assurance-case.png","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:13 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/assurance-case.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4978'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '22'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAD1:2EBCC6:A86A2E:26F1F5D:6A15FB91
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:13 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/background.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '224'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/background.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4977'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '23'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAD2:2F85D9:C0386D:2CA06EF:6A15FB91
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/background.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:13 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/background.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4976'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '24'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAD3:2EBCC6:A86CB9:26F289F:6A15FB91
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:13 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/best-practices.py
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '228'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/best-practices.py
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4975'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '25'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAD4:3216DE:AFBA88:289C089:6A15FB91
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/best-practices.py","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:13 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/best-practices.py
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4974'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '26'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAD5:159756:BB9F7D:2B9B8C5:6A15FB91
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:14 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/compute-criteria-2017-02-06.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '242'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/compute-criteria-2017-02-06.txt
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4973'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '27'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAD6:12A05C:AADE36:2795210:6A15FB92
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/compute-criteria-2017-02-06.txt","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:14 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/compute-criteria-2017-02-06.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4972'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '28'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAD7:267AE8:AE8350:286BE37:6A15FB92
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:14 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/compute-criteria-2017-09-06.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '242'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/compute-criteria-2017-09-06.txt
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4971'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '29'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAD8:159756:BBA3A4:2B9C8B4:6A15FB92
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/compute-criteria-2017-09-06.txt","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:14 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/compute-criteria-2017-09-06.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4970'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '30'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAD9:2F85D9:C041DD:2CA28B0:6A15FB92
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:14 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/compute-criteria-2019-03-07.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '242'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/compute-criteria-2019-03-07.txt
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4969'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '31'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DADA:2644DD:A9C84B:273D112:6A15FB92
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/compute-criteria-2019-03-07.txt","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:14 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/compute-criteria-2019-03-07.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4968'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '32'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DADB:29DED:B849A6:2B3CF3F:6A15FB92
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:14 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/criteria-footer.markdown
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '235'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/criteria-footer.markdown
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4967'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '33'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DADC:2F85D9:C0466B:2CA3979:6A15FB92
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/criteria-footer.markdown","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:15 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/criteria-footer.markdown
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4966'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '34'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DADD:482DE:A6D206:26A6810:6A15FB93
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:15 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/criteria-header.markdown
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '235'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/criteria-header.markdown
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4965'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '35'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DADE:9B44C:AC079B:27EF5D0:6A15FB93
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/criteria-header.markdown","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:15 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/criteria-header.markdown
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4964'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '36'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DADF:1B21E6:ACA935:27BA7E5:6A15FB93
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:15 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/criteria.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '222'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/criteria.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4963'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '37'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAE0:2F85D9:C04BC0:2CA4D4E:6A15FB93
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/criteria.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:15 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/criteria.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4962'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '38'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAE1:278BA6:B0D1EC:28EA890:6A15FB93
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:15 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/dawnscanner.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '225'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/dawnscanner.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4961'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '39'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAE2:13F34A:B22510:28FB077:6A15FB93
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/dawnscanner.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:15 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/dawnscanner.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4960'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '40'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAE3:1EFEAD:C7E398:2D70EBB:6A15FB93
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:15 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/dco.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '218'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/dco.txt
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4959'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '41'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAE4:29D191:AEEB76:28612C8:6A15FB93
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/dco.txt","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:16 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/dco.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4958'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '42'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAE5:312011:AE6C00:2885145:6A15FB94
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:16 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/dependency_decisions.yml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '235'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/dependency_decisions.yml
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4957'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '43'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAE6:381EF3:AE9DF3:28461F2:6A15FB94
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/dependency_decisions.yml","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:16 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/dependency_decisions.yml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4956'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '44'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAE7:482DE:A6DDD1:26A9591:6A15FB94
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:16 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/design.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '220'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/design.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4955'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '45'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAE8:12A05C:AAF3CD:279A3E3:6A15FB94
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/design.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:16 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/design.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4954'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '46'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAE9:D5F2:AFC792:28A4CA0:6A15FB94
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:16 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/design.odg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '221'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/design.odg
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4953'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '47'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAEA:312011:AE72BD:2886A1A:6A15FB94
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/design.odg","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:16 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/design.odg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4952'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '48'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAEB:1EFEAD:C7EFCD:2D73BA3:6A15FB95
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:17 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/design.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '221'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/design.png
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4951'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '49'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAEC:13F34A:B23304:28FE47C:6A15FB95
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/design.png","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:17 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/design.png
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4950'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '50'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAED:278BA6:B0E163:28EE28A:6A15FB95
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:17 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/governance.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '224'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/governance.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4949'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '51'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAEE:381EF3:AEA7BD:28486E1:6A15FB95
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/governance.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:17 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/governance.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4948'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '52'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAEF:381EF3:AEA8E9:2848B1F:6A15FB95
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:17 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/implementation.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '228'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/implementation.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4947'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '53'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAF0:2644DD:A9E2D4:2743373:6A15FB95
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/implementation.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:17 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/implementation.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4946'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '54'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAF1:12A05C:AAFEC1:279CC45:6A15FB95
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:17 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/markdown-urls
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '224'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/markdown-urls
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4945'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '55'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAF2:482DE:A6EC39:26ACA50:6A15FB95
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/markdown-urls","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:18 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/markdown-urls
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4944'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '56'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAF3:2FAFF6:AAC2FE:276D988:6A15FB96
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:18 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/nyc-2016.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '222'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/nyc-2016.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4943'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '57'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAF4:B20F3:A98B66:272EA72:6A15FB96
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/nyc-2016.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:18 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/nyc-2016.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4942'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '58'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAF5:2EBCC6:A897B4:26FCBD9:6A15FB96
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:18 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/other.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '219'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/other.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4941'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '59'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAF6:312011:AE82AF:288A4D6:6A15FB96
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/other.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:18 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/other.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4940'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '60'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAF7:2F85D9:C06A07:2CABFCF:6A15FB96
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:18 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/requirements.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '226'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/requirements.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4939'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '61'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAF8:2EBCC6:A89B94:26FDAAC:6A15FB96
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/requirements.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:18 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/requirements.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4938'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '62'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAF9:120676:B02659:28D1A65:6A15FB96
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:19 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/roadmap.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '221'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/roadmap.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4937'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '63'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAFA:482DE:A6F6B7:26AF264:6A15FB97
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/roadmap.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:19 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/roadmap.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4936'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '64'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAFB:1EFEAD:C80728:2D7915E:6A15FB97
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:19 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/security.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '222'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/security.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4935'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '65'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAFC:2169D:AEA237:285516F:6A15FB97
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/security.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:19 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/security.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4934'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '66'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAFD:120676:B02C6B:28D311E:6A15FB97
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:19 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/self.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '220'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/self.json
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4933'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '67'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DAFE:B20F3:A99920:2731DD4:6A15FB97
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/self.json","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:19 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/self.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4932'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '68'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DAFF:2644DD:A9F4E0:27476EA:6A15FB97
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:20 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/test-coverage-criteria.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '236'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/test-coverage-criteria.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4931'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '69'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DB00:29DED:B87D8B:2B49546:6A15FB98
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/test-coverage-criteria.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:20 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/test-coverage-criteria.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4930'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '70'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DB01:1B21E6:ACD5A8:27C4D54:6A15FB98
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:20 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/test-markdown.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '227'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/test-markdown.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4929'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '71'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DB02:1EFEAD:C81263:2D7B990:6A15FB98
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/test-markdown.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:20 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/test-markdown.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4928'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '72'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DB03:B20F3:A99F6D:27334F3:6A15FB98
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:20 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/testing.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '221'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/testing.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4927'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '73'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DB04:2F85D9:C07D32:2CB07A1:6A15FB98
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/testing.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:20 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/testing.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4926'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '74'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DB05:482DE:A7059F:26B2B11:6A15FB98
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:20 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/linuxfoundation/cii-best-practices-badge/contents/doc/vetting.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '221'
+      Location:
+      - https://api.github.com/repositories/39528049/contents/doc/vetting.md
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4925'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '75'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - DB06:3216DE:AFFCC7:28ABB60:6A15FB98
+      Server:
+      - github.com
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/39528049/contents/doc/vetting.md","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:21 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/39528049/contents/doc/vetting.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 7.2.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic M2U5MDE5NGM3MGI1N2I3MTE4OGU6ZDJlM2YwMDI4MzhmNjExYTUxNGI4NGExNzI3YmY2ZTUwMGE2N2QyYg==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 26 May 2026 19:59:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Deprecation:
+      - Tue, 10 Mar 2026 00:00:00 GMT
+      Sunset:
+      - Fri, 10 Mar 2028 00:00:00 GMT
+      Link:
+      - <https://docs.github.com/en/rest/about-the-rest-api/api-versions>; rel="deprecation";
+        type="text/html"
+      X-Github-Api-Version-Selected:
+      - '2022-11-28'
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4924'
+      X-Ratelimit-Reset:
+      - '1779827351'
+      X-Ratelimit-Used:
+      - '76'
+      X-Ratelimit-Resource:
+      - core
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset, Warning
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      Transfer-Encoding:
+      - chunked
+      X-Github-Request-Id:
+      - DB07:1A45FE:AA3393:2752CE0:6A15FB99
+      Server:
+      - github.com
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}'
+    http_version:
+  recorded_at: Tue, 26 May 2026 19:59:21 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
When the GitHub contents API returns 404 (transient error, deleted repo, or private repo accessed without auth), the original code set @top_level to [] and then produced UNMET with hardcoded confidence 5 for license_location_status. Confidence 5 >= CONFIDENCE_OVERRIDE (4), so it overrode a user-set "Met" value on the next form save.

Fix by passing not_found_result: nil to get_info for the root scan so that @top_level is nil on 404 (distinguishable from a successful but empty listing). Use confidence 1 (non-forced) when @top_level is nil, and confidence 5 only when we actually scanned the repo and confirmed no license is present. Propagate this conditional confidence through to osps_le_03_01_status as well.

Also fix a latent crash in SubdirFileContentsDetective: when a file listed in a directory subsequently returned 404, get_info returned [] and the old code called Base64.decode64 on nil. Extracted fetch_file_content to guard with blank?/is_a?(Array) before decoding.

Correct the get_info comment: empty repos return 409 Conflict (not 404) so they never hit the not_found_result path; renamed repos redirect. Exclude temp/ from the 7-day ruby syntax check in default.rake.