### PR TITLE
Turn Bootsnap on in development, where it was silently off

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -8,21 +8,40 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 
-if ENV['RAILS_ENV'] == 'development'
-  require 'bootsnap'
-  Bootsnap.setup(
-    # Path to your cache
-    cache_dir:            'tmp/cache',
-    # This should be set to whatever evaluates your current working environment,
-    # e.g. RACK_ENV, RAILS_ENV, etc
-    development_mode:     ENV['RAILS_ENV'] == 'development',
-    # Should we optimize the LOAD_PATH with a cache?
-    load_path_cache:      true,
-    # Sets `RubyVM::InstructionSequence.compile_option =
-    #   { trace_instruction: false }`
-    # Should compile Ruby code into ISeq cache?
-    compile_cache_iseq:   true,
-    # Should compile YAML into a cache?
-    compile_cache_yaml:   true
-  )
+# Work out the environment the way RAILS ITSELF does, rather than by
+# testing ENV['RAILS_ENV'] alone. Rails.env is
+# ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development', so an UNSET
+# RAILS_ENV means development, and unset is the normal case for "rake",
+# "rails console" and "rails server".
+#
+# This file used to test ENV['RAILS_ENV'] == 'development' directly, so
+# Bootsnap was skipped in exactly those cases: measured at 3.89s against
+# 2.09s for "rake -T". About 1.8 seconds, lost every time anyone did the
+# ordinary thing, on the machine of every developer.
+rails_env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+
+if rails_env == 'development'
+  begin
+    require 'bootsnap'
+    Bootsnap.setup(
+      # Path to your cache
+      cache_dir:            'tmp/cache',
+      # We are in development here by definition, per the check above.
+      development_mode:     true,
+      # Should we optimize the LOAD_PATH with a cache?
+      load_path_cache:      true,
+      # Sets `RubyVM::InstructionSequence.compile_option =
+      #   { trace_instruction: false }`
+      # Should compile Ruby code into ISeq cache?
+      compile_cache_iseq:   true,
+      # Should compile YAML into a cache?
+      compile_cache_yaml:   true
+    )
+  rescue LoadError
+    # bootsnap is in the development bundle group, so a bundle installed
+    # without that group has no gem to require. Carry on: this is a
+    # cache, not a dependency, and refusing to boot over a missing
+    # accelerator would be worse than booting slowly.
+    warn 'Note: bootsnap is not installed, so boot will be slower.'
+  end
 end

--- a/docs/build-environment-staleness.md
+++ b/docs/build-environment-staleness.md
@@ -1472,6 +1472,40 @@ That second row is the point: it is not a rake improvement, it is on
 every development and test boot, including `rails console`, `rails
 server` and the test suite.
 
+### Bootsnap was switched off in the case that matters
+
+Found 2026-08-05, chasing the last of `rake -T`. `config/boot.rb` read:
+
+```ruby
+if ENV['RAILS_ENV'] == 'development'
+  require 'bootsnap'
+```
+
+**An unset `RAILS_ENV` is not the string `development`**, so that test
+was false for plain `rake`, `rails console`, `rails server` and
+`rails runner`, which is to say for nearly everything anyone does by
+hand. Rails itself treats unset as development: `Rails.env` is
+`ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'`. So Bootsnap, a
+gem in the Gemfile precisely to make development boots fast, was being
+skipped in development.
+
+Measured, with the variable unset both times:
+
+| Command | Before | After |
+| ------- | ------ | ----- |
+| `rake -T` | 3.89s | **2.29s** |
+| `rails runner 'puts 1'` | 8.38s | **3.23s** |
+| `rails console` | | 4.61s |
+
+`rails runner` is now under a third of the 10.80s it took at the start
+of this work. `RAILS_ENV=test` and `RAILS_ENV=production` are unchanged,
+as they should be: neither uses Bootsnap.
+
+The require is now wrapped in a `rescue LoadError`, because `bootsnap`
+is in the development bundle group and a bundle installed without that
+group has no gem to load. It is a cache, not a dependency; refusing to
+boot over a missing accelerator would be worse than booting slowly.
+
 ### The marker, and why silence is not allowed
 
 The rule is one sentence: **a task needs Rails unless every task


### PR DESCRIPTION
config/boot.rb read:

    if ENV['RAILS_ENV'] == 'development'
      require 'bootsnap'

An UNSET RAILS_ENV is not the string "development", so that test was false for plain "rake", "rails console", "rails server" and "rails runner": nearly everything anyone does by hand.  Rails itself treats unset as development, Rails.env being
ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'.  So Bootsnap, a gem in the Gemfile precisely to make development boots fast, was being skipped in development.

Measured with the variable unset both times:

    rake -T                  3.89s -> 2.29s
    rails runner 'puts 1'    8.38s -> 3.23s
    rails console                    4.61s

rails runner is now under a third of the 10.80s it took before this week's work.  RAILS_ENV=test and RAILS_ENV=production are unchanged, as they should be: neither uses Bootsnap.

The require is now wrapped in a rescue LoadError, because bootsnap sits in the development bundle group and a bundle installed without that group has no gem to load.  It is a cache, not a dependency; refusing to boot over a missing accelerator would be worse than booting slowly.

Verified with a full "rake default": 1232 tests, 23 system tests, Combined Coverage 100.0%, every file at 100% statement coverage.