### PR TITLE
Report restored backup's age, and warn if stale

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -736,12 +736,22 @@ jobs:
                     $0 ~ /(^|[[:space:]])(Completed|Finished)([[:space:]]|$)/ {
                       print; exit
                     }' || true)"
-            # One read: every field we want is on that one row, the
-            # identifier followed by the three tokens of "Created at".
-            # "|| true" because read reports EOF, and this shell exits
-            # on any unchecked failure.
-            read -r backup_id c_date c_time c_zone _ <<<"$backup_row" \
-              || true
+            # Two awk calls, and NOT bash's "read x y z" fed by a
+            # here-string, however much tidier one read would look.
+            #
+            # A here-string starts with a DOUBLED LESS-THAN sign, and
+            # CircleCI reads that pair as the opening of one of its own
+            # parameter expressions. It then scans for the closing
+            # doubled greater-than that never comes and rejects the
+            # WHOLE config file: "Expressions must be less than 2048
+            # characters", reported against the top of this step, which
+            # is nowhere near the actual character. Here-documents open
+            # the same way and are the same trap.
+            #
+            # Nothing else in this file uses that pair, including in
+            # comments, because a comment inside a command block is
+            # still part of the string CircleCI parses. Keep it so.
+            backup_id="$(printf '%s\n' "$backup_row" | awk '{print $1}')"
             if ! printf '%s' "$backup_id" | grep -qE '^[a-z][0-9]+$'; then
               echo "ERROR: found no completed backup for ${SOURCE_APP}."
               echo 'Refusing to restore. Check "heroku pg:backups".'
@@ -761,7 +771,8 @@ jobs:
             # Validate its shape rather than trusting it: a changed
             # layout then says it could not read the date instead of
             # printing whatever happened to sit in those fields.
-            created_at="${c_date} ${c_time} ${c_zone}"
+            created_at="$(printf '%s\n' "$backup_row" |
+              awk '{print $2, $3, $4}')"
             age_days=''
             if printf '%s' "$created_at" | grep -qE \
               '^[0-9]{4}(-[0-9]{2}){2} ([0-9]{2}:){2}[0-9]{2} [-+][0-9]{4}$'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -715,7 +715,7 @@ jobs:
             # awk's default field splitting handles any run of spaces
             # or tabs, so the exact column widths do not matter.
             echo "Restoring ${SOURCE_APP}'s latest backup over ${TARGET_APP}"
