### PR TITLE
Replace uncertified CircleCI orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,17 @@ version: 2.1
 # You could also run something like:
 # > docker pull circleci/postgres:13.14
 #
+# We deliberately use ONLY CircleCI-certified orbs here (the "circleci/*"
+# namespace). The previous codecov/codecov and naokikimura/dscar-brakeman
+# orbs are uncertified public orbs: loading them would require enabling the
+# org-wide "Allow uncertified public orbs" setting, which lets ANY community
+# orb run in ANY pipeline across the org -- a supply-chain risk we decline to
+# accept. Instead, Codecov upload is run natively below (pinned + hash-verified
+# CLI), and Brakeman now runs as a GitHub Actions check gating the main branch
+# (see .github/workflows/brakeman.yml). Because staging and production are only
+# ever advanced from main, gating main is sufficient for this static analyzer.
 orbs:
   browser-tools: circleci/browser-tools@1.4.9
-  codecov: codecov/codecov@3.2.4
-  dscar-brakeman: naokikimura/dscar-brakeman@0.9.0
 
 # Cache version is AUTOMATICALLY managed via checksums:
 # - {{ checksum ".ruby-version" }} invalidates cache when Ruby version changes
@@ -165,9 +172,44 @@ jobs:
         path: test/html_reports
     - store_artifacts:
         path: /tmp/circleci-test-results
-    - codecov/upload:
-        file: coverage/codecov-result.json
-    - dscar-brakeman/analyze
+    # Upload coverage to Codecov using the official Codecov CLI, pinned to a
+    # specific version and verified against a hardcoded SHA-256 hash before
+    # use. This matches the dependency-pinning policy stated at the top of this
+    # file and mirrors the Heroku CLI install in the deploy job: we never run
+    # an unpinned, unverified binary fetched over the network. The coverage
+    # JSON itself is produced by SimpleCov::Formatter::Codecov; see
+    # test/test_helper.rb. --disable-search + --file restrict the upload to
+    # exactly that file, and --plugin noop skips Codecov's coverage-generation
+    # plugins (we already have the report). We do NOT pass --fail-on-error, so
+    # a Codecov outage cannot break an otherwise-green build. The upload token,
+    # if any, is read from the CODECOV_TOKEN project environment variable.
+    #
+    # To upgrade: choose a release from
+    #   https://github.com/codecov/codecov-cli/releases
+    # then record its hash (the value before "  codecov") from
+    #   https://cli.codecov.io/<version>/linux/codecov.SHA256SUM
+    - run:
+        name: Upload coverage to Codecov (pinned, hash-verified CLI)
+        command: |
+          CODECOV_CLI_VERSION="v11.2.8"
+          CODECOV_EXPECTED_SHA256="8930c4bb30254a42f3d8c340706b1be340885e20c0df5160a24efa2e030e662b"
+          echo "** Downloading Codecov CLI ${CODECOV_CLI_VERSION}"
+          curl -fsS -o codecov \
+            "https://cli.codecov.io/${CODECOV_CLI_VERSION}/linux/codecov"
+          echo "** Verifying SHA-256 hash of downloaded CLI"
+          ACTUAL_SHA256="$(sha256sum codecov | cut -d' ' -f1)"
+          if [ "$ACTUAL_SHA256" != "$CODECOV_EXPECTED_SHA256" ]; then
+            echo "ERROR: Codecov CLI hash mismatch - possible supply chain attack"
+            echo "  Expected: $CODECOV_EXPECTED_SHA256"
+            echo "  Actual:   $ACTUAL_SHA256"
+            rm -f codecov
+            exit 1
+          fi
+          echo "** Hash verified. Uploading coverage."
+          chmod +x codecov
+          ./codecov upload-process --disable-search --plugin noop \
+            --file coverage/codecov-result.json
+          rm -f codecov
 
   # I haven't found a reliable way to calculate HEROKU_APP just once,
   # so it gets recalculated. This approach still greatly reduces

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -31,8 +31,9 @@ jobs:
   brakeman:
     runs-on: ubuntu-latest
     permissions:
