### PR TITLE
Bound memory in project recalc loops (fix OOM)

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -680,6 +680,15 @@ class Project < ApplicationRecord
   # Updates badge percentages for all project entries.
   # Use this after badging rules have changed. We precalculate and store
   # percentages in the database for speed, but rule changes don't automatically
+  # Batch size for the whole-table recalc loops below. A `projects` row is
+  # extremely wide (>400 columns, about half of them text: every criterion's status
+  # and justification across all levels), so each loaded Project object is
+  # large. find_each's default batch of 1000 keeps ~1000 of these giants alive
+  # at once, peaking over 1GB and OOM-killing a standard 512MB dyno (R14/R15,
+  # SIGKILL/exit 137) -- which silently aborts these migrations. A small batch
+  # bounds the working set so the recalc fits in a normal dyno.
+  BULK_RECALC_BATCH_SIZE = 100
+
   # update the precalculated values.
   # NOTE: No emails are sent to badge losers or gainers — email notification
   # only happens through the controller's normal save flow.
@@ -695,7 +704,7 @@ class Project < ApplicationRecord
       raise ArgumentError, "Invalid level: #{l}" unless l.in? Criteria.keys
     end
     Project.skip_callbacks = true
-    Project.find_each do |project|
+    Project.find_each(batch_size: BULK_RECALC_BATCH_SIZE) do |project|
       project.with_lock do
         # Snapshot current badge levels before recalculation so we can
         # record any losses for later notification.
@@ -758,7 +767,7 @@ class Project < ApplicationRecord
     # before_save callback cannot fire.  update_columns bypasses callbacks
     # unconditionally, making skip_callbacks both unnecessary and risky
     # (an exception would leave it true for the process lifetime).
-    Project.find_each do |project|
+    Project.find_each(batch_size: BULK_RECALC_BATCH_SIZE) do |project|
       apply_badge_warning_for_project(project, levels,
                                       effective_date: effective_date,
                                       report: report)

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -851,7 +851,9 @@ desc 'Backfill baseline_tiered_percentage for all projects'
 task backfill_baseline_tiered_percentage: :environment do
   puts 'Backfilling baseline_tiered_percentage for all projects...'
   count = 0
-  Project.find_each do |project|
+  # Small batch: projects are very wide (>400 cols), so the default 1000 can
+  # OOM a 512MB dyno. See Project::BULK_RECALC_BATCH_SIZE.
+  Project.find_each(batch_size: Project::BULK_RECALC_BATCH_SIZE) do |project|
     # rubocop:disable Rails/SkipsModelValidations
     # Intentionally skip validations for performance; we're computing from existing data
     project.update_column(:baseline_tiered_percentage,
@@ -1418,22 +1420,6 @@ end
 desc 'Update Database list of bad passwords from raw-bad-passwords-lowercase'
 task update_bad_password_db: :environment do
   BadPassword.force_load
-end
-
-desc 'Convert old papertrail version values from YAML to json'
-task convert_papertrail_yaml_to_json: :environment do
-  # We request access to the full environment; that makes this easier to do
-  # since that loads what we need.
-  PaperTrail::Version.where.not(old_yaml_object: nil).find_each do |version|
-    # Show progress
-    puts "#{version.item_id} #{version.event} #{version.created_at} " \
-         "#{version.whodunnit} " \
-         "#{version.old_yaml_object[0..200].tr("\n", ' ')}\n\n"
-    # rubocop:disable Rails/SkipsModelValidations
-    version.update_columns old_yaml_object: nil,
-                           object: YAML.unsafe_load(version.old_yaml_object)
-    # rubocop:enable Rails/SkipsModelValidations
-  end
 end
 
 desc 'Update SVG badge images from shields.io'


### PR DESCRIPTION
This fixes a sneaky out-of-memory (OOM) that was causing the production site to fail to perform a migration.

A projects row is very wide (>400 columns, about half of them text: every criterion's status and justification across all levels). So find_each's default 1000-row batch keeps ~1000 of these giant objects alive at once, exceeding 1GB. On a standard 512MB dyno that triggers R14/R15 and a SIGKILL (exit 137), which silently aborts the baseline badge-percentage recalc migration (20260607150000) before it records. Thus, the migration stays pending and re-runs on every deploy.

This commit adds Project::BULK_RECALC_BATCH_SIZE = 100 and applies it to every whole-table project loop:
update_all_badge_percentages, update_all_badge_warnings, and the backfill_baseline_tiered_percentage rake task. This bounds the working set so the recalc fits in a normal dyno. The projects#index Project.all path is unaffected (lazy, pagy-paginated).

We also remove the obsolete convert_papertrail_yaml_to_json rake task: it was a one-off conversion we will never reuse, and it had the same unbounded- batch shape over fat serialized-project rows. Code no longer present is even easier to maintain :-).