### PR TITLE
Fix signing: use cosign --bundle

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -102,19 +102,23 @@ jobs:
       # identity, signs the SBOM, and records the signature in the public
       # Rekor transparency log. A human never handles a key.
       #
-      # Outputs, uploaded as release assets in the next step:
-      #   <sbom>.sig  -- detached signature; the ".sig" suffix is what
-      #                  Scorecard's Signed-Releases check recognizes.
-      #   <sbom>.pem  -- the Fulcio-issued signing certificate, needed to
-      #                  verify the signature.
-      # See docs/improve-scorecard.md for how to verify a released signature.
+      # Output, uploaded as a release asset in the next step:
+      #   <sbom>.sigstore.json -- a self-contained Sigstore bundle holding
+      #     the signature, the signing certificate, and the transparency-log
+      #     proof. The ".sigstore.json" suffix is one of those Scorecard's
+      #     Signed-Releases check recognizes as a signed artifact.
+      #
+      # We pass --bundle (a single self-contained file) rather than the older
+      # --output-signature / --output-certificate flags: recent cosign
+      # defaults to its "new bundle format", under which those flags are
+      # deprecated and IGNORED -- leaving the bundle path empty and failing
+      # the step. See docs/improve-scorecard.md for how to verify a bundle.
       - name: Sign the SBOM (cosign keyless)
         env:
           SBOM: ${{ steps.vars.outputs.sbom_filename }}
         run: |
           cosign sign-blob --yes \
-            --output-signature "${SBOM}.sig" \
-            --output-certificate "${SBOM}.pem" \
+            --bundle "${SBOM}.sigstore.json" \
             "${SBOM}"
 
       # Create a GitHub Release and attach the SBOM as a release asset.
@@ -152,5 +156,4 @@ jobs:
             --title "SBOM ${{ github.ref_name }} ${{ steps.vars.outputs.date }} (${{ steps.vars.outputs.sha_short }})" \
             --notes "Auto-generated SBOM for commit ${{ github.sha }} on branch ${{ github.ref_name }}" \
             "${{ steps.vars.outputs.sbom_filename }}" \
-            "${{ steps.vars.outputs.sbom_filename }}.sig" \
-            "${{ steps.vars.outputs.sbom_filename }}.pem"
+            "${{ steps.vars.outputs.sbom_filename }}.sigstore.json"

--- a/docs/improve-scorecard.md
+++ b/docs/improve-scorecard.md
@@ -217,14 +217,21 @@ SBOM with **cosign keyless (Sigstore)** signing, fully automatically in CI:
 - Add `id-token: write` to the job so cosign can mint a short-lived GitHub
   OIDC token; no private key is stored and no human acts.
 - Install cosign via the pinned first-party `sigstore/cosign-installer`
-  action, then `cosign sign-blob --yes` the SBOM. cosign exchanges the OIDC
-  token at Fulcio for an ephemeral certificate bound to this workflow's
-  identity, signs, and logs the signature in the public Rekor transparency
-  log.
-- Upload `<sbom>.sig` (detached signature — the suffix Scorecard matches)
-  and `<sbom>.pem` (the Fulcio signing certificate) as release assets,
+  action, then `cosign sign-blob --yes --bundle <sbom>.sigstore.json` the
+  SBOM. cosign exchanges the OIDC token at Fulcio for an ephemeral
+  certificate bound to this workflow's identity, signs, and logs the
+  signature in the public Rekor transparency log.
+- Upload `<sbom>.sigstore.json` — a single self-contained Sigstore bundle
+  (signature + signing certificate + transparency-log proof) whose
+  `.sigstore.json` suffix Scorecard recognizes — as a release asset
   alongside the SBOM, via the existing `gh release create` step. (`gh` is
   preinstalled on the runner; no new dependency, and none needed locally.)
+
+  We use `--bundle`, not the older `--output-signature` /
+  `--output-certificate` flags: recent cosign defaults to its "new bundle
+  format", under which those flags are deprecated and ignored, which leaves
+  the bundle path empty and fails the signing step (the mistake in the first
+  cut of this workflow).
 
 This moves Signed-Releases from 0 to **8** once the last five releases
 carry signatures. Reaching **10** additionally requires SLSA provenance
@@ -235,8 +242,7 @@ follow-up.
 
 ```sh
 cosign verify-blob \
-  --signature <sbom>.sig \
-  --certificate <sbom>.pem \
+  --bundle <sbom>.sigstore.json \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp \
     '^https://github.com/ossf/best-practices-badge/\.github/workflows/sbom\.yml@' \


### PR DESCRIPTION
The first cut of the signing step used cosign's --output-signature and --output-certificate flags. Recent cosign defaults to its "new bundle format", under which those flags are deprecated and ignored; with no --bundle path given, cosign fails with:

  create bundle file: open : no such file or directory

This failed the SBOM workflow on the first staging deploy (ee1627a2), so no signed release was ever produced (the release step runs after signing).

Sign into a single self-contained Sigstore bundle instead:

  cosign sign-blob --yes --bundle "${SBOM}.sigstore.json" "${SBOM}"

The bundle holds the signature, signing certificate, and transparency-log proof. Its ".sigstore.json" suffix is one of those OpenSSF Scorecard's Signed-Releases check recognizes, so it still scores. Upload the bundle as the release asset (replacing the .sig/.pem pair) and update the verify command in docs/improve-scorecard.md to use --bundle.