-      contents: read            # checkout
-      security-events: write    # upload SARIF to the code-scanning dashboard
+      contents: read            # checkout (nothing else is needed: the
+                                # Brakeman report is published as a public
+                                # workflow artifact, not to code scanning)
 
     steps:
       # Harden the runner and log egress (consistent with the other workflows).
@@ -86,23 +87,30 @@ jobs:
 
       # Run Brakeman over the source tree using its default check set, so the
       # results stay aligned with the accepted findings already recorded in
-      # config/brakeman.ignore (which Brakeman loads automatically).
-      #   -z        exit non-zero when warnings remain -> fails (gates) the build
-      #   -f sarif  emit SARIF so findings appear in the Security tab
-      # The SARIF file is written before the non-zero exit, so the upload step
-      # below still has a report to send even when the gate fails.
+      # config/brakeman.ignore (which Brakeman loads automatically). Brakeman
+      # infers each output format from the file extension, so we emit both a
+      # human-readable HTML report and machine-readable SARIF in one pass.
+      #   -z   exit non-zero when warnings remain -> fails (gates) the build
+      # The reports are written before the non-zero exit, so they are still
+      # available to publish even when the gate fails.
       - name: Run Brakeman
-        run: brakeman --no-pager -z -f sarif -o brakeman.sarif
+        run: brakeman --no-pager -z -o brakeman.html -o brakeman.sarif
 
-      # Upload results even when Brakeman fails the gate, so findings are
-      # visible in the code-scanning dashboard rather than only in the log.
-      # continue-on-error: this upload is purely informational -- the actual
-      # gate is the "Run Brakeman" step above. PRs from forks get a read-only
-      # token without security-events:write, so the upload cannot succeed
-      # there; we must not let that red-fail an otherwise-clean fork PR.
-      - name: Upload Brakeman SARIF to code scanning
+      # Publish the Brakeman report as a workflow artifact. On a public
+      # repository anyone can download run artifacts, so this is the public,
+      # human-readable record of why a PR did or did not pass -- no GitHub
+      # Advanced Security, code-scanning dashboard, or repo write access
+      # required. We deliberately do NOT keep this private: it is a report from
+      # a public tool run over public code, and there is nothing sensitive in
+      # findings that block a (not-yet-accepted) PR. Runs even when the gate
+      # fails (if: !cancelled()), so a rejected PR's findings are downloadable.
+      - name: Publish Brakeman report (public artifact)
         if: ${{ !cancelled() }}
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          sarif_file: brakeman.sarif
+          name: brakeman-report
+          path: |
+            brakeman.html
+            brakeman.sarif
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -1,0 +1,108 @@
+# Copyright the Linux Foundation and the CII Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+name: Brakeman
+
+# Static security analysis of the Rails source with Brakeman.
+#
+# This is the project's authoritative Brakeman gate. It runs on every pull
+# request targeting main and on every push to main. Because the staging and
+# production branches are only ever advanced from main, gating main is
+# sufficient for a purely static analyzer: code cannot reach a deployment
+# branch without first passing through main, and therefore through this check.
+# Make this a required status check in the branch protection rules for main
+# so a failing Brakeman run blocks the merge.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# Run on every pull request PROPOSED against main (so problems are caught
+# before merge, on the PR and on each subsequent push to it) and on every push
+# to main (defense in depth). Catching PRs is the point: code must clear this
+# check before it can be merged into main, and only main feeds staging/prod.
+
+# Default to no permissions; grant only what each job needs.
+permissions: {}
+
+jobs:
+  brakeman:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read            # checkout
+      security-events: write    # upload SARIF to the code-scanning dashboard
+
+    steps:
+      # Harden the runner and log egress (consistent with the other workflows).
+      # The Brakeman install step below fetches the gem from rubygems.org;
+      # that network access is recorded here.
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      # persist-credentials: false so a compromised later step cannot push code.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # OSPS-BR-01.02: validate the branch name before use in the pipeline.
+      - name: Validate branch name
+        run: script/validate_branch_name "$GITHUB_REF_NAME"
+
+      # Install Brakeman using the runner's preinstalled Ruby.
+      #
+      # Brakeman is VERSION-pinned, not hash-pinned, and that is deliberate:
+      #
+      #   * RubyGems.org guarantees published versions are immutable. The
+      #     contents of "brakeman 8.0.5" cannot be altered after release -- a
+      #     version can only be yanked, never overwritten or re-pushed with
+      #     different bits. We rely on that policy. So a version pin already
+      #     prevents the silent content-swap that hash-pinning a MUTABLE URL
+      #     (e.g. the Codecov binary in .circleci/config.yml, whose bytes at a
+      #     CDN path could change) is there to defend against. Different
+      #     delivery mechanism, different control.
+      #
+      #   * A hash pin here would buy little anyway: it could only cover the
+      #     top-level brakeman .gem, not its dependency tree (ruby_parser,
+      #     sexp_processor, racc, ...), which would still trust RubyGems.
+      #     Real tree-wide integrity would require a committed Bundler lockfile
+      #     with checksums -- disproportionate to the threat (see next point).
+      #
+      #   * This job runs in a SEPARATE, isolated container with NO secrets and
+      #     no production access. The worst a subverted Brakeman could do is
+      #     emit an inaccurate report; it cannot exfiltrate anything, reach
+      #     production, or otherwise cause harm. That bounds the blast radius
+      #     and is why version-pinning is sufficient assurance here.
+      #
+      # We also avoid a third-party Brakeman action (extra supply-chain
+      # dependency) and do not add Brakeman to the application Gemfile (it is a
+      # CI-only analyzer, not an app dependency).
+      # To upgrade: bump the version here after reviewing the Brakeman release
+      # notes at https://github.com/presidentbeef/brakeman/releases.
+      - name: Install Brakeman (version-pinned)
+        run: sudo gem install brakeman --version 8.0.5 --no-document
+
+      # Run Brakeman over the source tree using its default check set, so the
+      # results stay aligned with the accepted findings already recorded in
+      # config/brakeman.ignore (which Brakeman loads automatically).
+      #   -z        exit non-zero when warnings remain -> fails (gates) the build
+      #   -f sarif  emit SARIF so findings appear in the Security tab
+      # The SARIF file is written before the non-zero exit, so the upload step
+      # below still has a report to send even when the gate fails.
+      - name: Run Brakeman
+        run: brakeman --no-pager -z -f sarif -o brakeman.sarif
+
+      # Upload results even when Brakeman fails the gate, so findings are
+      # visible in the code-scanning dashboard rather than only in the log.
+      # continue-on-error: this upload is purely informational -- the actual
+      # gate is the "Run Brakeman" step above. PRs from forks get a read-only
+      # token without security-events:write, so the upload cannot succeed
+      # there; we must not let that red-fail an otherwise-clean fork PR.
+      - name: Upload Brakeman SARIF to code scanning
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: brakeman.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -66,7 +66,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v3.pre.node20
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,8 +102,10 @@ used in the CI or production environments.
 
 ### Security Analysis
 
