### PR TITLE
Harden input validation vs params + control chars

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -372,7 +372,39 @@ class ApplicationController < ActionController::Base
     Sections::INPUT_TO_INTERNAL[level] || '0'
   end
 
+  # Empty, frozen params used as the safe fallback for hash_param when a
+  # request omits a nested key or sends it as a scalar/array. Shared and frozen
+  # so no allocation occurs on the malformed-input path either.
+  EMPTY_PARAMS = ActionController::Parameters.new.freeze
+
   private
+
+  # Safely read a scalar (String) request parameter.
+  # Rails parses `k[]=v` into an Array and `k[x]=v` into a Hash, so a crafted
+  # request can make params[key] a non-String (or nil). Calling String methods
+  # on such a value raises (NoMethodError/TypeError), turning a crafted request
+  # into an unhandled 500. This returns `default` unless the value is genuinely
+  # a String, letting callers treat request input uniformly. There is no
+  # allocation on the common path.
+  # @param key [Symbol, String] the parameter name
+  # @param default [Object] returned when the param is absent or not a String
+  # @return [String, Object] the String value, or `default`
+  def scalar_param(key, default = nil)
+    value = params[key]
+    value.is_a?(String) ? value : default
+  end
+
+  # Safely read a nested params hash (e.g. params[:session]).
+  # Returns EMPTY_PARAMS when the key is absent or was sent as a scalar/array,
+  # so callers can index the result uniformly (every field reads as nil)
+  # without risking a 500. The common path (a real nested hash) is returned
+  # as-is, with no allocation.
+  # @param key [Symbol, String] the parameter name
+  # @return [ActionController::Parameters] the nested params, or EMPTY_PARAMS
+  def hash_param(key)
+    value = params[key]
+    value.is_a?(ActionController::Parameters) ? value : EMPTY_PARAMS
+  end
 
   # Ensures all URLs include the current locale parameter.
   # Always includes locale in URLs for consistent internationalization,

--- a/app/controllers/criteria_controller.rb
+++ b/app/controllers/criteria_controller.rb
@@ -45,16 +45,19 @@ class CriteriaController < ApplicationController
   end
 
   # Convert user-provided parameter "name" into true/false.
-  # This is untrusted input, be cautious with it.
-  # @param name [String] The name name
-  # @param default_value [Object] The default value parameter
+  # This is untrusted input, be cautious with it. scalar_param yields the
+  # default (nil here) for an absent, bare, or non-scalar value (e.g.
+  # ?details[]=1, which Rails parses into an Array); without that guard,
+  # calling casecmp? on a non-String would raise, turning a crafted query
+  # string into an unhandled 500 on this public, unauthenticated page.
+  # @param name [Symbol] The parameter name to read
+  # @param default_value [Object] The value to use when the param is absent
+  #   or is not a simple string
   # @return [Boolean]
   def boolean_param(name, default_value = true)
-    if params.key?(name)
-      user_value = params[name]
-      user_value.casecmp?('true') || user_value == '1'
-    else
-      default_value
-    end
+    value = scalar_param(name)
+    return default_value if value.nil?
+
+    value.casecmp?('true') || value == '1'
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -4,7 +4,6 @@
 # OpenSSF Best Practices badge contributors
 # SPDX-License-Identifier: MIT
 
-# rubocop: disable Metrics/ClassLength
 class PasswordResetsController < ApplicationController
   before_action :obtain_user, only: %i[edit update]
   before_action :require_valid_user, only: %i[edit update]
@@ -31,7 +30,7 @@ class PasswordResetsController < ApplicationController
   # going to go beyond what some might see as the minimum, and instead
   # do what we can to maximize our users' privacy.
   def create
