### PR TITLE
Fix badge percentage recalc crash in migrations

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -722,7 +722,7 @@ class Project < ApplicationRecord
               Sections::BADGE_LEVEL_RANK[old_baseline_level]
           end
         end
-        project.save!(touch: false)
+        project.save(validate: false, touch: false)
       end
     end
     Project.skip_callbacks = false

--- a/db/migrate/20260602200801_recalc_baseline_badge_percentages.rb
+++ b/db/migrate/20260602200801_recalc_baseline_badge_percentages.rb
@@ -6,11 +6,9 @@
 
 class RecalcBaselineBadgePercentages < ActiveRecord::Migration[8.1]
   def change
-    # Baseline criteria set has changed (futures activated, obsoletes
-    # removed), so stored badge_percentage_baseline_* values are stale.
-    # Recalculate for all projects at all baseline levels.
-    # update_all_badge_percentages also calls FastlyRails.purge_all,
-    # so the CDN cache is cleared and badges update immediately.
-    Project.update_all_badge_percentages(Sections::BASELINE_LEVEL_NAMES)
+    # This migration originally called Project.update_all_badge_percentages,
+    # but it crashed in staging due to validation errors on existing data.
+    # It has been made a no-op here to protect production; the work is now
+    # handled by the subsequent 'fixed' migration.
   end
 end

--- a/db/migrate/20260607150000_recalc_baseline_badge_percentages_fixed.rb
+++ b/db/migrate/20260607150000_recalc_baseline_badge_percentages_fixed.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Copyright the Linux Foundation and the
+# OpenSSF Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+class RecalcBaselineBadgePercentagesFixed < ActiveRecord::Migration[8.1]
+  def change
+    # Re-run the baseline badge percentage recalculation.
+    # This time it uses the updated Project.update_all_badge_percentages
+    # which skips validations, ensuring it completes even for projects
+    # with data that is now considered 'invalid' (e.g., legacy IP-based URLs).
+    Project.update_all_badge_percentages(Sections::BASELINE_LEVEL_NAMES)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_03_010000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_07_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"


### PR DESCRIPTION
Batch recalculation was failing on projects with dubious homepage_url data that violated modern validation rules, specifically, the recently added IP-based URL restrictions.

- Update Project.update_all_badge_percentages to use `save(validate: false)` to skip model validations during batch pre-calculation updates. This makes badge percentage update calculations more robust. The recalculation simply reuses already-accepted data, so we don't need to revalidate it, and in fact revalidating at *this* stage can cause updates to fail.
- Convert the original failing migration (20260602200801) to a no-op to protect production.
- Add a new 'fixed' migration (20260607150000) to safely perform the recalculation in all environments.

Assisted-By: Gemini