### PR TITLE
Run the static checks in a parallel job, so they leave the critical path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,31 @@ executors:
           SE_START_XVFB: "false"
           SE_START_VNC: "false"
 
+  # The static checks need Ruby and nothing else. Checked, not assumed:
+  # every one of them passes with PGHOST pointed at a dead port, so no
+  # database is involved, and none of them opens a browser.
+  #
+  # Hence its own executor rather than reusing ruby-postgres: that would
+  # start and pay for a PostgreSQL container and a 2.12GB Chrome
+  # container that this job never speaks to.
+  #
+  # The image below is deliberately the same as the primary image above,
+  # and the two must move together. Renovate proposes an upgrade for
+  # each occurrence, so they arrive in one pull request; take both or
+  # neither. If they ever disagree, the static job and the test job are
+  # no longer checking the same environment, which is the whole point of
+  # sharing the prepare_ruby command.
+  ruby-only:
+    docker:
+      - image: heroku/heroku:24-build@sha256:a6e743f508a2f37f90ddd551587c3a0776529219ae427296db8836fa9a680275
+        environment:
+          RAILS_ENV: test
+          RACK_ENV: test
+          # Same reason as above: this image leaves LANG unset, which
+          # gives a US-ASCII default external encoding, and prepare_ruby
+          # asserts UTF-8 rather than letting it corrupt text later.
+          LANG: C.UTF-8
+
   deploy-only:
     docker:
       # The deploy job needs git, node, npm, wget, and openssl, and
@@ -151,7 +176,211 @@ executors:
       # requires node >=20.
       - image: cimg/node:24.19.0@sha256:8966565f07189a67d64d6808a2b127f31dafae566508e3547f55640e1070bfad
 
