### PR TITLE
Drop the session cookie if it's useless

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,16 @@ class ApplicationController < ActionController::Base
   ENFORCE_ORIGIN_SHIELDING =
     ENV['ENFORCE_ORIGIN_SHIELDING'] == 'true' && !TRUSTED_PROXIES_DISABLED
 
+  # Name of the Rails session cookie, read from config so this stays correct
+  # if the key is ever renamed (see config/initializers/session_store.rb).
+  SESSION_COOKIE_NAME = Rails.application.config.session_options[:key]
+
+  # Session keys that are framework bookkeeping, not real per-user content:
+  # Rack's always-present session_id and the flash.
+  # Method drop_unneeded_session_cookie
+  # ignores these when deciding whether the session still holds anything.
+  SESSION_BOOKKEEPING_KEYS = %w[session_id flash].freeze
+
   # Make criteria_level conversion methods available to views
   helper_method :criteria_level_to_internal, :normalize_criteria_level
 
@@ -67,6 +77,7 @@ class ApplicationController < ActionController::Base
   # This before_action handles session timeout and the remember token.
   before_action :setup_authentication_state
   after_action :update_session_timestamp
+  after_action :drop_unneeded_session_cookie
 
   # For the PaperTrail gem. We must call this *after* the action
   # `setup_authentication_state`; this action calls
@@ -587,6 +598,59 @@ class ApplicationController < ActionController::Base
 
     session[:time_last_used] = Time.now.utc
     @session_timestamp = session[:time_last_used] # Update cache
+  end
+
+  # Actively expire the session cookie once it is carrying nothing useful,
+  # so a browser that previously received one (e.g. just logged out, or was
+  # shown a stored flash) falls back onto the CDN-cached anonymous pages on
+  # its NEXT request, instead of bypassing the cache until the browser
+  # closes.
+  #
+  # This complements omit_session_cookie: that only *skips writing* a cookie
+  # and cannot remove one the browser already holds; this sends an explicit
+  # deletion. Runs as an after_action. See docs/cdn-cache-not-logged-in.md.
+  #
+  # Deliberately resilient to Rails/middleware internals: the session is
+  # never literally empty (Rack always keeps a session_id, and the flash is
+  # committed by middleware *after* this runs, so a spent 'flash' key may
+  # still linger). We therefore use flash.empty? as the authoritative "is
+  # there a flash to carry" signal and a read-only check for "is there any
+  # real user content left", then suppress the session middleware's own
+  # write. Correctness is pinned by
+  # test/integration/drop_session_cookie_test.rb, which asserts the final
+  # cookie state rather than any internal behavior.
+  # @return [void]
+  def drop_unneeded_session_cookie
+    # Only act when the browser actually sent the cookie. This is
+    # load-bearing: an anonymous request WITHOUT it is the cacheable case,
+    # and we must never add a Set-Cookie there (it would be cached and
+    # shipped to every visitor). Requests that DO carry it are already
+    # passed to origin by the CDN (never cached), so a deletion header on
+    # them is safe. Also the cheap early-out that keeps the hot cacheable
+    # path free.
+    return unless request.cookies.key?(SESSION_COOKIE_NAME)
+    return if logged_in?            # never touch a logged-in user's session
+    return unless flash.empty?      # a pending flash still needs the cookie
+
+    # Keep the cookie if the session still holds real per-user content (a CSRF
+    # token a rendered form needs, locale, forwarding_url, ...).
+    return if session_has_user_content?
+
+    # Suppress the session middleware's own Set-Cookie so it cannot emit a
+    # competing cookie alongside our deletion.
+    omit_session_cookie
+    cookies.delete(SESSION_COOKIE_NAME, path: '/')
+  end
+
+  # True when the session holds real per-user data -- anything beyond the
+  # framework bookkeeping keys (Rack's always-present session_id and a spent
+  # flash). any? short-circuits on the first real key and allocates no
+  # intermediate arrays. Read-only on purpose: mutating the session here would
+  # itself generate a session_id and defeat the check. Unknown future keys
+  # count as content, so callers fail safe (keep the cookie).
+  # @return [Boolean]
+  def session_has_user_content?
+    session.keys.any? { |key| !SESSION_BOOKKEEPING_KEYS.include?(key.to_s) }
   end
 
   # Attempts to login using remember token cookies.