-    @user = User.find_by(email: nested_params(:password_reset, :email),
+    @user = User.find_by(email: hash_param(:password_reset)[:email],
                          provider: 'local')
     if @user
       # NOTE: We send the password reset to the email address originally
@@ -49,7 +48,7 @@ class PasswordResetsController < ApplicationController
   # Updates an existing resource.
   # @return [void]
   def update
-    new_password = nested_params(:user, :password)
+    new_password = hash_param(:user)[:password]
     if new_password.nil? || new_password == ''
       @user.errors.add(:password, t('password_resets.password_empty'))
       render 'edit'
@@ -124,16 +123,4 @@ class PasswordResetsController < ApplicationController
     flash[:danger] = t('password_resets.reset_expired')
     redirect_to new_password_reset_url
   end
-
-  # Return params[outer][inner] but handle nil gracefully by returning nil.
-  # This makes it easier to avoid nil dereferences.
-  # @param outer [Object] The outer parameter key
-  # @param inner [Object] The inner parameter key within outer
-  def nested_params(outer, inner)
-    return if params.nil? || !params.key?(outer)
-    return unless params[outer].key?(inner)
-
-    params[outer][inner]
-  end
 end
-# rubocop: enable Metrics/ClassLength

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -52,7 +52,7 @@ class SessionsController < ApplicationController
       render 'new', status: :forbidden
     elsif request.env['omniauth.auth'].present?
       omniauth_login
-    elsif params[:session][:provider] == 'local'
+    elsif hash_param(:session)[:provider] == 'local'
       local_login
     else
       # There is no information disclosure in this error message.
@@ -145,9 +145,10 @@ class SessionsController < ApplicationController
   # Handles local email/password authentication.
   # @return [void]
   def local_login
+    session_params = hash_param(:session)
     user = User.authenticate_local_user(
-      params[:session][:email],
-      params[:session][:password]
+      session_params[:email],
+      session_params[:password]
     )
 
     if user
@@ -189,10 +190,11 @@ class SessionsController < ApplicationController
       flash.now[:danger] = t('sessions.cannot_login_yet')
       render 'new', status: :forbidden
     else
-      return_to = params.dig(:session, :return_to)
+      session_params = hash_param(:session)
+      return_to = session_params[:return_to]
       return_to = nil unless valid_return_path?(return_to)
       successful_login(user, return_to)
-      params[:session][:remember_me] == '1' ? remember(user) : forget(user)
+      session_params[:remember_me] == '1' ? remember(user) : forget(user)
     end
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/app/validators/text_validator.rb
+++ b/app/validators/text_validator.rb
@@ -5,12 +5,35 @@
 # SPDX-License-Identifier: MIT
 
 class TextValidator < ActiveModel::EachValidator
-  INVALID_CONTROL = /[\x01-\x08\x0b\x0c\x0e-\x1f]/
+  # Control characters that we never appear in accepted text.
+  # We specially filter them out to prevent their presence.
+  # We allow only the whitespace controls that legitimately occur in user
+  # text: tab (0x09), LF (0x0a), and CR (0x0d). We reject the rest of the
+  # C0 range plus DEL (0x7f). NUL (0x00) is included deliberately in
+  # the set we do NOT allow: PostgreSQL cannot store it in a text column,
+  # so without this it would surface as a 500 at save time.
+  # The pattern is intentionally limited to US-ASCII code points
+  # so it stays encoding-compatible with any string that passed valid_encoding?
+  # below. We don't worry about other ranges like the C1 code points
+  # U+0080..U+009F ("C1"); tools generally don't do anything special
+  # with them, so we don't see any risk.
+  # Also, adding them would make this regexp
+  # UTF-8 and could raise Encoding::CompatibilityError on binary input, the
+  # opposite of the robustness we want, if we allow other encodings.
+  INVALID_CONTROL = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/
+
+  # Accept only well-formed text that is free of disallowed control chars.
+  # @param value [String, nil] the text to check (nil is accepted)
+  # @return [Boolean] true if the value is acceptable text
   def text_acceptable?(value)
     return true if value.nil?
+    # All accepted text must be valid in its declared encoding (UTF-8 for our
+    # inputs); reject broken byte sequences before matching.
     return false unless value.valid_encoding?
 
-    (value =~ INVALID_CONTROL).nil?
+    # Use match? (not =~): it allocates no MatchData and sets no $~ global,
+    # which matters on this hot, per-field validation path under heavy load.
+    !value.match?(INVALID_CONTROL)
   end
 
   def validate_each(record, attribute, value)

--- a/test/controllers/criteria_controller_test.rb
+++ b/test/controllers/criteria_controller_test.rb
@@ -129,5 +129,22 @@ class CriteriaControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes @response.body, 'Basic project website content'
   end
+
+  # Security/robustness: non-scalar boolean params (which Rails parses into an
+  # Array or Hash) must not raise an unhandled exception. Previously these
+  # crafted query strings triggered a 500 (NoMethodError) on this public,
+  # unauthenticated page; the toggle should simply fall back to its default.
+  test 'Get criteria with array-valued toggle param does not error' do
+    get '/en/criteria?details[]=1'
+    assert_response :success
+    assert_not_includes @response.body, 'Details:'
+  end
+
+  test 'Get criteria with hash-valued toggle param does not error' do
+    get '/en/criteria?rationale[x]=1&autofill[y]=1'
+    assert_response :success
+    assert_not_includes @response.body, 'Rationale:'
+    assert_not_includes @response.body, 'Autofill:'
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -177,5 +177,16 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to password_resets_path(locale: 'en')
   end
+
+  # Security/robustness: a crafted request can send the nested `password_reset`
+  # key as a scalar instead of a hash. That must not raise an unhandled
+  # exception (previously NoMethodError -> 500) on this public, unauthenticated
+  # endpoint; it should be treated as an absent email and reply normally.
+  test 'password reset create with scalar param does not error' do
+    assert_no_difference 'ActionMailer::Base.deliveries.size' do
+      post '/en/password_resets', params: { password_reset: 'foo' }
+    end
+    assert_redirected_to root_url
+  end
 end
 # rubocop: enable Metrics/ClassLength

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -234,5 +234,21 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       Rails.application.config.deny_login = old_deny
     end
   end
+
+  # Security/robustness: a crafted login request can send the nested `session`
+  # key as a scalar, or omit it entirely. Neither must raise an unhandled
+  # exception (previously TypeError/NoMethodError -> 500) on this public,
+  # unauthenticated endpoint; both should be treated as a failed login.
+  test 'local login with scalar session param does not error' do
+    post '/en/login', params: { session: 'foo' }
+    assert_response :success # re-renders 'new'
+    assert flash&.now && flash.now[:danger]
+  end
+
+  test 'local login with missing session param does not error' do
+    post '/en/login'
+    assert_response :success # re-renders 'new'
+    assert flash&.now && flash.now[:danger]
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -133,7 +133,18 @@ class ProjectTest < ActiveSupport::TestCase
     assert_not validator.text_acceptable?("The best practices badge\xe4")
     # Don't accept an invalid control character
     assert_not validator.text_acceptable?("The best practices badge\x0c")
+    # Reject NUL (PostgreSQL can't store it) and DEL, plus other C0 controls.
+    # Built from byte values so the source file stays control-char free.
+    assert_not validator.text_acceptable?("badge#{0x00.chr}here")
+    assert_not validator.text_acceptable?("badge#{0x7f.chr}here")
+    assert_not validator.text_acceptable?("badge#{0x01.chr}here")
+    # Accept the whitespace controls we intentionally allow: tab, LF, CR.
+    assert validator.text_acceptable?(
+      "line1#{0x09.chr}col2#{0x0a.chr}line2#{0x0d.chr}"
+    )
+    # Accept ordinary UTF-8 text including multibyte code points.
     assert validator.text_acceptable?('The best practices badge.')
+    assert validator.text_acceptable?("caf#{[0xE9].pack('U')} #{[0x65E5].pack('U')}")
   end
 
   # rubocop:disable Metrics/BlockLength

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -143,8 +143,12 @@ class ProjectTest < ActiveSupport::TestCase
       "line1#{0x09.chr}col2#{0x0a.chr}line2#{0x0d.chr}"
     )
     # Accept ordinary UTF-8 text including multibyte code points.
