### PR TITLE
Update OmniAuth CSRF protection gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem 'omniauth-github', '~> 2.0' # Authentication to GitHub (get project info)
 # However, using a git reference busts CI pipeline caching, slowing down
 # all testing, and over time we've become more comfortable that this is
 # the "standard way to resolve this issue".
-gem 'omniauth-rails_csrf_protection', '~> 1.0' # integrate omniauth with rails
+gem 'omniauth-rails_csrf_protection', '~> 2.0' # integrate omniauth with rails
 gem 'pagy', '~> 9.0' # Paginator for web pages
 gem 'paleta', '~> 0.3' # Color manipulation, used for badges
 gem 'paper_trail', '~> 17.0' # Record previous versions of project data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,7 +342,7 @@ GEM
     omniauth-oauth2 (1.9.0)
       oauth2 (>= 2.0.2, < 3)
       omniauth (~> 2.0)
-    omniauth-rails_csrf_protection (1.0.2)
+    omniauth-rails_csrf_protection (2.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     ostruct (0.6.3)
@@ -653,7 +653,7 @@ DEPENDENCIES
   multi_json (< 1.21.0)
   octokit (~> 7)
   omniauth-github (~> 2.0)
-  omniauth-rails_csrf_protection (~> 1.0)
+  omniauth-rails_csrf_protection (~> 2.0)
   ostruct
   pagy (~> 9.0)
   paleta (~> 0.3)

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -150,16 +150,18 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     ActionController::Base.allow_forgery_protection = true
     OmniAuth.config.test_mode = false
 
+    https!
     post '/auth/github', headers: {
-      'HTTPS' => 'on',
       'HTTP_ORIGIN' => 'https://www.example.com'
     }
 
     assert_response :redirect
-    assert_match %r{/auth/failure\?}, response.location
-    assert_includes response.location, 'InvalidAuthenticityToken'
-    assert_no_match %r{\Ahttps://github.com/login/oauth/authorize},
-                    response.location
+    failure_uri = URI.parse(response.location)
+    failure_params = Rack::Utils.parse_nested_query(failure_uri.query)
+    assert_equal '/auth/failure', failure_uri.path
+    assert_equal 'github', failure_params['strategy']
+    assert_match(/csrf|InvalidAuthenticityToken/i,
+                 failure_params['message'].to_s)
   ensure
     ActionController::Base.allow_forgery_protection = old_forgery_protection
     OmniAuth.config.test_mode = old_omniauth_test_mode

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -142,6 +142,9 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'github auth request phase rejects missing csrf token' do
+    # WARNING: This test manipulates global OmniAuth/Rails settings.
+    # Parallel testing with *processes* is fine, parallel testing with
+    # *threads* would need suite-wide locking for OmniAuth config changes.
     old_forgery_protection = ActionController::Base.allow_forgery_protection
     old_omniauth_test_mode = OmniAuth.config.test_mode
     ActionController::Base.allow_forgery_protection = true

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -141,6 +141,27 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[type='hidden'][name='session[return_to]'][value='#{destination}']"
   end
 
+  test 'github auth request phase rejects missing csrf token' do
+    old_forgery_protection = ActionController::Base.allow_forgery_protection
+    old_omniauth_test_mode = OmniAuth.config.test_mode
+    ActionController::Base.allow_forgery_protection = true
+    OmniAuth.config.test_mode = false
+
+    post '/auth/github', headers: {
+      'HTTPS' => 'on',
+      'HTTP_ORIGIN' => 'https://www.example.com'
+    }
+
+    assert_response :redirect
+    assert_match %r{/auth/failure\?}, response.location
+    assert_includes response.location, 'InvalidAuthenticityToken'
+    assert_no_match %r{\Ahttps://github.com/login/oauth/authorize},
+                    response.location
+  ensure
+    ActionController::Base.allow_forgery_protection = old_forgery_protection
+    OmniAuth.config.test_mode = old_omniauth_test_mode
+  end
+
   test 'local login fails if deny_login' do
     # WARNING: This test manipulates a global setting, namely
     # Rails.application.config.deny_login. Parallel testing with *processes*


### PR DESCRIPTION
## Summary
- Update `omniauth-rails_csrf_protection` from `~> 1.0` / `1.0.2` to `~> 2.0` / `2.0.1`.
- Add a regression test that temporarily enables Rails forgery protection and verifies a tokenless `POST /auth/github` does not proceed to GitHub OAuth.
- This removes the Rails 8.1 `ActiveSupport::Configurable` deprecation triggered while loading `config/application`.

## Security notes
- This touches the OmniAuth request-phase CSRF protection path, so I kept the change intentionally small.
- The test environment disables forgery protection by default, so the new test enables it only for this check and restores global state in `ensure`.
- In local verification, both the old and new gem versions rejected tokenless `POST /auth/github` with `ActionController::InvalidAuthenticityToken` when forgery protection was enabled. I do not see evidence that this needs a private security advisory path.

## Tests
Run in Docker using the pinned project image and pinned Postgres image:
- `bundle exec ruby -e 'require_relative "config/application"'` -- no `ActiveSupport::Configurable` deprecation
- `bundle exec rake test TEST=test/controllers/sessions_controller_test.rb` -- 12 tests, 42 assertions, 0 failures
- `bundle exec rake test TEST=test/integration/users_login_test.rb` -- 7 tests, 25 assertions, 0 failures
- `bundle exec bundle audit check` -- No vulnerabilities found
- `git diff --check`

I did not run full default `rake` locally because the pinned Docker image does not include `chromedriver`; CircleCI installs it as a separate workflow step.
