### PR TITLE
Fail test suite if < 100% statement coverage

### DIFF
--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -977,6 +977,7 @@ task 'test:coverage_gaps' do
   end
 
   puts 'All files have 100% statement coverage.' unless gaps_found
+  fail 'Untested production code statements exist.' if gaps_found
 end
 
 # This is the task to run every day, e.g., to record statistics

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -977,7 +977,7 @@ task 'test:coverage_gaps' do
   end
 
   puts 'All files have 100% statement coverage.' unless gaps_found
-  fail 'Untested production code statements exist.' if gaps_found
+  raise StandardError, 'Has untested production code statements.' if gaps_found
 end
 
 # This is the task to run every day, e.g., to record statistics


### PR DESCRIPTION
Rake task test:optimized executes the unit tests *and* system tests. We treat anything less than 100% combined statement coverage of the production code as a failure.

By ensuring that we run at least one test on each line, we eliminate a lot of nonsense. Boris Beizer would be proud.

Sadly, AI systems don't always view the "FAILURE" report as a real failure.

Therefore, this commit modifies the gap coverage report so it's
 *expressly* considered a failure when there is a coverage gap.
In particular, now there's a failure exit code when this occurs. This way the failure to cover everything isn't so easily ignored.