### PR TITLE
Handle OmniAuth login failures instead of 404ing

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,8 +13,17 @@ class SessionsController < ApplicationController
   include SessionsHelper
 
   # Do *NOT* redirect session creation, that will cause complicated failures
-  # because we don't really want the locale.
-  skip_before_action :redir_missing_locale, only: :create
+  # because we don't really want the locale. The same applies to :failure:
+  # OmniAuth redirects to the path '/auth/failure' with no locale prefix, so
+  # skipping this before_action just avoids a needless extra redirect to add
+  # one. This does NOT make the response English-only -- the later
+  # set_locale_to_best_available before_action still runs, so I18n.locale
+  # (hence the flash message and the login_path we redirect to) reflects the
+  # browser's Accept-Language. We use Accept-Language rather than the locale
+  # of the originating page on purpose: these failures are often caused by a
+  # missing/stale session cookie, so relying on session state to localize
+  # would be unreliable exactly when it matters.
+  skip_before_action :redir_missing_locale, only: %i[create failure]
 
   # Display login form or redirect if already logged in.
   # Supports `GET /login`.
@@ -65,6 +74,30 @@ class SessionsController < ApplicationController
     log_out if logged_in?
     flash[:success] = t('sessions.signed_out')
     redirect_to root_url
+  end
+
+  # Handle an OmniAuth login failure. OmniAuth redirects here (302) whenever a
+  # login attempt fails; the most common cause in production is a missing or
+  # stale request-phase CSRF token (e.g. a stale or CDN-cached login page
+  # whose token no longer matches the browser's session). Previously there was
+  # no route for '/auth/failure', so the user just saw a bare 404 ("not
+  # found"). We log the rejection (so its frequency is visible on
+  # staging/production) and send the user back to the login page with a
+  # "please try again" message, which is what a manual reload accomplished.
+  # Supports `GET /auth/failure`.
+  # @return [void]
+  def failure
+    # `message` and `strategy` come from OmniAuth, but this endpoint is
+    # public, so treat them as untrusted: truncate and use `inspect` (which
+    # escapes newlines) to prevent log forging and log bloat.
+    message = params[:message].to_s[0, 200]
+    strategy = params[:strategy].to_s[0, 50]
+    Rails.logger.warn(
+      "OmniAuth login failed: strategy=#{strategy.inspect} " \
+      "message=#{message.inspect} ip=#{request.remote_ip}"
+    )
+    flash[:danger] = t('sessions.login_failed')
+    redirect_to login_path
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,6 +117,8 @@ en:
     already_logged_in: You are already logged in.
     login_disabled: All logins temporarily disabled
     incorrect_login_info: Incorrect login information
+    login_failed: >-
+      Sorry, that login attempt could not be completed. Please try again.
     invalid_combo: Invalid email/password combination
     signed_in: "Logged in! Last login: %{last_login_at}"
     not_activated: >-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,6 +252,13 @@ Rails.application.routes.draw do
     get 'login' => 'sessions#new'
     post 'login' => 'sessions#create'
     get 'auth/:provider/callback' => 'sessions#create'
+    # OmniAuth redirects here (302) when a login attempt fails, e.g. when the
+    # request-phase CSRF token is missing/stale (a stale or CDN-cached login
+    # page). Without this route that redirect 404s ("not found"); the action
+    # turns it into a friendly "please try again" and logs the rejection.
+    # OmniAuth's default path_prefix is '/auth', so the path is
+    # '/auth/failure'.
+    get 'auth/failure' => 'sessions#failure'
     get '/signout' => 'sessions#destroy', as: :signout
     delete 'logout' => 'sessions#destroy'
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -173,6 +173,48 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     OmniAuth.config.logger = old_omniauth_logger
   end
 
