### PR TITLE
No reserved ip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,6 +135,7 @@ gem 'sprockets-rails', '3.5.2' # Rails. Asset precompilation
 gem 'terser', '~> 1.1', require: false # Minify JavaScript
 gem 'sentry-ruby' # Support Sentry real-time crash reporting
 gem 'sentry-rails' # Support Sentry real-time crash reporting
+gem 'ssrf_filter' # Ensure external URLs don't resolve to invalid IP addrs
 
 group :development, :test do
   gem 'awesome_print' # Pretty print Ruby objects

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -552,6 +552,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.5.0)
     stringio (3.2.0)
     terser (1.2.7)
       execjs (>= 0.3.0, < 3)
@@ -686,6 +687,7 @@ DEPENDENCIES
   solid_queue (~> 1.1)
   spring (~> 4.1)
   sprockets-rails (= 3.5.2)
+  ssrf_filter
   terser (~> 1.1)
   translation (= 1.41)
   vcr (< 5.1)

--- a/app/lib/evidence.rb
+++ b/app/lib/evidence.rb
@@ -4,19 +4,26 @@
 # OpenSSF Best Practices badge contributors
 # SPDX-License-Identifier: MIT
 
-require 'open-uri'
+require 'ssrf_filter'
 require 'security_utils'
 
+# This class collects and caches all evidence gathered so far on a project.
+# If parallel execution is possible, this class locks/unlocks so
+# parallel writing doesn't cause any harm.
+# It defends itself, e.g., from domain URLs that map to
+# reserved IP addresses.
+#
+# NOTE: The current plan is to remove this class, it's not helping much.
 class Evidence
-  # This class collects and caches all evidence gathered so far on a project.
-  # If parallel execution is possible, this class locks/unlocks so
-  # parallel writing doesn't cause any harm.
-
-  # NOTE: The current plan is to remove this class, it's not helping much.
-
-  def initialize(project)
+  # Initialize an Evidence collector for a project.
+  #
+  # @param project [Project] The ActiveRecord project instance.
+  # @param resolver [Proc, #resolve] Optional DNS resolver for ssrf_filter,
+  #   primarily for testing.
+  def initialize(project, resolver: nil)
     @project = project # ActiveRecord. Detectives should NOT change this.
     @cached_data = {}
+    @resolver = resolver
   end
 
   attr_reader :project
@@ -26,6 +33,12 @@ class Evidence
   MAXREAD = 1 * (2**20)
 
   # Get contents of given URL and return it (cached).
+  # Returns a hash with :meta (headers) and :body (content) if successful.
+  #
+  # @param url [String] The URL to fetch data from.
+  # @return [Hash, nil] The fetched data or nil if the URL is invalid or the
+  #   fetch fails.
+  #
   # TODO: Handle exceptions - turn into nothing useful.
   # TODO: Lock for parallel access. Possibly return while still reading.
   # TODO: Timeout on reads.
@@ -42,11 +55,36 @@ class Evidence
       end
 
       begin
-        URI.parse(url).open('rb') do |file|
-          @cached_data[url] = { meta: file.meta, body: file.read(MAXREAD) }
+        # Use ssrf_filter to ensure GET requests are not performed if the
+        # domain dynamically resolves (possibly via redirects) to a
+        # reserved IP address (IPv4 or IPv6) like 127.0.0.1.
+        # Note that ssrf_filter checks on *every* request; attackers might
+        # dynamically switch DNS resolution between valid and invalid
+        # IP addresses, which we catch by checking each time.
+        options = {}
+        options[:resolver] = @resolver if @resolver
+        SsrfFilter.get(url, options) do |res|
+          # Only process successful responses
+          if res.is_a?(Net::HTTPSuccess)
+            body = (+'').force_encoding('BINARY')
+            res.read_body do |chunk|
+              body << chunk
+              break if body.bytesize >= MAXREAD
+            end
+            # Truncate if we went over in the last chunk
+            body = body.byteslice(0, MAXREAD) if body.bytesize > MAXREAD
+
+            # meta in open-uri is a hash-like object of headers
+            # We convert Net::HTTP headers to a simple hash
+            meta = res.to_hash.transform_values { |v| v.join(', ') }
+            @cached_data[url] = { meta: meta, body: body }
+          else
+            @cached_data[url] = nil
+          end
         end