-            backup_id="$(heroku pg:backups --app "$SOURCE_APP" \
+            backup_row="$(heroku pg:backups --app "$SOURCE_APP" \
               | awk '
                   # Track which section we are in. The command prints
                   # Backups, then Restores, then Copies, and restore
@@ -734,14 +734,74 @@ jobs:
                   # accept both.
                   $1 ~ /^[a-z][0-9]+$/ &&
                     $0 ~ /(^|[[:space:]])(Completed|Finished)([[:space:]]|$)/ {
-                      print $1; exit
+                      print; exit
                     }' || true)"
+            # One read: every field we want is on that one row, the
+            # identifier followed by the three tokens of "Created at".
+            # "|| true" because read reports EOF, and this shell exits
+            # on any unchecked failure.
+            read -r backup_id c_date c_time c_zone _ <<<"$backup_row" \
+              || true
             if ! printf '%s' "$backup_id" | grep -qE '^[a-z][0-9]+$'; then
               echo "ERROR: found no completed backup for ${SOURCE_APP}."
               echo 'Refusing to restore. Check "heroku pg:backups".'
               exit 1
             fi
-            echo "Using backup ${backup_id}"
+
+            # Report how old the backup is, because "newest completed"
+            # says nothing about recent. We deliberately restore the
+            # latest EXISTING backup rather than capturing a fresh one,
+            # so if production's scheduled backups ever stop, this step
+            # would keep succeeding while quietly restoring older and
+            # older data. Nothing else would notice: the restore itself
+            # succeeds, and staging then looks merely out of date.
+            #
+            # Unlike the status, "Created at" cannot be matched as a
+            # whole word, so it has to be taken by column position.
+            # Validate its shape rather than trusting it: a changed
+            # layout then says it could not read the date instead of
+            # printing whatever happened to sit in those fields.
+            created_at="${c_date} ${c_time} ${c_zone}"
+            age_days=''
+            if printf '%s' "$created_at" | grep -qE \
+              '^[0-9]{4}(-[0-9]{2}){2} ([0-9]{2}:){2}[0-9]{2} [-+][0-9]{4}$'
+            then
+              # Guarded anyway: under "-e" an unparsable date would
+              # otherwise abort the deploy over a diagnostic.
+              created_epoch="$(date -d "$created_at" +%s 2>/dev/null \
+                || true)"
+              if [ -n "$created_epoch" ]; then
+                age_days=$(( ($(date +%s) - created_epoch) / 86400 ))
+              fi
+            else
+              created_at=''
+            fi
+
+            if [ -n "$age_days" ]; then
+              units='days'
+              if [ "$age_days" -eq 1 ]; then units='day'; fi
+              echo "Using backup ${backup_id}, created ${created_at}" \
+                   "(${age_days} ${units} old)"
+            elif [ -n "$created_at" ]; then
+              echo "Using backup ${backup_id}, created ${created_at}"
+            else
+              echo "Using backup ${backup_id}; could not read its date"
+              echo "  row: ${backup_row}"
+            fi
+
+            # Scheduled backups run daily, so more than a couple of days
+            # means the schedule has stopped. Report it loudly rather
+            # than refusing: a stale copy of production is still a more
+            # useful staging database than whatever is there now, and a
+            # deploy is a bad moment to discover a backup problem by
+            # being blocked. Two days, not one, so that ordinary drift
+            # in when the schedule runs is not reported as a fault.
+            if [ -n "$age_days" ] && [ "$age_days" -gt 2 ]; then
+              echo "WARNING: that backup is ${age_days} days old."
+              echo 'WARNING: check that production still backs up daily:'
+              echo "WARNING:   heroku pg:backups:schedules" \
+                   "--app ${SOURCE_APP}"
+            fi
 
             # The redaction stays even though we pass no URL: the CLI
             # may resolve the identifier to one internally and print it.

--- a/docs/build-environment-staleness.md
+++ b/docs/build-environment-staleness.md
@@ -1790,11 +1790,14 @@ Three consequences to accept deliberately, none of them objections:
    re-running it is safe; afterwards it wipes staging and restores
    production. Reasonable for staging, but it changes what a familiar
    button does, so say so where people will read it.
-3. **Verify that `pg:backups:restore` survives the running dyno.**
-   Maintenance mode stops web traffic but the dyno keeps running, and
-   solid_queue runs inside Puma, so connections stay open. Check whether
-   the restore terminates them or fails; do not preemptively add a
-   `ps:scale web=0` that may not be needed.
+3. **`pg:backups:restore` survives the running dyno. Confirmed
+   2026-08-05**, on the first real staging deploy through this step.
+   The worry was reasonable: maintenance mode stops web traffic but the
+   dyno keeps running, and solid_queue runs inside Puma, so connections
+   stay open. It restored anyway, reporting `Restoring... done` and
+   exiting zero, and the deploy went on to a successful release. So no
+   `ps:scale web=0` is needed, which is why it was worth not adding one
+   preemptively.
 
 **Hardcode both application names in the restore step.** The
 surrounding job derives `HEROKU_APP` from `$CIRCLE_BRANCH`, but the
@@ -1806,6 +1809,94 @@ only one.
 Checked, not assumed: `heroku pg:backups` runs with no plugins
 installed on CLI 11.8.1, the version the `deploy` job pins, so the
 `deploy-only` executor needs nothing added.
+
+### Newest completed is not the same as recent
+
+Added 2026-08-05, prompted by reading the first real deploy's log. It
+said `Using backup a3822` and finished, and nothing in it could tell
+you whether that backup was four hours old or four weeks old.
+
+That gap matters because of a choice made deliberately above: we
+restore production's latest *existing* backup rather than capturing a
+fresh one, so as not to put load on production. If production's
+scheduled backups ever stopped, this step would keep succeeding while
+restoring older and older data. Nothing would report it. The restore
+genuinely succeeds; staging merely looks out of date, which is
+indistinguishable from any of the ordinary reasons staging looks out of
+date.
+
+So the step now reports the age:
+
+```text
+Using backup a3822, created 2026-08-05 09:00:11 +0000 (0 days old)
+```
+
+and past two days says so plainly:
+
+```text
+WARNING: that backup is 9 days old.
+WARNING: check that production still backs up daily:
+WARNING:   heroku pg:backups:schedules --app production-bestpractices
+```
+
+**It warns rather than refusing**, which is a judgement and not an
+oversight. A stale copy of production is still a better staging
+database than whatever is on staging already, and the middle of a
+deploy is a bad moment to be blocked by a backup problem that is not
+this deploy's fault. Two days rather than one, so that ordinary drift
+in when the schedule runs is not reported as a fault.
+
+**"Created at" must be read by column, and that is the weak part.** The
+status is matched as a whole word anywhere on the line precisely so a
+layout change cannot shift it out from under us. A date gets no such
+protection, being a date wherever it sits. So its shape is validated
+instead, and a row that does not match says what it could not do rather
+than printing whatever happened to sit in those fields:
+
+```text
+Using backup a3822; could not read its date
+  row: a3822 Completed 2026-08-05 09:04:33 +0000  ...
+```
+
+The restore then proceeds. A diagnostic that cannot be produced is not
+a reason to refuse a deploy.
+
+### Testing the shipped code, not a copy of it
+
+The eight listings the parse was first tested against were run against
+a *copy* of the step's shell. This change was tested differently: a
+harness extracts the step's `command` from `.circleci/config.yml` with
+Psych and runs **that** under `/bin/bash -eo pipefail`, which is the
+shell the deploy job actually gets, with `heroku` stubbed to print a
+fixture and to record the arguments it is handed.
+
+The distinction has earned its keep twice already in this document.
+The remote browser passed while driving local Chrome, and the release
+parse passed against fixtures whose shape had been assumed rather than
+observed. Both times the tests were exercising something that was not
+the shipped code.
+
+33 checks pass: the original eight listings, behaving exactly as
+before; that the restore still receives
+`production-bestpractices::a3822` and `--app staging-bestpractices`;
+that nine branch names including `staging2`, `Staging`,
+`staging-bestpractices` and `"staging "` with a trailing space still
+restore nothing; and the new reporting, including the two negative
+checks that matter, that a fresh listing emits no warning and that an
+unreadable date invents no age. `shellcheck` on the extracted step is
+clean, which is the only static analysis this shell can get while it
+lives inside YAML.
+
+Fixture timestamps are computed relative to the clock rather than
+written down, since the step reads the real clock and a hardcoded date
+would quietly change meaning every day.
+
+**The harness is not committed**, because there is nowhere for it to
+live yet: `test/` is hermetic Minitest, and this needs a real
+`.circleci/config.yml` and a stubbed CLI. Recorded here so that the
+next person knows the method rather than rediscovering it. Putting it
+in `script/`, and eventually in `rake default`, is the obvious next
+step and is not taken here.
 
 ### Then the deploy can be a button
 
@@ -1983,6 +2074,9 @@ cause.
   Heroku.
 * `heroku pg:backups` and `pg:backups:restore` are core CLI commands,
   needing no plugin install, on CLI 11.8.1.
+* `pg:backups:restore` completes with the dyno still running under
+  maintenance mode; no `ps:scale web=0` is needed. Confirmed on staging
+  2026-08-05.
 * A CircleCI job's executor image must come from a registry. Its cache
   cannot supply one, because `restore_cache` is a step and steps run
   inside the executor that is already running.

--- a/docs/build-environment-staleness.md
+++ b/docs/build-environment-staleness.md
@@ -1891,12 +1891,33 @@ Three things make this worth recording rather than merely fixing.
   explaining the trap, spelling the pair out literally, which would
   have reintroduced it. A comment inside a `command:` block is part of
   the string CircleCI parses, not an aside to a human.
-* **Nothing local catches it.** `rake yaml_syntax_check` passes,
-  because the file is valid YAML; the fault is in CircleCI's own
-  expression layer, above YAML. The `circleci` CLI would catch it with
-  `circleci config validate`, and is not installed here. Failing that,
-  the cheap guard is a check that this file contains that character
-  pair nowhere at all, which is true today and easy to keep true.
+* **Nothing local caught it.** `rake yaml_syntax_check` passes, because
+  the file is valid YAML; the fault is in CircleCI's own expression
+  layer, above YAML. The `circleci` CLI would catch it with
+  `circleci config validate`, and is not installed here.
+
+So `rake circleci_config_check` now catches it, in `rake default`
+beside the YAML check. It is a grep rather than a second tool to
+install and keep current, which for one character pair is the right
+size of answer.
+
+**It permits a genuine expression.** `<< parameters.foo >>` and
+`<< pipeline.number >>` pass, so the parameterized executor this
+document considered and set aside remains available; everything else
+fails with the file, the line number, and the line.
+
+Tested by breaking what it guards, which is the only way to know a
+guard works:
+
+| Case | Result |
+| ---- | ------ |
+| the here-string that caused this, restored | caught, exit 1 |
+| a here-document, in a comment | caught, exit 1 |
+| `<< parameters.image >>`, `<< pipeline.number >>` | passes |
+
+Note the second row. The trap is not "do not use here-strings"; it is
+that **CircleCI parses the whole command string**, comments included,
+and does not know the shell would have ignored part of it.
 
 ### Testing the shipped code, not a copy of it
 

--- a/docs/build-environment-staleness.md
+++ b/docs/build-environment-staleness.md
@@ -1861,6 +1861,43 @@ Using backup a3822; could not read its date
 The restore then proceeds. A diagnostic that cannot be produced is not
 a reason to refuse a deploy.
 
+### The shell you may write here is not the shell you know
+
+Found the hard way 2026-08-05: this change was first written with
+bash's here-string, `read backup_id c_date c_time c_zone` fed from the
+row, which is tidier than calling `awk` twice. CircleCI rejected the
+entire configuration:
+
+```text
+Error calling workflow: 'build-deploy'
+Error calling job: 'deploy'
+Expressions must be less than 2048 characters.
+```
+
+**A here-string opens with a doubled less-than sign, and that pair is
+how CircleCI opens its own parameter expressions.** It read the pair as
+the start of an expression, scanned forward for the closing doubled
+greater-than that never came, and gave up after 2048 characters.
+Here-documents open the same way and are the same trap.
+
+Three things make this worth recording rather than merely fixing.
+
+* **The error points nowhere near the cause.** It is reported against
+  the first line of the step, which was a comment, so the message
+  invites you to shorten a long command. Length was never the problem:
+  four other commands in the file are longer than 2048 characters and
+  always have been, including one of 7585.
+* **Comments are not exempt.** The first fix carried a comment
+  explaining the trap, spelling the pair out literally, which would
+  have reintroduced it. A comment inside a `command:` block is part of
+  the string CircleCI parses, not an aside to a human.
+* **Nothing local catches it.** `rake yaml_syntax_check` passes,
+  because the file is valid YAML; the fault is in CircleCI's own
+  expression layer, above YAML. The `circleci` CLI would catch it with
+  `circleci config validate`, and is not installed here. Failing that,
+  the cheap guard is a check that this file contains that character
+  pair nowhere at all, which is true today and easy to keep true.
+
 ### Testing the shipped code, not a copy of it
 
 The eight listings the parse was first tested against were run against
@@ -2077,6 +2114,15 @@ cause.
 * `pg:backups:restore` completes with the dyno still running under
   maintenance mode; no `ps:scale web=0` is needed. Confirmed on staging
   2026-08-05.
+* **A doubled less-than sign anywhere in `.circleci/config.yml` breaks
+  the whole file**, comments inside a `command:` included, because
+  CircleCI reads that pair as the start of a parameter expression. So
+  no bash here-strings and no here-documents. The error names an
+  expression length limit and points at the top of the step, which is
+  not where the character is.
+* CircleCI's 2048-character limit applies to *expressions*, not to
+  commands. Several commands in that file exceed it, the longest at
+  7585 characters, and always have.
 * A CircleCI job's executor image must come from a registry. Its cache
   cannot supply one, because `restore_cache` is a step and steps run
   inside the executor that is already running.

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -39,6 +39,7 @@ task(:default).clear.enhance %w[
   license_okay
   license_finder_report.html
   yaml_syntax_check
+  circleci_config_check
   html_from_markdown
   eslint
   report_code_statistics
@@ -376,6 +377,58 @@ task :yaml_syntax_check do
     puts 'YAML syntax check failed:'
     puts output
     exit exit_status
+  end
+end
+
+# CircleCI parses ".circleci/config.yml" at a layer ABOVE YAML, where a
+# doubled less-than sign opens one of its own parameter expressions. It
+# scans forward for the matching doubled greater-than and, not finding
+# one, rejects the entire file with "Expressions must be less than 2048
+# characters" reported against the top of the enclosing step.
+#
+# Two shell constructs open with exactly that pair, here-strings and
+# here-documents, and both are natural things to write in a "command:"
+# block. Neither survives. Comments inside a command block do not
+# survive either, because CircleCI parses the whole string and does not
+# know that the shell would have ignored part of it.
+#
+# None of this is visible to "rake yaml_syntax_check": the file is
+# perfectly good YAML. The "circleci" CLI would catch it with
+# "circleci config validate", but that is another tool to install and
+# keep current, and this is a grep.
+#
+# A genuine CircleCI expression is still allowed, so that a
+# parameterized executor remains available: see
+# docs/build-environment-staleness.md.
+desc 'Check .circleci/config.yml for shell syntax CircleCI misreads'
+task :circleci_config_check do
+  path = '.circleci/config.yml'
+  puts "Checking #{path} for CircleCI expression traps..."
+  raise StandardError, "Missing #{path}" unless File.exist?(path)
+
+  # The only legitimate use of the pair: opening a reference to a
+  # CircleCI parameter or pipeline value.
+  allowed = /\A<<\s*(parameters|pipeline)\./
+  offenders =
+    File.readlines(path).each_with_index.filter_map do |line, index|
+      found = line.enum_for(:scan, /<</).map { Regexp.last_match.begin(0) }
+      next if found.empty? || found.all? { |at| line[at..].match?(allowed) }
+
+      [index + 1, line.strip]
+    end
+
+  if offenders.empty?
+    puts 'CircleCI config check completed successfully.'
+  else
+    puts 'ERROR: a doubled less-than sign in .circleci/config.yml.'
+    puts 'CircleCI reads it as the start of a parameter expression and'
+    puts 'rejects the whole file. Shell here-strings and here-documents'
+    puts 'open with it; so rewrite them (awk, or a pipe), and describe'
+    puts 'the characters in comments rather than spelling them out.'
+    offenders.each do |line_number, text|
+      puts "  #{path}:#{line_number}: #{text}"
+    end
+    exit 1
   end
 end
 


### PR DESCRIPTION
The first real deploy through this step said "Using backup a3822" and finished, and nothing in the log could tell you whether that backup was four hours old or four weeks old.

That gap matters because of a choice made deliberately: we restore production's latest existing backup rather than capturing a fresh one, so as not to put load on production.  If production's scheduled backups ever stopped, this step would keep succeeding while restoring older and older data, and nothing would report it.  The restore genuinely succeeds; staging merely looks out of date, which is indistinguishable from any of the ordinary reasons staging looks out of date.

So the step now reports the age, and past two days says so plainly and points at "pg:backups:schedules".  It warns rather than refusing: a stale copy of production is still a better staging database than whatever is on staging already, and the middle of a deploy is a bad moment to be blocked by a backup problem that is not this deploy's fault.  Two days rather than one, so ordinary drift in when the schedule runs is not reported as a fault.

"Created at" has to be read by column, unlike the status, which is matched as a whole word anywhere on the line precisely so a layout change cannot shift it out from under us.  A date gets no such protection, being a date wherever it sits, so its shape is validated instead, and a row that does not match reports that it could not read the date rather than printing whatever sat in those fields.  The restore then proceeds, because a diagnostic that cannot be produced is not a reason to refuse a deploy.

Tested by extracting the step's own command from .circleci/config.yml and running that, rather than a copy of it, under the shell the deploy job actually gets, with the Heroku CLI stubbed.  33 checks: the original eight listings unchanged, the restore's arguments, nine branch names that must restore nothing, and the new reporting including that a fresh listing emits no warning and an unreadable date invents no age.

Also records that pg:backups:restore survives the running dyno, which this deploy confirmed and which had been left open on purpose rather than answered by preemptively scaling the web dyno to zero.