### PR TITLE
Clarify bestpractices JSON path and OSPS key forms

### DIFF
--- a/docs/automation-proposals.md
+++ b/docs/automation-proposals.md
@@ -249,6 +249,10 @@ dashes or periods (both are replaced with `_`).
 
 Each OSPS criterion also has an `original_id` in the format
 `OSPS-XX-NN.SS` (e.g., `OSPS-AC-01.01`).
+Some readbacks and UI labels display baseline status fields using the
+original OSPS ID with `_status`, for example `OSPS-AC-01.01_status`.
+Proposal URLs, `.bestpractices.json` files, and internal field names use
+the lowercase underscore form, for example `osps_ac_01_01_status`.
 
 **Examples:**
 

--- a/docs/bestpractices-json.md
+++ b/docs/bestpractices-json.md
@@ -1,8 +1,8 @@
 # bestpractices.json
 
-If a project repository has a `.bestpractices.json` file in its top-level
-(or in a `.projects.d` subdirectory), that information is used to fill in
-proposed answers.
+If a project repository has either a `.bestpractices.json` file at its
+top level or a `.project.d/bestpractices.json` file, that information is
+used to fill in proposed answers.
 
 ## Building on other projects
 


### PR DESCRIPTION
## Summary
- correct the repository JSON docs to use `.project.d/bestpractices.json`
- clarify that OSPS readback/display keys use `OSPS-AC-01.01_status` while proposal URLs, `.bestpractices.json`, and internal fields use `osps_ac_01_01_status`

## Test plan
- `git diff --check`

## Notes
- `mdl` was not available locally
- `rake whitespace_check` could not run because the local Ruby environment is missing Bundler 2.7.2