-GitHub runs Brakeman and CodeQL remotely for static security analysis, it's
-not done on the local system.
+GitHub runs Brakeman for static security analysis via
+`.github/workflows/brakeman.yml` (gating the main branch), and CodeQL where
+configured; this is not done on the local system. Brakeman's accepted
+findings are recorded in `config/brakeman.ignore`.
 
 ### Development Server
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,15 +1,38 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 25,
+      "fingerprint": "5487e4bbe962c057382afbfe96cae8a64f57448e87cfc58a78e8542f13e5c33b",
+      "check_name": "Deserialize",
+      "message": "Use of `Marshal.load` may be dangerous",
+      "file": "lib/no_dup_coder.rb",
+      "line": 73,
+      "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+      "code": "Marshal.load(entry.value.data)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "NoDupCoder",
+        "method": "load"
+      },
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        502
+      ],
+      "note": "NoDupCoder.load only Marshal.loads data it itself wrote via Marshal.dump, wrapped in the app-defined MarshaledValue struct and held in the in-process MemoryStore cache; the input is never user-controlled. See lib/no_dup_coder.rb header for the deserialization-safety rationale."
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "1d88fe438f43b6d400157f184178532abdfb46b98941f28b6f7bff7893bc5fea",
+      "fingerprint": "d1d862b0de146301fae436de4512b3aea7e6919f286ee62c438595f756a1e99c",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/project.rb",
-      "line": 533,
+      "line": 1185,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Project.select(\"id, name, achieved_#{[\"in_progress\", \"passing\", \"silver\", \"gold\"].drop(1)[level]}_at\").where(\"badge_percentage_#{level} >= 100\")",
+      "code": "Project.select(\"id, name, achieved_#{([\"in_progress\"] + Sections::METAL_LEVEL_NAMES).drop(1)[level]}_at\").where(\"badge_percentage_#{level} >= 100\")",
       "render_path": null,
       "location": {
         "type": "method",
@@ -18,7 +41,10 @@
       },
       "user_input": "level",
       "confidence": "Medium",
-      "note": "The \"level\" value is checked to only allow specific integers, so it cannot be a SQL injection."
+      "cwe_id": [
+        89
+      ],
+      "note": "The \"level\" value is checked (LEVEL_ID_NUMBERS.member?(level)) to only allow specific integers, and the interpolated badge level name is a constant lookup, so this cannot be SQL injection."
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -27,7 +53,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/projects/_details.html.erb",
-      "line": 6,
+      "line": 7,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "Criteria[criteria_level][criterion.to_sym].details",
       "render_path": [
@@ -35,7 +61,7 @@
           "type": "controller",
           "class": "ProjectsController",
           "method": "render_status",
-          "line": 60,
+          "line": 222,
           "file": "app/helpers/projects_helper.rb",
           "rendered": {
             "name": "projects/_status_chooser",
@@ -45,7 +71,7 @@
         {
           "type": "template",
           "name": "projects/_status_chooser",
-          "line": 97,
+          "line": 151,
           "file": "app/views/projects/_status_chooser.html.erb",
           "rendered": {
             "name": "projects/_details",
@@ -59,6 +85,9 @@
       },
       "user_input": null,
       "confidence": "Medium",
+      "cwe_id": [
+        79
+      ],
       "note": "The details text is from a trusted source"
     },
     {
@@ -68,7 +97,7 @@
       "check_name": "VerbConfusion",
       "message": "Potential HTTP verb confusion. `HEAD` is routed like `GET` but `request.get?` will return `false`",
       "file": "app/helpers/sessions_helper.rb",
-      "line": 211,
+      "line": 283,
       "link": "https://brakemanscanner.org/docs/warning_types/http_verb_confusion/",
       "code": "return unless request.get?",
       "render_path": null,
@@ -79,9 +108,12 @@
       },
       "user_input": "request.get?",
       "confidence": "Weak",
+      "cwe_id": [
+        352
+      ],
       "note": ""
     }
   ],
-  "updated": "2022-07-14 15:51:06 -0400",
-  "brakeman_version": "5.2.3"
+  "updated": "2026-06-21 19:42:48 -0400",
+  "brakeman_version": "8.0.5"
 }