+  # OmniAuth redirects failed logins (e.g. the CSRF rejection above) to
+  # '/auth/failure'. Confirm that path no longer 404s but instead sends the
+  # user back to login with a friendly message, and that it logs the failure.
+  test 'auth failure redirects to login with a message and logs it' do
+    old_logger = Rails.logger
+    log_output = StringIO.new
+    Rails.logger = Logger.new(log_output)
+
+    get '/auth/failure',
+        params: { message: 'invalid_authenticity_token', strategy: 'github' }
+
+    assert_redirected_to login_path
+    assert_equal I18n.t('sessions.login_failed'), flash[:danger]
+    assert_match(/OmniAuth login failed/, log_output.string)
+    assert_match(/invalid_authenticity_token/, log_output.string)
+    assert_match(/github/, log_output.string)
+
+    # The friendly login page actually renders (no 404).
+    follow_redirect!
+    assert_response :success
+  ensure
+    Rails.logger = old_logger
+  end
+
+  # A public endpoint must not let attacker-supplied params forge log lines;
+  # embedded newlines must be escaped (via inspect), not written literally.
+  test 'auth failure escapes newlines in logged params' do
+    old_logger = Rails.logger
+    log_output = StringIO.new
+    Rails.logger = Logger.new(log_output)
+
+    get '/auth/failure',
+        params: { message: "evil\nFORGED LOG LINE", strategy: 'x' }
+
+    assert_redirected_to login_path
+    # The literal newline+text must not appear as its own log line.
+    assert_no_match(/^FORGED LOG LINE/, log_output.string)
+    assert_match(/evil\\nFORGED LOG LINE/, log_output.string)
+  ensure
+    Rails.logger = old_logger
+  end
+
   test 'local login fails if deny_login' do
     # WARNING: This test manipulates a global setting, namely
     # Rails.application.config.deny_login. Parallel testing with *processes*

--- a/test/system/robots_contents_test.rb
+++ b/test/system/robots_contents_test.rb
@@ -8,7 +8,7 @@ require 'application_system_test_case'
 
 class RobotsContentsTest < ApplicationSystemTestCase
   test 'robots.txt on nonproduction site' do
-    # The tests never seet ENV['PUBLIC_HOSTNAME'] to the production site value.
+    # The tests never set ENV['PUBLIC_HOSTNAME'] to the production site value.
     visit '/robots.txt'
     assert_text 'User-Agent: *'
     assert_not has_content? 'Allow: /'


### PR DESCRIPTION
When a GitHub login attempt fails (most commonly a missing/stale request-phase CSRF token from a stale or CDN-cached login page, but also GitHub authorization denials), OmniAuth 302-redirects to `/auth/failure`. That path had no route, so the user saw a bare 404 ("not found"). This intermittent, hard-to-reproduce 404 is was noticed on staging: a first login attempt failed, a reload worked.

This adds a `GET /auth/failure` route and `SessionsController#failure` action that logs the rejection (so its frequency is visible on staging/production) and redirects the user back to the login page with a generic "please try again" flash, which is what a manual reload did before.

Security notes:

- `message`/`strategy` come from OmniAuth but this endpoint is public, so they are treated as untrusted: truncated and logged via `inspect` (which escapes newlines) to prevent log forging and log bloat.
- The redirect target is the hardcoded `login_path`; no user input reaches it, so there is no open-redirect risk. OmniAuth's origin/return_to params are ignored.
- The log uses ".inspect" to ensure that newlines, etc., are escaped in the logs.
- The login page keeps the default `private, no-store` cache control (the sessions controller never opts into CDN caching), so Fastly will not cache one user's flash for another. It displays the message using the usual flash mechanism.

Localization: `:failure` skips only `redir_missing_locale` (the path has no locale prefix); `set_locale_to_best_available` still runs, so the flash and redirect use the browser's Accept-Language. Accept-Language is used rather than the originating page's locale on purpose, since these failures are often caused by missing/stale session state.

Add tests for the friendly redirect + logging and for newline escaping in logged params.