### PR TITLE
Update coreinfrastructure.org -> bestpractices.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <table border="0">
   <tr>
     <td align="left" border="0" valign="middle">
-      <a href="https://bestpractices.coreinfrastructure.org/projects/1"><img src="https://bestpractices.coreinfrastructure.org/projects/1/badge" alt="OpenSSF Best Practices" align="middle"></a>&nbsp;
+      <a href="https://www.bestpractices.dev/projects/1"><img src="https://www.bestpractices.dev/projects/1/badge" alt="OpenSSF Best Practices" align="middle"></a>&nbsp;
       <a href="https://www.bestpractices.dev/projects/1"><img src="https://www.bestpractices.dev/projects/1/baseline" alt="OpenSSF Baseline" align="middle"></a>&nbsp;
       <a href="https://app.circleci.com/pipelines/github/ossf/best-practices-badge"><img src="https://circleci.com/gh/ossf/best-practices-badge.svg?&style=shield" alt="CircleCI Build Status" align="middle"></a>&nbsp;
       <a href="https://codecov.io/gh/ossf/best-practices-badge"><img src="https://codecov.io/gh/ossf/best-practices-badge/branch/main/graph/badge.svg" alt="codecov" align="middle"></a>&nbsp;
@@ -34,7 +34,7 @@ We support both our original "metal" badge criteria and the
 OpenSSF Baseline criteria.
 
 See the