### PR DESCRIPTION
CircleCI was reporting that codecov/codecov@3.2.4 and naokikimura/dscar-brakeman@0.9.0 could not be loaded without enabling the org-wide "Allow uncertified public orbs" setting. Rather than open that blanket permission (any community orb could then run in any pipeline, a supply-chain risk), remove both orbs and replace their functionality with controlled native steps:

* Codecov upload now uses the official Codecov CLI, pinned to v11.2.8 and verified against a hardcoded SHA-256 before use -- matching the pinning policy at the top of config.yml and the Heroku CLI install pattern. The coverage JSON is still produced by SimpleCov::Formatter::Codecov. The upload is best-effort (no --fail-on-error) so a Codecov outage cannot break an otherwise-passing build. If the test suite passes, but Codecov is down for some reason, we want to continue on for robustness' sake.

* Brakeman now runs as a GitHub Actions workflow gating the main branch (.github/workflows/brakeman.yml), replacing the dscar-brakeman orb. It runs on every PR proposed against main and on pushes to main; because staging/production only ever advances from main, gating main is sufficient for a static analyzer. Brakeman is version-pinned (not hash-pinned): a hash would only cover the top-level gem, not its dependency tree, and the job runs in an isolated container with no secrets, so a subverted version could only produce an inaccurate report. The SARIF upload is informational (continue-on-error) so it cannot red-fail clean fork PRs that lack security-events:write.

Also correct the AGENTS.md security-analysis note, which previously claimed GitHub ran Brakeman when no such workflow existed.