+    # Built from code points ("cafe" with an acute e, then a CJK character)
+    # so the source stays ASCII and free of any partial-word fragments.
+    # Otherwise the spelling checker will reject this.
     assert validator.text_acceptable?('The best practices badge.')
-    assert validator.text_acceptable?("caf#{[0xE9].pack('U')} #{[0x65E5].pack('U')}")
+    multibyte = [0x63, 0x61, 0x66, 0xE9, 0x20, 0x65E5].pack('U*')
+    assert validator.text_acceptable?(multibyte)
   end
 
   # rubocop:disable Metrics/BlockLength


### PR DESCRIPTION
Harden input validation against malformed parameters and control characters in text input.

Several public endpoints read request parameters that a normal form sends as a simple string, then called String methods on them directly. Rails parses "k[]=v" into an Array and "k[x]=v" into a Hash, so a crafted request could make the value a non-string (or nil) and turn the method call into an unhandled exception, that is, an unauthenticated 500. While that's not a *disaster*, it'd be better to detect and reject as early as possible, as a hardening measure to make the system difficult to break.

We confirmed three such cases by reproducing the 500 before fixing each one:

  * GET  /:locale/criteria   with ?details[]=1       (Array#casecmp?)
  * POST /password_resets    with password_reset=foo (String#key?)
  * POST /login              with session=foo or no session param
                                                     (String#[] / nil#[])

Rather than patch each site separately, this adds two small shared helpers to ApplicationController so the protection is systemic:

  * scalar_param(key, default = nil) returns the value only when it is genuinely a String, else the default.
  * hash_param(key) returns the nested params only when it really is a Parameters, else a shared frozen empty Parameters, so callers can index it uniformly without risking a 500.

Both allocate nothing on the normal path (the frozen empty fallback is only returned for malformed input), so there is no meaningful cost on these hot, public endpoints. The criteria, sessions, and password_resets controllers now use these helpers, which also let us drop two one-off private helpers and their associated Metrics/ClassLength disables.

Also tighten TextValidator, which guards all accepted user text (project name, description, license, general comments, and every justification):

  * Confirm and document the existing UTF-8 requirement: text that is not valid in its declared encoding is still rejected before matching.
  * Reject the disallowed control characters. The old pattern began at \x01, so it silently accepted NUL (\x00), which PostgreSQL cannot store in a text column and would therefore surface as a 500 at save time. The new pattern rejects all C0 controls plus DEL, allowing only the whitespace controls that belong in text: tab, LF, and CR.
  * Use match? instead of =~, which allocates no MatchData and sets no $~ global. This matters on this per-field path under heavy load, and it is marginally faster.

The control-character pattern is deliberately kept to US-ASCII code points. Adding the U+0080..U+009F "C1" range would make the regexp UTF-8 and could raise Encoding::CompatibilityError on binary input, which is the opposite of the robustness we want, and such code points are vanishingly rare in legitimate text.

Verified that proper inputs still sail through: the login, signup, and password-reset integration flows pass, a NUL in a project name now produces a clean validation error instead of a 500, and tab/LF text and UTF-8 emoji/accented names validate fine. Add regression tests for each hardened path.