### PR TITLE
Log when get_content drops a file for size

### DIFF
--- a/app/lib/github_content_access.rb
+++ b/app/lib/github_content_access.rb
@@ -77,7 +77,13 @@ class GithubContentAccess
     return if file_info['type'] != 'file'
 
     # Trust but verify: Check GitHub's reported size before fetching
-    return if file_info['size'] > max_size
+    if file_info['size'] > max_size
+      Rails.logger.info(
+        "GithubContentAccess: #{filename} exceeds max_size " \
+        "(#{file_info['size']} bytes > #{max_size}); skipping fetch"
+      )
+      return
+    end
 
     # Now fetch raw content. GitHub already told us the size is OK.
     # Use raw API to get unencoded content (avoids base64 overhead).
@@ -89,7 +95,14 @@ class GithubContentAccess
     )
 
     # Defense in depth: Verify actual size matches GitHub's claim
-    return if content.bytesize > max_size
+    if content.bytesize > max_size
+      Rails.logger.warn(
+        "GithubContentAccess: #{filename} actual size #{content.bytesize} " \
+        "bytes exceeds reported #{file_info['size']} and max_size #{max_size}; " \
+        'rejecting (possible GitHub size misreport or MITM)'
+      )
+      return
+    end
 
     content
   rescue StandardError

--- a/test/unit/lib/github_content_access_test.rb
+++ b/test/unit/lib/github_content_access_test.rb
@@ -92,6 +92,34 @@ class GithubContentAccessTest < ActiveSupport::TestCase
     assert_nil result
   end
 
+  test 'get_content logs at info level when file exceeds max_size' do
+    mock_client =
+      Class.new do
+        def contents(_fullname, **)
+          {
+            'type' => 'file',
+            'size' => 100_000, # 100KB
+            'content' => Base64.encode64('x' * 100_000)
+          }
+        end
+      end
+
+    access = GithubContentAccess.new('owner/repo', proc { mock_client.new })
+
+    log_output = StringIO.new
+    original_logger = Rails.logger
+    Rails.logger = ActiveSupport::Logger.new(log_output)
+    begin
+      result = access.get_content('huge.txt', max_size: 50_000)
+    ensure
+      Rails.logger = original_logger
+    end
+
+    assert_nil result
+    assert_match(/huge\.txt exceeds max_size/, log_output.string)
+    assert_match(/100000 bytes > 50000/, log_output.string)
+  end
+
   test 'get_content returns nil when content is blank' do
     mock_client =
       Class.new do
@@ -125,6 +153,35 @@ class GithubContentAccessTest < ActiveSupport::TestCase
     result = access.get_content('malicious.txt', max_size: 50_000)
 
     assert_nil result # Should reject due to actual size > max_size
+  end
+
+  test 'get_content logs at warn level when actual content exceeds reported size' do
+    mock_client =
+      Class.new do
+        def contents(_fullname, **options)
+          if options[:accept] == 'application/vnd.github.raw'
+            # Attacker scenario: huge content under a small-size claim
+            'x' * 100_000
+          else
+            { 'type' => 'file', 'size' => 1000 }
+          end
+        end
+      end
+
+    access = GithubContentAccess.new('owner/repo', proc { mock_client.new })
+
+    log_output = StringIO.new
+    original_logger = Rails.logger
+    Rails.logger = ActiveSupport::Logger.new(log_output, level: Logger::WARN)
+    begin
+      result = access.get_content('lying.txt', max_size: 50_000)
+    ensure
+      Rails.logger = original_logger
+    end
+
+    assert_nil result
+    assert_match(/lying\.txt actual size 100000/, log_output.string)
+    assert_match(/possible GitHub size misreport or MITM/, log_output.string)
   end
 
   test 'get_content decodes valid base64 content' do


### PR DESCRIPTION
When `GithubContentAccess#get_content` rejects a file because the reported size or post-fetch size exceeds `max_size`, log it. Five early-return cases were collapsed into a single silent `nil`.

| Branch | Level | Rationale |
|--------|-------|-----------|
| `file_info['size'] > max_size` | `info` | Normal "someone wrote too big a file" — config-bound, not an app error |
| `content.bytesize > max_size`  | `warn` | Shouldn't happen; would indicate GitHub misreport or MITM (per the existing security note above the method) |

Each log line includes the filename and the offending size(s) so a developer can diagnose without re-instrumenting.

## Motivating case

A downstream project's `.bestpractices.json` landed 912 bytes over `RepoJsonDetective::MAX_FILE_SIZE = 50_000`. Clicking the robot-icon **"Save (and continue) 🤖"** silently produced zero highlighted fields — no log line, no surfaced error. The 912-byte overage was indistinguishable from "file not found" until the code path was traced by hand: prisma-risk/tsoracle#519.

## Tests

Two new tests in `test/unit/lib/github_content_access_test.rb` extend the existing `'returns nil when file exceeds max_size'` and `'returns nil when actual content exceeds reported size'` tests with log-output assertions (StringIO-backed `ActiveSupport::Logger`, swap-and-restore, no new gem dependencies).

## DCO

Commit is signed off (`git commit -s`); trailer is in the commit message.

## Out of scope

The bare `rescue StandardError; nil` at the end of `get_content` also fail-silents, but I suspect Octokit middleware already logs the underlying transport errors. Happy to file a separate issue/PR if that's wrong.

## Style note

I prefixed the messages with `"GithubContentAccess: ..."` to make production grep easier. Other log calls in this codebase (e.g., `Rails.logger.info("Invalid JSON in #{path}: ...")` in `RepoJsonDetective`) don't carry a class prefix — happy to drop it for house-style consistency if you'd prefer.