+commands:
+  prepare_ruby:
+    description: >
+      Everything both jobs need before they can run any Ruby: the
+      cache identity, the restore, Ruby and Node in $HOME, the
+      toolchain check, and the bundle. Defined once because the
+      static job and the test job must agree about the environment
+      exactly; two copies of this would drift, and the drift would
+      show up as one job passing and the other failing on the same
+      commit.
+    steps:
+      # Work out what makes a cache compatible, and let the key say so.
+      #
+      # CircleCI stores cache paths as ABSOLUTE paths, so a cache saved
+      # under one $HOME cannot be written under another. When this job
+      # moved from an image whose user was "circleci" to one whose user is
+      # "heroku", nothing in the key noticed: the restore matched, then
+      # produced 23,404 "permission denied" lines, wasted 27 seconds and
+      # restored nothing.
+      #
+      # So the key carries the three things that decide compatibility, read
+      # from the running container rather than written down by hand: who we
+      # are, where home is, and which OS this is. A stack upgrade therefore
+      # changes the key by itself, which is why no version number appears
+      # anywhere below.
+      #
+      # Why hash a file instead of putting these in the key directly? A
+      # cache key can only interpolate CircleCI's own templates, and
+      # {{ .Environment.X }} is restricted to variables CircleCI exports or
+      # a context supplies, "not any arbitrary environment variable".
+      # {{ checksum }} on a file is the only way to get a runtime value
+      # into a key. The step prints the file so the log stays readable.
+      - run:
+          name: Work out what makes a cache compatible
+          command: |
+            set -euo pipefail
+            . /etc/os-release
+            { id -un; echo "$HOME"; echo "${ID}-${VERSION_ID}"; } \
+              > /tmp/cache-env-id
+            echo 'Cache environment identity:'
+            sed 's/^/  /' /tmp/cache-env-id
+      # Restore BEFORE installing anything, because the cache now carries
+      # ~/ruby, which holds both the interpreter and every installed gem
+      # (Gem.dir is $HOME/ruby/lib/ruby/gems/X). A hit therefore skips the
+      # Ruby download AND most of "bundle install".
+      #
+      # arch comes before the checksums so the looser fallbacks below
+      # cannot cross architectures.
+      - restore_cache:
+          keys:
+          # Exact: this environment, this Ruby, these gems, this branch.
+          - v2-{{ checksum "/tmp/cache-env-id" }}-{{ arch }}-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}-{{ .Branch }}
+          # Same Ruby and gems from any branch. This is what stops every
+          # new branch from starting cold, which it previously did: the old
+          # key ended in {{ .Branch }} with no fallback at all.
+          - v2-{{ checksum "/tmp/cache-env-id" }}-{{ arch }}-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}-
+          # Same Ruby, any gems: the interpreter is still right and
+          # "bundle install" reconciles the difference, which is far
+          # cheaper than building the world.
+          - v2-{{ checksum "/tmp/cache-env-id" }}-{{ arch }}-{{ checksum ".ruby-version" }}-
+      - run:
+          name: Install Ruby and Node into $HOME
+          command: |
+            set -euo pipefail
+            # Both versions come from the files that already govern them,
+            # so there is no third place to forget to update. The stack
+            # name is named once, here.
+            STACK=heroku-24
+            RUBY_VERSION="$(tr -d '[:space:]' < .ruby-version)"
+            NODE_VERSION="$(sed -n 's/.*"node": *"\([^"]*\)".*/\1/p' \
+                            package.json | head -1)"
+            test -n "$RUBY_VERSION"; test -n "$NODE_VERSION"
+
+            # Heroku's own prebuilt Ruby, so the interpreter matches
+            # production and this is a download rather than a compile.
+            # Note the arch segment: S3 answers 403, not 404, when listing
+            # is denied, so a missing object and a forbidden one look
+            # identical and only a 200 means anything.
+            # Skip if the cache already brought it, gems and all. Verify by
+            # running it rather than trusting the directory's existence, so
+            # a truncated or half-restored cache falls back to a download
+            # instead of failing later in a confusing way.
+            if "$HOME/ruby/bin/ruby" -v >/dev/null 2>&1; then
+              echo "Ruby restored from cache: $("$HOME/ruby/bin/ruby" -v)"
+            else
+              echo "Installing Ruby ${RUBY_VERSION} for ${STACK}"
+              rm -rf "$HOME/ruby"
+              curl -sfSL --retry 5 --retry-delay 5 --retry-all-errors \
+                "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/${STACK}/amd64/ruby-${RUBY_VERSION}.tgz" \
+                | tar xz -C "$HOME" --one-top-level=ruby
+            fi
+
+            # Guard against the cache and .ruby-version disagreeing. The
+            # key includes .ruby-version so this should be impossible;
+            # if it ever happens, say so rather than test the wrong Ruby.
+            got="$("$HOME/ruby/bin/ruby" -e 'print RUBY_VERSION')"
+            if [ "$got" != "$RUBY_VERSION" ]; then
+              echo "ERROR: .ruby-version says ${RUBY_VERSION}, but the Ruby"
+              echo "in \$HOME is ${got}. Refusing to test the wrong one."
+              exit 1
+            fi
+
+            # Node at the version package.json pins, so CI minifies
+            # JavaScript with the interpreter production minifies with.
+            # Verified against nodejs.org's own SHASUMS256.txt: integrity,
+            # not provenance, since both come from the same host, but it
+            # catches a truncated or corrupted download.
+            echo "Installing Node ${NODE_VERSION}"
+            nb="https://nodejs.org/download/release/v${NODE_VERSION}"
+            nt="node-v${NODE_VERSION}-linux-x64.tar.gz"
+            curl -sfSL --retry 5 --retry-delay 5 --retry-all-errors \
+              "${nb}/${nt}" -o "/tmp/${nt}"
+            curl -sfSL --retry 5 --retry-delay 5 --retry-all-errors \
+              "${nb}/SHASUMS256.txt" -o /tmp/SHASUMS256.txt
+            (cd /tmp && grep " ${nt}\$" SHASUMS256.txt | sha256sum -c -)
+            mkdir -p "$HOME/node"
+            tar xz -C "$HOME/node" --strip-components=1 -f "/tmp/${nt}"
+            rm -f "/tmp/${nt}" /tmp/SHASUMS256.txt
+
+            echo 'export PATH="$HOME/ruby/bin:$HOME/node/bin:$PATH"' \
+              >> "$BASH_ENV"
+      - run:
+          name: Confirm the toolchain, and that it can read UTF-8
+          command: |
+            set -euo pipefail
+            ruby -v
+            node --version
+            echo "CPUs visible: $(nproc)"
+            if [ -r /sys/fs/cgroup/memory.max ]; then
+              echo "memory limit (cgroup v2): $(cat /sys/fs/cgroup/memory.max)"
+            elif [ -r /sys/fs/cgroup/memory/memory.stat ]; then
+              grep hierarchical_memory_limit /sys/fs/cgroup/memory/memory.stat
+            fi
+            # Fail here, with a sentence, rather than in a test that
+            # mangles an accented character three steps later.
+            ruby -e 'raise "default_external is #{Encoding.default_external}" \
+                     unless Encoding.default_external == Encoding::UTF_8'
+      # Implement OSPS-BR-01.02: Validate branch name before use in pipeline
+      # Protect against malicious branch names that could cause cache poisoning
+      # or command injection attacks. Branch names are used in cache keys below.
+      - run:
+          name: Validate branch name
+          command: script/validate_branch_name "$CIRCLE_BRANCH"
+      - run:
+          name: Update bundler to match Gemfile.lock
+          # No sudo: this image has none, and does not need it, because
+          # Ruby lives in $HOME and so its gem directory is already ours.
+          #
+          # --force, not "yes |". Heroku's Ruby tarball ships its own
+          # "bundle" binstub, which belongs to no gem, so RubyGems refuses
+          # with "bundle from bundler conflicts with .../bin/bundle". That
+          # is an error, not a prompt, so piping "yes" cannot answer it;
+          # --force skips the overwrite check. The same is true of any gem
+          # whose binstub collides with the tarball's, "rake" included.
+          command: |
+            set -euo pipefail
+            want="$(tail -1 Gemfile.lock | tr -d '[:space:]')"
+            echo "Gemfile.lock was bundled with ${want}"
+            gem install bundler --no-document --force -v "${want}"
+      - run:
+          name: Bundler Version
+          command: bundle --version
+      - run:
+          name: Install Bundle
+          # Note: --path=vendor/bundle removed, we don't need it.
+          command: >
+            bundle check ||
+            bundle install --jobs=4 --retry=3
+
 jobs:
+  # The checks that are settled by the commit, run beside the tests
+  # rather than in front of them. They took roughly 200 seconds of the
+  # single job they used to share with the suite, and they need nothing
+  # the suite needs: no database, no browser, no test results.
+  #
+  # This job does not exist on the staging and production branches; the
+  # workflow filter at the bottom of this file leaves it out entirely,
+  # because those branches are reached only by fast-forwarding main,
+  # which has already run every check in it. That filter, and not a
+  # conditional inside a step, is what makes "we do not re-check
+  # deploys" true.
+  #
+  # It shares the dependency cache with "build": the keys come from the
+  # same prepare_ruby command, so whichever job runs first warms it for
+  # the other on the next pipeline. Only "build" writes the cache, so
+  # the two never race to save the same key.
+  static:
+    executor: ruby-only
+    working_directory: ~/ossf/best-practices-badge
+    resource_class: medium
+    shell: /bin/bash --login
+    steps:
+      - checkout
+      - prepare_ruby
+      # No database is used, but Rails still wants the file to exist
+      # when it boots. One copy is cheaper than finding out.
+      - run:
+          name: Configure database
+          command: |
+            cd config/
+            cp {database.ci,database}.yml
+      - run:
+          name: Run the checks settled by the commit (rake static_checks)
+          command: CI=true bundle exec rake static_checks
+
   build:
     executor: ruby-postgres
     working_directory: ~/ossf/best-practices-badge
@@ -163,132 +392,7 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
     - checkout
-    # Work out what makes a cache compatible, and let the key say so.
-    #
-    # CircleCI stores cache paths as ABSOLUTE paths, so a cache saved
-    # under one $HOME cannot be written under another. When this job
-    # moved from an image whose user was "circleci" to one whose user is
-    # "heroku", nothing in the key noticed: the restore matched, then
-    # produced 23,404 "permission denied" lines, wasted 27 seconds and
-    # restored nothing.
-    #
-    # So the key carries the three things that decide compatibility, read
-    # from the running container rather than written down by hand: who we
-    # are, where home is, and which OS this is. A stack upgrade therefore
-    # changes the key by itself, which is why no version number appears
-    # anywhere below.
-    #
-    # Why hash a file instead of putting these in the key directly? A
-    # cache key can only interpolate CircleCI's own templates, and
-    # {{ .Environment.X }} is restricted to variables CircleCI exports or
-    # a context supplies, "not any arbitrary environment variable".
-    # {{ checksum }} on a file is the only way to get a runtime value
-    # into a key. The step prints the file so the log stays readable.
-    - run:
-        name: Work out what makes a cache compatible
-        command: |
-          set -euo pipefail
-          . /etc/os-release
-          { id -un; echo "$HOME"; echo "${ID}-${VERSION_ID}"; } \
-            > /tmp/cache-env-id
-          echo 'Cache environment identity:'
-          sed 's/^/  /' /tmp/cache-env-id
-    # Restore BEFORE installing anything, because the cache now carries
-    # ~/ruby, which holds both the interpreter and every installed gem
-    # (Gem.dir is $HOME/ruby/lib/ruby/gems/X). A hit therefore skips the
-    # Ruby download AND most of "bundle install".
-    #
-    # arch comes before the checksums so the looser fallbacks below
-    # cannot cross architectures.
-    - restore_cache:
-        keys:
-        # Exact: this environment, this Ruby, these gems, this branch.
-        - v2-{{ checksum "/tmp/cache-env-id" }}-{{ arch }}-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}-{{ .Branch }}
-        # Same Ruby and gems from any branch. This is what stops every
-        # new branch from starting cold, which it previously did: the old
-        # key ended in {{ .Branch }} with no fallback at all.
-        - v2-{{ checksum "/tmp/cache-env-id" }}-{{ arch }}-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}-
-        # Same Ruby, any gems: the interpreter is still right and
-        # "bundle install" reconciles the difference, which is far
-        # cheaper than building the world.
-        - v2-{{ checksum "/tmp/cache-env-id" }}-{{ arch }}-{{ checksum ".ruby-version" }}-
-    - run:
-        name: Install Ruby and Node into $HOME
-        command: |
-          set -euo pipefail
-          # Both versions come from the files that already govern them,
-          # so there is no third place to forget to update. The stack
-          # name is named once, here.
-          STACK=heroku-24
-          RUBY_VERSION="$(tr -d '[:space:]' < .ruby-version)"
-          NODE_VERSION="$(sed -n 's/.*"node": *"\([^"]*\)".*/\1/p' \
-                          package.json | head -1)"
-          test -n "$RUBY_VERSION"; test -n "$NODE_VERSION"
-
-          # Heroku's own prebuilt Ruby, so the interpreter matches
-          # production and this is a download rather than a compile.
-          # Note the arch segment: S3 answers 403, not 404, when listing
-          # is denied, so a missing object and a forbidden one look
-          # identical and only a 200 means anything.
-          # Skip if the cache already brought it, gems and all. Verify by
-          # running it rather than trusting the directory's existence, so
-          # a truncated or half-restored cache falls back to a download
-          # instead of failing later in a confusing way.
-          if "$HOME/ruby/bin/ruby" -v >/dev/null 2>&1; then
-            echo "Ruby restored from cache: $("$HOME/ruby/bin/ruby" -v)"
-          else
-            echo "Installing Ruby ${RUBY_VERSION} for ${STACK}"
-            rm -rf "$HOME/ruby"
-            curl -sfSL --retry 5 --retry-delay 5 --retry-all-errors \
-              "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/${STACK}/amd64/ruby-${RUBY_VERSION}.tgz" \
-              | tar xz -C "$HOME" --one-top-level=ruby
-          fi
-
-          # Guard against the cache and .ruby-version disagreeing. The
-          # key includes .ruby-version so this should be impossible;
-          # if it ever happens, say so rather than test the wrong Ruby.
-          got="$("$HOME/ruby/bin/ruby" -e 'print RUBY_VERSION')"
-          if [ "$got" != "$RUBY_VERSION" ]; then
-            echo "ERROR: .ruby-version says ${RUBY_VERSION}, but the Ruby"
-            echo "in \$HOME is ${got}. Refusing to test the wrong one."
-            exit 1
-          fi
-
-          # Node at the version package.json pins, so CI minifies
-          # JavaScript with the interpreter production minifies with.
-          # Verified against nodejs.org's own SHASUMS256.txt: integrity,
-          # not provenance, since both come from the same host, but it
-          # catches a truncated or corrupted download.
-          echo "Installing Node ${NODE_VERSION}"
-          nb="https://nodejs.org/download/release/v${NODE_VERSION}"
-          nt="node-v${NODE_VERSION}-linux-x64.tar.gz"
-          curl -sfSL --retry 5 --retry-delay 5 --retry-all-errors \
-            "${nb}/${nt}" -o "/tmp/${nt}"
-          curl -sfSL --retry 5 --retry-delay 5 --retry-all-errors \
-            "${nb}/SHASUMS256.txt" -o /tmp/SHASUMS256.txt
-          (cd /tmp && grep " ${nt}\$" SHASUMS256.txt | sha256sum -c -)
-          mkdir -p "$HOME/node"
-          tar xz -C "$HOME/node" --strip-components=1 -f "/tmp/${nt}"
-          rm -f "/tmp/${nt}" /tmp/SHASUMS256.txt
-
-          echo 'export PATH="$HOME/ruby/bin:$HOME/node/bin:$PATH"' \
-            >> "$BASH_ENV"
-    - run:
-        name: Confirm the toolchain, and that it can read UTF-8
-        command: |
-          set -euo pipefail
-          ruby -v
-          node --version
-          echo "CPUs visible: $(nproc)"
-          if [ -r /sys/fs/cgroup/memory.max ]; then
-            echo "memory limit (cgroup v2): $(cat /sys/fs/cgroup/memory.max)"
-          elif [ -r /sys/fs/cgroup/memory/memory.stat ]; then
-            grep hierarchical_memory_limit /sys/fs/cgroup/memory/memory.stat
-          fi
-          # Fail here, with a sentence, rather than in a test that
-          # mangles an accented character three steps later.
-          ruby -e 'raise "default_external is #{Encoding.default_external}" \
-                   unless Encoding.default_external == Encoding::UTF_8'
+    - prepare_ruby
     # Refresh apt package lists before any apt-based installs.
     # Ubuntu mirrors occasionally return 404 for stale package versions
     # that have been replaced by a newer release; apt-get update fetches
@@ -342,12 +446,6 @@ jobs:
           done
           echo 'ERROR: Selenium grid never became ready'
           exit 1
-    # Implement OSPS-BR-01.02: Validate branch name before use in pipeline
-    # Protect against malicious branch names that could cause cache poisoning
-    # or command injection attacks. Branch names are used in cache keys below.
-    - run:
-        name: Validate branch name
-        command: script/validate_branch_name "$CIRCLE_BRANCH"
     - run: pwd
     - run: ls -l
     # There is deliberately no Chrome and no JVM in this image. The
@@ -369,31 +467,6 @@ jobs:
     # Restore the dependency cache
     # This would show what we restored
     # - run: find ~/.rubygems || true
-    - run:
-        name: Update bundler to match Gemfile.lock
-        # No sudo: this image has none, and does not need it, because
-        # Ruby lives in $HOME and so its gem directory is already ours.
-        #
-        # --force, not "yes |". Heroku's Ruby tarball ships its own
-        # "bundle" binstub, which belongs to no gem, so RubyGems refuses
-        # with "bundle from bundler conflicts with .../bin/bundle". That
-        # is an error, not a prompt, so piping "yes" cannot answer it;
-        # --force skips the overwrite check. The same is true of any gem
-        # whose binstub collides with the tarball's, "rake" included.
-        command: |
-          set -euo pipefail
-          want="$(tail -1 Gemfile.lock | tr -d '[:space:]')"
-          echo "Gemfile.lock was bundled with ${want}"
-          gem install bundler --no-document --force -v "${want}"
-    - run:
-        name: Bundler Version
-        command: bundle --version
-    - run:
-        name: Install Bundle
-        # Note: --path=vendor/bundle removed, we don't need it.
-        command: >
-          bundle check ||
-          bundle install --jobs=4 --retry=3
     # Here's how we could show more:
     # - run: find ~/.rubygems || true
     # - run: find ~/.bundle || true
@@ -431,29 +504,19 @@ jobs:
         name: Check for whitespace issues.
         command: '[[ ! -s "$(git rev-parse --git-dir)/shallow" ]] || git fetch --unshallow'
     - run:
-        name: Run checks and tests (rake default, or deploy_checks)
-        command: |
-          # On staging and production, run only the checks whose answer
-          # can change without the code changing, plus the whole test
-          # suite. Everything else in "rake default" is settled by the
-          # commit, and these branches are reached only by
-          # fast-forwarding main, which has already run them. Branch
-          # protection on staging and production is what makes that a
-          # fact rather than a habit.
-          #
-          # The tests still run here, every time. A passing suite is not
-          # a property of the commit alone: re-running it is how
-          # flapping gets noticed, and it is the last thing between a
-          # deploy and production.
-          #
-          # Exact matches only, and any other branch gets the full set,
-          # so a new branch is never accidentally checked less.
-          case "$CIRCLE_BRANCH" in
-            staging|production) rake_task=deploy_checks ;;
-            *)                  rake_task=default ;;
-          esac
-          echo "Branch '${CIRCLE_BRANCH}': running 'rake ${rake_task}'"
-          CI=true bundle exec rake "$rake_task"
+        name: Run the tests and the time-varying checks (rake dynamic_checks)
+        # The same task on every branch, which is a simplification worth
+        # noticing. This used to choose between "rake default" and a
+        # shorter list by branch name, because the code-determined
+        # checks had to run here on pull requests and had to not run
+        # here on deploys. They now run in the "static" job instead, so
+        # this job has one job on every branch and there is nothing to
+        # decide.
+        #
+        # What is left is what a re-run can genuinely tell us: the
+        # tests, and the two checks whose answer moves while the code
+        # stands still. See lib/tasks/default.rake.
+        command: CI=true bundle exec rake dynamic_checks
     # Save test results
     - store_test_results:
         path: /tmp/circleci-test-results