--- a/test/integration/drop_session_cookie_test.rb
+++ b/test/integration/drop_session_cookie_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+# Copyright the OpenSSF Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+require 'test_helper'
+
+# Verifies ApplicationController#drop_unneeded_session_cookie: a browser
+# holding a session cookie that no longer carries anything useful gets it
+# actively deleted, so it falls back onto the CDN-cached anonymous pages
+# instead of bypassing the cache until the browser closes.
+#
+# These tests assert the FINAL cookie outcome (what the response does to the
+# cookie, or the browser's end state) rather than any Rails/middleware
+# internal -- the flash-in-session handling and empty-session cookie behavior
+# have varied across framework versions, so we pin to the observable result.
+class DropSessionCookieTest < ActionDispatch::IntegrationTest
+  # Read the name from the same constant the controller uses, so a cookie
+  # rename can't silently make these tests pass against the wrong cookie.
+  SESSION_KEY = ApplicationController::SESSION_COOKIE_NAME
+
+  setup do
+    @project = projects(:one)
+    # An anonymous, read-only page that writes nothing into the session.
+    @anon_path = "/en/projects/#{@project.id}/passing"
+  end
+
+  # --- helpers: what the response did to the session cookie ---
+
+  def set_cookie_lines
+    Array(response.headers['Set-Cookie']).flat_map { |h| h.to_s.split("\n") }
+  end
+
+  def session_cookie_lines
+    set_cookie_lines.select { |line| line.start_with?("#{SESSION_KEY}=") }
+  end
+
+  # A deletion has an empty value and/or a past expiry / max-age 0.
+  def deletion_line?(line)
+    line.start_with?("#{SESSION_KEY}=;") ||
+      line.match?(/expires=thu, 01[ -]jan[ -]1970/i) ||
+      line.match?(/max-age=0\b/i)
+  end
+
+  def session_cookie_deleted?
+    session_cookie_lines.any? { |line| deletion_line?(line) }
+  end
+
+  def with_forgery_protection
+    original = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+    yield
+  ensure
+    ActionController::Base.allow_forgery_protection = original
+  end
+
+  # --- tests ---
+
+  # Anonymous, carrying a spent/empty session cookie: it is deleted, so the
+  # next request is cookie-free and can be served straight from the CDN cache.
+  test 'anonymous request carrying a spent session cookie deletes it' do
+    cookies[SESSION_KEY] = 'stale'
+    get @anon_path
+    assert_response :success
+    assert session_cookie_deleted?,
+           'a spent anonymous session cookie should be actively deleted'
+  end
+
+  # No cookie sent: the response must NOT emit any session Set-Cookie. This is
+  # the load-bearing guard -- such a header would be cached and shipped to
+  # every visitor, deleting their cookies and polluting the cached object.
+  test 'anonymous request with no cookie emits no session Set-Cookie' do
+    get @anon_path
+    assert_response :success
+    assert_empty session_cookie_lines,
+                 'must not touch the session cookie when none was sent'
+  end
+
+  # Logged in: never delete -- the cookie is doing its job.
+  test 'logged-in request never deletes the session cookie' do
+    log_in_as(users(:test_user))
+    get @anon_path
+    assert_response :success
+    assert_not session_cookie_deleted?,
+               'a logged-in session cookie must not be deleted'
+  end
+
+  # A request that stores a CSRF token (a rendered anonymous form) must KEEP
+  # the cookie, or the form's embedded authenticity_token would be orphaned
+  # and the POST would fail CSRF. Needs forgery protection ON (off in test).
+  test 'request that stores a CSRF token keeps the session cookie' do
+    with_forgery_protection do
+      cookies[SESSION_KEY] = 'stale'
+      # The login page renders forms -> writes session[:_csrf_token].
+      get login_path(locale: :en)
+      assert_response :success
+      assert_not session_cookie_deleted?,
+                 'a session holding a CSRF token must keep its cookie'
+    end
+  end
+
+  # A persistent flash being displayed must KEEP the cookie on the request
+  # that shows it (flash.empty? is false there).
+  test 'request displaying a carried-over flash keeps the session cookie' do
+    post '/en/password_resets',
+         params: { password_reset: { email: 'nobody@example.org' } }
+    assert response.redirect?
+    get @anon_path # displays the flash
+    assert_response :success
+    assert_not session_cookie_deleted?,
+               'cookie carrying a flash must survive the request showing it'
+  end
+
+  # ...and once that flash is spent, the browser ends up WITHOUT the cookie.
+  # Asserts the browser end state (cookie jar), so it holds whether the cookie
+  # was cleared by our after_action or by the framework.
+  test 'a spent-flash cookie is gone from the browser next request' do
+    post '/en/password_resets',
+         params: { password_reset: { email: 'nobody@example.org' } }
+    get @anon_path # show + sweep the flash; cookie kept here
+    assert_not session_cookie_deleted?
+    get @anon_path # clean request: empty session -> cookie dropped
+    assert cookies[SESSION_KEY].blank?,
+           'after the flash is spent the browser should not carry the cookie'
+  end
+end


### PR DESCRIPTION
Drop the session cookie if it's useless, to improve our CDN caching.

A browser that received a session cookie (e.g. just logged out, or shown a stored flash) keeps sending it until the browser closes. Then the Fastly rule passes every such request to origin and the user never gets the CDN-cached anonymous pages. The method omit_session_cookie only skips *writing* a cookie; it can't remove one the browser already holds.

This commit adds an after_action, drop_unneeded_session_cookie, that actively expires the cookie when: the browser sent it, the user is not logged in, there is no
flash to carry, and the session holds no real per-user content. The "real content" check (session_has_user_content?) ignores framework bookkeeping keys (Rack's always-present session_id and a spent flash) and is read-only, since mutating the session itself generates a session_id. It fails safe: unknown keys count as content, and anonymous requests that did not send the cookie get no Set-Cookie at all (so cached responses are never polluted).

SESSION_COOKIE_NAME is read from config so a cookie rename stays correct.

Tests (test/integration/drop_session_cookie_test.rb) check various cases. They assert the observable
cookie outcome (not middleware internals) across: spent cookie deleted, no-cookie emits nothing, logged-in kept, CSRF-token kept, flash-display kept, and spent-flash gone on the next request.