-      rescue
+      rescue SsrfFilter::Error, StandardError => e
         # Skip if error - use what we have, if anything.
+        Rails.logger.warn "Error fetching URL #{url}: #{e.message}"
         @cached_data[url] ||= nil
       end
     end

--- a/app/lib/evidence.rb
+++ b/app/lib/evidence.rb
@@ -20,10 +20,18 @@ class Evidence
   # @param project [Project] The ActiveRecord project instance.
   # @param resolver [Proc, #resolve] Optional DNS resolver for ssrf_filter,
   #   primarily for testing.
-  def initialize(project, resolver: nil)
+  # @param allow_private_ips [Boolean] If true, allow fetching from private
+  #   IP addresses (e.g., for internal use). Defaults to the value of the
+  #   ALLOW_PRIVATE_IPS environment variable.
+  def initialize(
+    project,
+    resolver: nil,
+    allow_private_ips: ENV['ALLOW_PRIVATE_IPS'] == 'true'
+  )
     @project = project # ActiveRecord. Detectives should NOT change this.
     @cached_data = {}
     @resolver = resolver
+    @allow_private_ips = allow_private_ips
   end
 
   attr_reader :project
@@ -54,41 +62,73 @@ class Evidence
         return
       end
 
-      begin
-        # Use ssrf_filter to ensure GET requests are not performed if the
-        # domain dynamically resolves (possibly via redirects) to a
-        # reserved IP address (IPv4 or IPv6) like 127.0.0.1.
-        # Note that ssrf_filter checks on *every* request; attackers might
-        # dynamically switch DNS resolution between valid and invalid
-        # IP addresses, which we catch by checking each time.
-        options = {}
-        options[:resolver] = @resolver if @resolver
-        SsrfFilter.get(url, options) do |res|
-          # Only process successful responses
-          if res.is_a?(Net::HTTPSuccess)
-            body = (+'').force_encoding('BINARY')
-            res.read_body do |chunk|
-              body << chunk
-              break if body.bytesize >= MAXREAD
-            end
-            # Truncate if we went over in the last chunk
-            body = body.byteslice(0, MAXREAD) if body.bytesize > MAXREAD
-
-            # meta in open-uri is a hash-like object of headers
-            # We convert Net::HTTP headers to a simple hash
-            meta = res.to_hash.transform_values { |v| v.join(', ') }
-            @cached_data[url] = { meta: meta, body: body }
-          else
-            @cached_data[url] = nil
-          end
-        end
-      rescue SsrfFilter::Error, StandardError => e
-        # Skip if error - use what we have, if anything.
-        Rails.logger.warn "Error fetching URL #{url}: #{e.message}"
-        @cached_data[url] ||= nil
+      # We normally use ssrf_filter to ensure GET requests are not performed
+      # if the domain dynamically resolves to a reserved IP address.
+      # However, we allow this to be disabled (e.g., for internal use).
+      if @allow_private_ips
+        get_insecure(url)
+      else
+        get_secure(url)
       end
     end
     @cached_data[url]
   end
   # rubocop:enable Metrics/MethodLength
+
+  private
+
+  # Extract the body from the response, respecting MAXREAD.
+  def extract_body(res)
+    body = (+'').force_encoding('BINARY')
+    res.read_body do |chunk|
+      body << chunk
+      break if body.bytesize >= MAXREAD
+    end
+    # Truncate if we went over in the last chunk
+    body.byteslice(0, MAXREAD)
+  end
+
+  # Perform a secure GET request using ssrf_filter.
+  # rubocop:disable Metrics/MethodLength
+  def get_secure(url)
+    # Use ssrf_filter to ensure GET requests are not performed if the
+    # domain dynamically resolves (possibly via redirects) to a
+    # reserved IP address (IPv4 or IPv6) like 127.0.0.1.
+    # Note that ssrf_filter checks on *every* request; attackers might
+    # dynamically switch DNS resolution between valid and invalid
+    # IP addresses, which we catch by checking each time.
+    options = {}
+    options[:resolver] = @resolver if @resolver
+    SsrfFilter.get(url, options) do |res|
+      # Only process successful responses
+      if res.is_a?(Net::HTTPSuccess)
+        body = extract_body(res)
+        # meta in open-uri is a hash-like object of headers
+        # We convert Net::HTTP headers to a simple hash
+        meta = res.to_hash.transform_values { |v| v.join(', ') }
+        @cached_data[url] = { meta: meta, body: body }
+      else
+        @cached_data[url] = nil
+      end
+    end
+  rescue SsrfFilter::Error, StandardError => e
+    # Skip if error - use what we have, if anything.
+    Rails.logger.warn "Error fetching URL #{url}: #{e.message}"
+    @cached_data[url] ||= nil
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  # Perform an insecure GET request (allows private IPs) using open-uri.
+  # This is only used if ALLOW_PRIVATE_IPS is set.
+  def get_insecure(url)
+    require 'open-uri'
+    begin
+      URI.parse(url).open('rb') do |file|
+        @cached_data[url] = { meta: file.meta, body: file.read(MAXREAD) }
+      end
+    rescue StandardError => e
+      Rails.logger.warn "Error fetching URL #{url} (insecure): #{e.message}"
+      @cached_data[url] ||= nil
+    end
+  end
 end