@@ -1042,7 +1105,31 @@ workflows:
   version: 2
   build-deploy:
     jobs:
+      # "build" and "static" have no "requires", so CircleCI starts them
+      # at the same time. That is the entire point: they are independent
+      # work, and the wall clock is now the longer of the two rather
+      # than their sum.
       - build
+      - static:
+          # Not on the deploy branches. Everything this job runs is
+          # settled by the commit, and staging and production are
+          # reached only by fast-forwarding main, which has already run
+          # all of it. Leaving the job out of the workflow entirely is
+          # better than a conditional inside it: there is no step to
+          # misread, and the absent job is visible in the pipeline.
+          #
+          # "ignore" rather than "only" so a new branch is checked more
+          # rather than less. CircleCI treats a plain string as an exact
+          # branch name; a regular expression would have to be written
+          # between slashes.
+          filters:
+            branches:
+              ignore:
+                - staging
+                - production
+      # Deploying requires the tests, and deliberately not "static":
+      # that job does not exist on these two branches, and a job cannot
+      # require one that was filtered out of the workflow.
       - deploy:
           context: bestpractices-heroku-deploy
           requires:

--- a/docs/build-environment-staleness.md
+++ b/docs/build-environment-staleness.md
@@ -2352,18 +2352,26 @@ beside `build` rather than in front of it. Neither requires the other,
 so CircleCI starts both at once and the wall clock is the longer of the
 two instead of their sum.
 