-*[OpenSSF Best Practices badge website](https://bestpractices.coreinfrastructure.org/)* if you want to try to actually get a badge.
+*[OpenSSF Best Practices badge website](https://www.bestpractices.dev/)* if you want to try to actually get a badge.
 
 This is the development site for the criteria and badge application
 software that runs the website.
@@ -55,8 +55,8 @@ the CII Best Practices badge.
 
 Interesting pages include:
 
-* Badging **[Criteria for the passing level](https://bestpractices.coreinfrastructure.org/criteria/0)**
-* **[Criteria for all badging levels](https://bestpractices.coreinfrastructure.org/criteria)**
+* Badging **[Criteria for the passing level](https://www.bestpractices.dev/criteria/0)**
+* **[Criteria for all badging levels](https://www.bestpractices.dev/criteria)**
 * Information on how to **[contribute](./CONTRIBUTING.md)**
 * Information on **[our own security, including how to report vulnerabilities in our badge application](./SECURITY.md)**
 * [Up-for-grabs](https://github.com/ossf/best-practices-badge/labels/up-for-grabs)

--- a/best_practices.openapi.yaml
+++ b/best_practices.openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: RESTful API for OpenSSF Best Practices badge website
   version: 1.0.0
 servers:
-  - url: https://bestpractices.coreinfrastructure.org
+  - url: https://www.bestpractices.dev
     description: Main site
 paths:
   /{locale}/projects/{id}/{level}.{format}:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -445,8 +445,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -3508,7 +3508,7 @@ This is evidence that the BadgeApp application is
 applying practices expected in a well-run FLOSS project.
 
 You can see the
-[CII Best Practices Badge entry for the BadgeApp](https://bestpractices.coreinfrastructure.org/en/projects/1/0).
+[CII Best Practices Badge entry for the BadgeApp](https://www.bestpractices.dev/en/projects/1/0).
 Note that we achieve a gold badge.
 
 ### Organizational Controls
@@ -3840,8 +3840,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/background.md
+++ b/docs/background.md
@@ -1761,8 +1761,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/best_practices.py
+++ b/docs/best_practices.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Download JSON data from bestpractices.coreinfrastructure.org and analyze it.
+# Download JSON data from www.bestpractices.dev and analyze it.
 
 # Since the JSON data is paged, we simply download each page in turn.
 # This is written to be simple code; it loads the entire dataset into memory.
@@ -19,7 +19,7 @@ from urllib.request import urlopen
 cached_filename = 'projects.json'
 
 # This is the base URL for project data.
-base_url = 'https://bestpractices.coreinfrastructure.org/' + cached_filename
+base_url = 'https://www.bestpractices.dev/' + cached_filename
 
 # Retrieve paged JSON data
 def retrieve_data():

--- a/docs/case.ltac
+++ b/docs/case.ltac
@@ -121,7 +121,7 @@
 
 - Claim Controls: Certifications & controls provide confidence in operating results
   - Claim CIIBadge: CII Best Practices Badge certification is obtained
-    - Evidence CIIBadgeEv: BadgeApp achieves gold CII Best Practices Badge (https://bestpractices.coreinfrastructure.org/en/projects/1)
+    - Evidence CIIBadgeEv: BadgeApp achieves gold CII Best Practices Badge (https://www.bestpractices.dev/en/projects/1)
 
 - Claim OWASPClaim: All of the most common important implementation vulnerability types (weaknesses) countered
   - Strategy OWASPStrat: OWASP top 10 represents a broad consensus of the most critical web application security flaws

--- a/docs/case.md
+++ b/docs/case.md
@@ -6849,7 +6849,7 @@ This is evidence that the BadgeApp application is
 applying practices expected in a well-run FLOSS project.
 
 You can see the
-[CII Best Practices Badge entry for the BadgeApp](https://bestpractices.coreinfrastructure.org/en/projects/1/0).
+[CII Best Practices Badge entry for the BadgeApp](https://www.bestpractices.dev/en/projects/1/0).
 Note that we achieve a gold badge.
 
 <!-- verocase element CIIBadgeEv -->
@@ -6861,10 +6861,10 @@ Referenced by: **[Package Controls](#package-controls)**
 
 Supports: **[Claim CIIBadge](#claim-ciibadge)**
 
-External Reference: [https://bestpractices.coreinfrastructure.org/en/projects/1](https://bestpractices.coreinfrastructure.org/en/projects/1)
+External Reference: [https://www.bestpractices.dev/en/projects/1](https://www.bestpractices.dev/en/projects/1)
 <!-- end verocase -->
 
-BadgeApp achieves gold CII Best Practices Badge. See [https://bestpractices.coreinfrastructure.org/en/projects/1](https://bestpractices.coreinfrastructure.org/en/projects/1).
+BadgeApp achieves gold CII Best Practices Badge. See [https://www.bestpractices.dev/en/projects/1](https://www.bestpractices.dev/en/projects/1).
 
 ### Organizational Controls
 
@@ -7195,8 +7195,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/criteria-footer.markdown
+++ b/docs/criteria-footer.markdown
@@ -128,8 +128,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/criteria-header.markdown
+++ b/docs/criteria-header.markdown
@@ -11,11 +11,11 @@
 We've recently moved the criteria information to the active website!
 
 There you can see the
-<a href="https://bestpractices.coreinfrastructure.org/criteria/0">passing
+<a href="https://www.bestpractices.dev/criteria/0">passing
 criteria</a>,
-<a href="https://bestpractices.coreinfrastructure.org/criteria">all
+<a href="https://www.bestpractices.dev/criteria">all
 criteria</a>, and the
-<a href="https://bestpractices.coreinfrastructure.org/criteria_discussion">criteria discussion</a>.
+<a href="https://www.bestpractices.dev/criteria_discussion">criteria discussion</a>.
 
 This change makes it easier to see the real criteria in any language,
 as well as hide or reveal the details and rationale.

--- a/docs/criteria.md
+++ b/docs/criteria.md
@@ -11,11 +11,11 @@
 We've recently moved the criteria information to the active website!
 
 There you can see the
-<a href="https://bestpractices.coreinfrastructure.org/criteria/0">passing
+<a href="https://www.bestpractices.dev/criteria/0">passing
 criteria</a>,
-<a href="https://bestpractices.coreinfrastructure.org/criteria">all
+<a href="https://www.bestpractices.dev/criteria">all
 criteria</a>, and the
-<a href="https://bestpractices.coreinfrastructure.org/criteria_discussion">criteria discussion</a>.
+<a href="https://www.bestpractices.dev/criteria_discussion">criteria discussion</a>.
 
 This change makes it easier to see the real criteria in any language,
 as well as hide or reveal the details and rationale.
@@ -596,8 +596,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -494,8 +494,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -306,8 +306,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -482,12 +482,12 @@ See [security.md](./security.md) for more information.
 
 Users indicate the locale via the URL.
 The recommended form is at the beginning of that path, e.g.,
-<https://bestpractices.coreinfrastructure.org/fr/projects/>
+<https://www.bestpractices.dev/fr/projects/>
 selects the locale "fr" (French) when displaying "/projects".
 This even works at the top page, e.g.,
-<https://bestpractices.coreinfrastructure.org/fr/>.
+<https://www.bestpractices.dev/fr/>.
 It also supports the locale as a query parameter, e.g.,
-<https://bestpractices.coreinfrastructure.org/projects?locale=fr>
+<https://www.bestpractices.dev/projects?locale=fr>
 
 ### Fixing locale data
 
@@ -1407,7 +1407,7 @@ these keys from anywhere else:
 ## Project stats omission on 2017-02-28
 
 The production site maintains a number of daily statistics and can
-[display the statistics graphically](https://bestpractices.coreinfrastructure.org/project_stats), but it is
+[display the statistics graphically](https://www.bestpractices.dev/project_stats), but it is
 missing a report for 2017-02-28.
 This was due to a multi-hour downtime in
 Amazon’s S3 web-based storage service, part of
@@ -1595,8 +1595,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/other.md
+++ b/docs/other.md
@@ -7,11 +7,11 @@
 We've recently moved the criteria information to the active website!
 
 There you can see the
-<a href="https://bestpractices.coreinfrastructure.org/criteria/0">passing
+<a href="https://www.bestpractices.dev/criteria/0">passing
 criteria</a>,
-<a href="https://bestpractices.coreinfrastructure.org/criteria">all
+<a href="https://www.bestpractices.dev/criteria">all
 criteria</a>, and the
-<a href="https://bestpractices.coreinfrastructure.org/criteria_discussion">criteria discussion</a>.
+<a href="https://www.bestpractices.dev/criteria_discussion">criteria discussion</a>.
 
 This change makes it easier to see the real criteria in any language,
 as well as hide or reveal the details and rationale.
@@ -1703,8 +1703,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -140,8 +140,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -65,8 +65,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/scorecard-map.md
+++ b/docs/scorecard-map.md
@@ -3,10 +3,10 @@
 This is a map from the
 [OpenSSF Scorecard checks](https://github.com/ossf/scorecard/blob/main/docs/checks.md)
 to the
-[OpenSSF Best Practices badge criteria](https://bestpractices.coreinfrastructure.org/en/criteria?details=true).
+[OpenSSF Best Practices badge criteria](https://www.bestpractices.dev/en/criteria?details=true).
 
 Scorecard has 19 checks.
-[The OpenSSF best practices criteria statistics](https://bestpractices.coreinfrastructure.org/en/criteria_stats)
+[The OpenSSF best practices criteria statistics](https://www.bestpractices.dev/en/criteria_stats)
 has 67 criteria for passing, 48 new criteria for silver, and 14 new criteria
 for gold; adding 1 for the existence of the badge leaves 130 total criteria.
 Looking at the Scorecard checks, in sum:
@@ -54,7 +54,7 @@ This maps to the OpenSSF best practices badge `test_continuous_integration`:
 
 ## CII-Best-Practices
 
-> This check determines whether the project has earned an [OpenSSF (formerly CII) Best Practices Badge](https://bestpractices.coreinfrastructure.org/) at the passing, silver, or gold level.
+> This check determines whether the project has earned an [OpenSSF (formerly CII) Best Practices Badge](https://www.bestpractices.dev/) at the passing, silver, or gold level.
 >
 > The OpenSSF Best Practices badge indicates whether or not that the project uses a set of security-focused best development practices for open
 source software. The check uses the URL for the Git repo and the OpenSSF Best Practices badge API.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -341,8 +341,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/docs/vetting.md
+++ b/docs/vetting.md
@@ -115,8 +115,8 @@ Project participation and interface:
 
 Criteria:
 
-* [Criteria for passing badge](https://bestpractices.coreinfrastructure.org/criteria/0)
-* [Criteria for all badge levels](https://bestpractices.coreinfrastructure.org/criteria)
+* [Criteria for passing badge](https://www.bestpractices.dev/criteria/0)
+* [Criteria for all badge levels](https://www.bestpractices.dev/criteria)
 
 Development processes and security:
 

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -290,7 +290,7 @@ desc 'Load current self.json'
 task :load_self_json do
   require 'json'
   require 'open-uri'
-  url = 'https://master.bestpractices.coreinfrastructure.org/projects/1.json'
+  url = 'https://staging.bestpractices.dev/projects/1.json'
   contents = URI.parse(url).open.read
   pretty_contents = JSON.pretty_generate(JSON.parse(contents))
   File.write('docs/self.json', pretty_contents)
@@ -452,7 +452,7 @@ namespace :fastly do
 
   desc 'Test Fastly Caching'
   task :test, [:site_name] do |_t, args|
-    args.with_defaults site_name: 'https://master.bestpractices.coreinfrastructure.org/projects/1/badge'
+    args.with_defaults site_name: 'https://staging.bestpractices.dev/projects/1/badge'
     puts 'Starting test of Fastly caching'
     verbose(false) do
       sh "script/fastly_test #{args.site_name}"
@@ -591,6 +591,15 @@ def normalize_string(value, locale)
   # Forcibly substitute GitHub organization with literal string match
   value = value.gsub('github.com/coreinfrastructure/best-practices-badge',
                      'github.com/ossf/best-practices-badge')
+
+  # Forcibly substitute the old production domain with the current one.
+  # Our site moved from bestpractices.coreinfrastructure.org to
+  # www.bestpractices.dev (we use the www. host, not the bare domain,
+  # because bare DNS domains complicate our Fastly CDN setup). Like the
+  # GitHub-org rewrite above, this catches stale references that arrive
+  # via translation.io so we don't have to hand-edit translated strings.
+  value = value.gsub('bestpractices.coreinfrastructure.org',
+                     'www.bestpractices.dev')
 
   return value if value.exclude?('<')
 

--- a/script/fastly_test
+++ b/script/fastly_test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-site_name=${1:-https://master.bestpractices.coreinfrastructure.org/projects/1/badge}
+site_name=${1:-https://staging.bestpractices.dev/projects/1/badge}
 echo "Purging Fastly cache of badge for ${site_name}"
 curl -X PURGE "$site_name" || exit 1
 echo


### PR DESCRIPTION
A while ago the production website moved from
bestpractices.coreinfrastructure.org to www.bestpractices.dev. We automatically forward, but we really should be only giving the new URLs.

This commit updates the live references across docs, the OpenAPI server URL, the Python client sample, and the README. We use the `www.bestpractices.dev` host (not the bare domain) because bare DNS domains complicate our Fastly CDN setup.

The old "master" branch deployment no longer runs. The only pre-production running site is the staging branch deployment. Thus, load_self_json and the Fastly cache test now target staging.bestpractices.dev.

This also adds a normalize_string rewrite in lib/tasks/default.rake so rake translation:sync converts stale old-domain references arriving via translation.io, mirroring the existing GitHub-organization rewrite.

Deliberately preserve the old domain where it is historically accurate:

- README's "previously was at" note about the former site.
- The dated 2017-2018 TLS/header scan evidence in the assurance case, which was measured against the site as it existed then (under the old domain).
- VCR cassettes (recorded HTTP responses with the old domain in frozen CSP headers).
- config/machine_translations/pt-BR.yml (handled by the sync normalizer).