--- a/test/unit/lib/evidence_test.rb
+++ b/test/unit/lib/evidence_test.rb
@@ -70,4 +70,22 @@ class EvidenceTest < ActiveSupport::TestCase
       assert result[:body].bytesize <= Evidence::MAXREAD
     end
   end
+
+  test 'get blocks SSRF resolving to private IP (offline-safe)' do
+    # nip.io is a service that resolves to the IP address in the subdomain.
+    # In this test we intercept the DNS request with a mock
+    # (so we don't actually do the lookup), but an attacker
+    # really *could* use a domain name like this to redirect to localhost.
+    url = 'http://127.0.0.1.nip.io'
+
+    # Mock resolver resolves our target to a private IP
+    mock_resolver = lambda { |hostname|
+      hostname == 'ssrf-target.local' ? [IPAddr.new('127.0.0.1')] : []
+    }
+
+    evidence_with_mock = Evidence.new(@project, resolver: mock_resolver)
+
+    result = evidence_with_mock.get(url)
+    assert_nil result
+  end
 end

--- a/test/unit/lib/evidence_test.rb
+++ b/test/unit/lib/evidence_test.rb
@@ -79,13 +79,44 @@ class EvidenceTest < ActiveSupport::TestCase
     url = 'http://127.0.0.1.nip.io'
 
     # Mock resolver resolves our target to a private IP
-    mock_resolver = lambda { |hostname|
-      hostname == 'ssrf-target.local' ? [IPAddr.new('127.0.0.1')] : []
-    }
+    mock_resolver =
+      lambda do |hostname|
+        hostname == '127.0.0.1.nip.io' ? [IPAddr.new('127.0.0.1')] : []
+      end
 
     evidence_with_mock = Evidence.new(@project, resolver: mock_resolver)
 
     result = evidence_with_mock.get(url)
+    assert_nil result
+  end
+
+  test 'get allows private IP if allow_private_ips is true' do
+    # We'll use a URL that is NOT dubious but resolves to a private IP.
+    url = 'http://private-target.local'
+
+    evidence_insecure = Evidence.new(@project, allow_private_ips: true)
+
+    # Mock the request using WebMock
+    stub_request(:get, url).to_return(
+      status: 200,
+      body: 'Insecure content',
+      headers: { 'Content-Type' => 'text/plain' }
+    )
+
+    result = evidence_insecure.get(url)
+    assert_not_nil result
+    assert_equal 'Insecure content', result[:body]
+    # In open-uri, meta returns a hash-like object.
+    # Our get_insecure uses file.meta directly.
+    assert_not_nil result[:meta]
+  end
+
+  test 'get_insecure handles errors gracefully' do
+    url = 'http://nonexistent.local'
+    evidence_insecure = Evidence.new(@project, allow_private_ips: true)
+
+    # URI.open will raise an error for nonexistent hosts
+    result = evidence_insecure.get(url)
     assert_nil result
   end
 end


### PR DESCRIPTION
Protect against dynamic DNS nonsense, where a "good" domain actually redirects (directly or indirectly) to reserved IP addresses. That shouldn't be exploitable anyway (our "internal" network doesn't just automatically trust requests because they're inside), but it's better to completely prevent the attack in the first place. This solution avoids race conditions, by using a gem specifically designed to solve it.