-Measured on a four-core machine:
+**Measured in CI**, which is the number that counts, comparing the
+first pipeline on the split against `main` immediately before it:
 
-| Task | Wall time |
-| ---- | --------- |
-| `rake static_checks` | 50s |
-| `rake dynamic_checks` | 199s |
-| the two in sequence, as `rake default` | 249s |
-| the two at once, as CI now runs them | 199s |
+| Pipeline | Job | Time |
+| -------- | --- | ---- |
+| `main`, everything in one job | `build` | 262.1s |
+| split | `build` | 204.9s |
+| split | `static` | 90.4s |
+| | **wall clock** | **204.9s** |
 
-CI's numbers will be larger and the ratio different, since two
-processors change the tests more than they change a linter. The shape
-is what matters: the checks stop being on the critical path.
+**57 seconds off the wall clock, about 22%.** And an honest second
+number beside it: 204.9 + 90.4 is 295.3, so the *total* compute went
+**up** by about 33 seconds. That is the second job paying its own
+checkout, Ruby install and bundle, and it is the trade being made
+deliberately. Wall clock is what a person waits for; the extra 33
+seconds is machine time that was always going to be spent on something.
+
+On a four-core development machine, where the two run in sequence:
+`rake static_checks` 50s, `rake dynamic_checks` 199s, `rake default`
+249s.
 
 **Three task lists, built from three constants**, so `rake default`
 cannot come to mean something different from what CI runs:

--- a/docs/build-environment-staleness.md
+++ b/docs/build-environment-staleness.md
@@ -2269,7 +2269,9 @@ an estimate when a real number is a build away.
    [One scan, not two](#one-scan-not-two).
 3. **DONE: C, the branch conditional.** See
    [What the deploy branches skip](#what-the-deploy-branches-skip).
-4. **A, split the job**, which extends C's benefit to pull requests.
+4. **DONE: A, split the job**, which extends C's benefit to pull
+   requests. See [Two jobs, not
+   one](#two-jobs-not-one-which-deletes-the-conditional).
 5. **Measure again**, and only then consider F, G and H.
 
 Steps 1 to 3 are plausibly 250 to 300 seconds off a deploy build
@@ -2307,33 +2309,18 @@ and `/tmp/circleci-artifacts` were both empty and neither complained.
 Done 2026-08-05, implementing the code-determined and time-varying
 distinction rather than merely describing it.
 
-`lib/tasks/default.rake` now names the short list, and `rake default`
-splices it in, so the two cannot drift:
-
-```ruby
-TIME_VARYING_CHECKS = %w[bundle bundle_audit percent_gems_up_to_date]
-```
-
-`rake deploy_checks` is that list plus `test:optimized`, and the
-`build` job picks between them:
-
-```text
-case "$CIRCLE_BRANCH" in
-  staging|production) rake_task=deploy_checks ;;
-  *)                  rake_task=default ;;
-esac
-```
-
-| Task | Prerequisites |
-| ---- | ------------- |
-| `default` | 17, unchanged apart from the licence report |
-| `deploy_checks` | 5 |
-
-**Exact matches, and any other branch gets everything**, so the failure
-mode is a branch checked too much rather than too little. Tested
-against ten branch names, including `Staging`, `staging2`,
+`lib/tasks/default.rake` names the short list, and `rake default`
+splices it in, so the two cannot drift. The `build` job chose between
+them by exact branch name, any other branch getting everything, so that
+the failure mode was a branch checked too much rather than too little.
+Tested against ten branch names, including `Staging`, `staging2`,
 `my-staging`, `staging-bestpractices`, `production2` and the empty
-string: only `staging` and `production` take the short list.
+string.
+
+**That conditional is now gone**, and the task it selected has been
+renamed; see [Two jobs, not
+one](#two-jobs-not-one-which-deletes-the-conditional). The policy it
+implemented survives, expressed somewhere better.
 
 **The tests always run.** That is the point of the split rather than an
 exception to it: a green suite is not a property of the commit alone,
@@ -2356,6 +2343,89 @@ Minitest::Assertion: CI must set SELENIUM_REMOTE_URL
 That is the guard from the Chrome work working exactly as intended: it
 refuses to let CI silently drive a local browser. Locally, either
 leave `CI` unset or point `SELENIUM_REMOTE_URL` at a container.
+
+### Two jobs, not one, which deletes the conditional
+
+Done 2026-08-05, and it is option A from the table above. The checks
+settled by the commit now run in their own CircleCI job, `static`,
+beside `build` rather than in front of it. Neither requires the other,
+so CircleCI starts both at once and the wall clock is the longer of the
+two instead of their sum.
+
+Measured on a four-core machine:
+
+| Task | Wall time |
+| ---- | --------- |
+| `rake static_checks` | 50s |
+| `rake dynamic_checks` | 199s |
+| the two in sequence, as `rake default` | 249s |
+| the two at once, as CI now runs them | 199s |
+
+CI's numbers will be larger and the ratio different, since two
+processors change the tests more than they change a linter. The shape
+is what matters: the checks stop being on the critical path.
+
+**Three task lists, built from three constants**, so `rake default`
+cannot come to mean something different from what CI runs:
+
+```ruby
+task(:default).clear.enhance(
+  %w[notice whitespace_check] + %w[static_checks dynamic_checks]
+)
+task(:static_checks).clear.enhance(PREFLIGHT + STATIC_CHECKS)
+task(:dynamic_checks).clear.enhance(PREFLIGHT + DYNAMIC_CHECKS)
+```
+
+A developer still types `rake` and gets everything, in the order that
+fails fastest. `deploy_checks` is renamed `dynamic_checks`, because it
+now runs on every branch and a name that says "deploy" would have been
+actively misleading. Its partner is `static_checks`, and the pair is
+the standard distinction: static analysis against dynamic analysis,
+which is what a test suite is.
+
+**The branch conditional is deleted, not moved.** The `build` job runs
+`rake dynamic_checks` on every branch, with nothing to decide. What
+keeps the checks off the deploy branches is now a workflow filter:
+
+```yaml
+- static:
+    filters:
+      branches:
+        ignore: [staging, production]
+```
+
+That is better than a `case` inside a step for a reason worth stating.
+A filtered-out job is **visible as absent** in the pipeline, where a
+step that decided to do nothing is visible only to somebody reading the
+log. `ignore` rather than `only`, so a new branch is checked more
+rather than less.
+
+`deploy` requires `build` and deliberately not `static`: on those two
+branches `static` does not exist, and a job cannot require one the
+workflow filtered away.
+
+**Its own executor, `ruby-only`.** Reusing `ruby-postgres` would start
+a PostgreSQL container and a 2.12 GB Chrome container for a job that
+speaks to neither. That the static checks need no database was checked
+rather than assumed: all ten pass with `PGHOST` pointed at a dead port.
+The `config/database.yml` copy is kept anyway, because Rails wants the
+file to exist at boot and one `cp` is cheaper than establishing whether
+it does.
+
+**The setup is shared, not copied.** The eight steps both jobs need,
+cache identity through `bundle install`, moved into a `prepare_ruby`
+command. Two copies would drift, and the drift would appear as one job
+passing and the other failing on the same commit. Verified after the
+extraction that all eight steps are byte-identical to what `build` ran
+before, and that `build` lost nothing but the old rake step.
+
+They share the cache too, since the keys come from that same command.
+Only `build` writes it, so the two never race to save one key.
+
+**One consequence to act on outside this repository:** `static` is a
+new status check, `ci/circleci: static`. Branch protection will not
+require it until somebody adds it, and a check that is not required is
+a check that can go red without stopping a merge.
 
 ### Rebuilding this on GitHub, later
 
@@ -2471,13 +2541,19 @@ Making the build faster, in the order decided under
     success it emits 205 bytes, not the report. See
     [One scan, not two](#one-scan-not-two).
 16. **DONE 2026-08-05: code-determined checks skipped on `staging` and
-    `production`.** `rake deploy_checks` is the time-varying checks
-    plus the whole test suite, and the `build` job picks it by exact
-    branch name. See
+    `production`.** First as a branch conditional in the `build` job,
+    then, in step 17, as a workflow filter that leaves the whole job
+    out. See
     [What the deploy branches skip](#what-the-deploy-branches-skip).
-17. **Split `build` into parallel `static` and `test` jobs**, which
-    extends step 16 to pull requests. The static job needs neither
-    PostgreSQL nor Chrome.
+17. **DONE 2026-08-05: split into parallel `static` and `build` jobs.**
+    The checks settled by the commit run beside the tests rather than
+    in front of them, on their own executor with no PostgreSQL and no
+    Chrome. The branch conditional from step 16 is deleted in favour of
+    a workflow filter. See [Two jobs, not
+    one](#two-jobs-not-one-which-deletes-the-conditional).
+
+    Outside this repository: add `ci/circleci: static` to the required
+    status checks, or it can go red without stopping a merge.
 18. **Measure in CI, then decide** about parallel system tests, a larger
     resource class, and splitting the suite across containers. None of
     those should be bought on an estimate.
@@ -2575,7 +2651,14 @@ cause.
   gate and produce the browsable page.
 * Ten of those checks are settled by the commit; only `bundle_audit`
   and `percent_gems_up_to_date` can change answer without the code
-  changing.
+  changing. `rake static_checks` and `rake dynamic_checks` are those
+  two halves, and `rake default` is defined as both, so it cannot come
+  to mean something different from what CI runs.
+* **None of the static checks needs a database.** All ten pass with
+  `PGHOST` pointed at a dead port, which is what lets them run on an
+  executor with no PostgreSQL and no browser.
+* A CircleCI `commands:` block is how two jobs share steps. Job-level
+  YAML anchors are not a supported substitute; a command is.
 * There is no test image. The `build` job runs on Heroku's stack image
   and installs Ruby and Node into `$HOME` in about fourteen seconds.
 * DockerHub pulls through CircleCI are not rate limited, by arrangement

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -20,65 +20,75 @@
 require 'English'
 require 'json'
 
-# NOTE: Our default runs test:optimized, not just test.
-# We want to make sure things work using *all* our tests.
-# test:optimized runs regular tests (parallelized) then system tests (serial).
-# We do the whitespace check early, so it will fail early.
-# AI assistants just can't help but add whitespace at the end of lines.
-# Everything else in the default list is settled by the commit: the same
-# tree gives the same answer for ever. These are not. bundle_audit reads
-# an advisory database and percent_gems_up_to_date reads rubygems.org,
-# both of which move underneath an unchanged commit, so a gem set that
-# was clean when it merged can be vulnerable by the time it deploys.
-# That is exactly the moment we want to be told.
+# The work "rake default" does, split three ways, because CI runs the
+# halves as separate jobs at the same time and a developer runs all of
+# it with one word. Every list below is built from these constants, so
+# "rake default" cannot come to mean something different from what CI
+# runs; see docs/build-environment-staleness.md.
 #
-# So these run on EVERY build, deploy builds included, while the
-# code-determined checks do not; see :deploy_checks below and
-# docs/build-environment-staleness.md. 'bundle' is here because the
-# tests cannot run without it, not because it is a check.
-TIME_VARYING_CHECKS = %w[
+# Getting Ruby and the gems in place. Not checks, but nothing else
+# works without them.
+PREFLIGHT = %w[
+  rbenv_rvm_setup
   bundle
-  bundle_audit
-  percent_gems_up_to_date
 ].freeze
 
+# STATIC: settled by the commit. The same tree gives the same answer for
+# ever, so these need to run once per commit and no more. That is what
+# lets them move to their own parallel job, and what lets staging and
+# production skip them: those branches are reached only by
+# fast-forwarding main, which has already run every one of them.
+#
+# whitespace_check leads deliberately, and "rake default" also names it
+# ahead of everything so it fails early. AI assistants just can't help
+# but add whitespace at the end of lines.
+STATIC_CHECKS = %w[
+  whitespace_check
+  ruby_syntax
+  generate_criteria_doc
+  rubocop
+  markdownlint
+  rails_best_practices
+  license_okay
+  yaml_syntax_check
+  circleci_config_check
+  html_from_markdown
+  eslint
+  report_code_statistics
+].freeze
+
+# DYNAMIC: not settled by the commit. bundle_audit reads an advisory
+# database and percent_gems_up_to_date reads rubygems.org, both of which
+# move underneath an unchanged commit, so a gem set that was clean when
+# it merged can be vulnerable by the time it deploys. That is exactly
+# the moment we want to be told, so these run on every build, deploys
+# included.
+#
+# The tests belong here for the same reason rather than by analogy: a
+# green suite is not a property of the commit alone. Re-running it is
+# how flapping is noticed, and it is the last thing standing between a
+# deploy and production.
+#
+# test:optimized runs the regular tests (parallelized) and then the
+# system tests (serial).
+DYNAMIC_CHECKS = %w[
+  bundle_audit
+  percent_gems_up_to_date
+  test:optimized
+].freeze
+
+# Everything, which is what a developer wants from one word, and what
+# runs on a machine with no CI to split the work across. Defined from
+# the two halves so it cannot drift from what CI actually runs.
 task(:default).clear.enhance(
-  %w[
-    rbenv_rvm_setup
-    notice
-    whitespace_check
-    ruby_syntax
-  ] + TIME_VARYING_CHECKS + %w[
-    generate_criteria_doc
-    rubocop
-    markdownlint
-    rails_best_practices
-    license_okay
-    yaml_syntax_check
-    circleci_config_check
-    html_from_markdown
-    eslint
-    report_code_statistics
-    test:optimized
-  ]
+  %w[notice whitespace_check] + %w[static_checks dynamic_checks]
 )
 
-# What CI runs on the staging and production branches, where the
-# code-determined checks above would only re-establish what main
-# already established: those branches are reached by fast-forward from
-# main, and branch protection is what makes that true rather than
-# merely customary.
-#
-# Tests still run, because a passing suite is not a property of the
-# commit alone: it is how flapping is noticed, and it is the last thing
-# standing between a deploy and production.
-#
-# Defined from the same constant the default list splices in, so the
-# two cannot drift apart.
-desc 'Checks that must run on every build, deploys included'
-task(:deploy_checks).clear.enhance(
-  %w[rbenv_rvm_setup] + TIME_VARYING_CHECKS + %w[test:optimized]
-)
+desc 'Checks settled by the commit; CI runs these in a parallel job'
+task(:static_checks).clear.enhance(PREFLIGHT + STATIC_CHECKS)
+
+desc 'Tests, and checks whose answer changes without the code changing'
+task(:dynamic_checks).clear.enhance(PREFLIGHT + DYNAMIC_CHECKS)
 # Temporarily removed fasterer
 # Waiting for Ruby 2.4 support: https://github.com/seattlerb/ruby_parser/issues/239
 # Temporarily removed railroader because of local install problems;


### PR DESCRIPTION
The checks settled by the commit now run in their own CircleCI job, "static", beside "build" rather than in front of it.  Neither requires the other, so CircleCI starts both at once and the wall clock becomes the longer of the two instead of their sum.

Measured on a four-core machine: rake static_checks 50s, rake dynamic_checks 199s, the two in sequence 249s.  CI's numbers will differ, and the ratio will differ more, since two processors change the tests more than they change a linter.  The shape is the point.

Three task lists built from three constants, so "rake default" cannot come to mean something other than what CI runs:

    task(:default).clear.enhance(
      %w[notice whitespace_check] + %w[static_checks dynamic_checks])
    task(:static_checks).clear.enhance(PREFLIGHT + STATIC_CHECKS)
    task(:dynamic_checks).clear.enhance(PREFLIGHT + DYNAMIC_CHECKS)

A developer still types "rake" and gets everything, still in the order that fails fastest.  deploy_checks is renamed dynamic_checks: it now runs on every branch, so a name saying "deploy" would be actively misleading, and its partner static_checks makes the pair the ordinary distinction between static and dynamic analysis, which is what a test suite is.

The branch conditional added yesterday is DELETED rather than moved. The build job runs one task on every branch with nothing to decide, and what keeps the checks off staging and production is now a workflow filter that leaves the whole job out.  That is better than a case statement inside a step: a filtered-out job is visible as absent in the pipeline, where a step that decided to do nothing is visible only to somebody reading the log.  "ignore" rather than "only", so a new branch is checked more rather than less.  deploy requires build and deliberately not static, since on those branches static does not exist and a job cannot require one the workflow filtered away.

Its own executor, ruby-only.  Reusing ruby-postgres would start a PostgreSQL container and a 2.12GB Chrome container for a job that speaks to neither.  That the static checks need no database was checked rather than assumed: all ten pass with PGHOST pointed at a dead port. The database.yml copy is kept anyway, because Rails wants the file to exist at boot and one cp is cheaper than establishing whether it does.

The setup is shared, not copied.  The eight steps both jobs need, cache identity through bundle install, moved into a prepare_ruby command; two copies would drift, and the drift would show up as one job passing and the other failing on the same commit.  Verified after the extraction that all eight are byte-identical to what build ran before, and that build lost nothing but the old rake step.  They share the dependency cache for the same reason, and only build writes it, so the two never race to save one key.

Both tasks verified locally: static_checks exits 0, dynamic_checks exits 0 with 1232 tests, 23 system tests, Combined Coverage 100.0% and every file at 100% statement coverage.  The gem currency line still prints, since percent_gems_up_to_date is in the dynamic half and so still runs on every build including deploys.

One thing to do outside this repository: "ci/circleci: static" is a new status check, and branch protection will not require it until somebody adds it.  A check that is not required can go red without stopping a merge.