### PR TITLE
Group codeql-action bumps: init+analyze must be =

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,24 @@ updates:
     schedule:
       # Every weekday
       interval: "daily"
+    # ONE PULL REQUEST FOR ALL OF github/codeql-action. Dependabot keys
+    # actions by their full path, so "github/codeql-action/init",
+    # ".../analyze" and ".../upload-sarif" look like three unrelated
+    # dependencies to it and each got its own pull request. They are not
+    # unrelated: they ship from one repository in one release, and init
+    # and analyze *must* run the same version, because init records its
+    # version in the config file that analyze reloads and analyze treats
+    # any mismatch as a fatal error. So a pull request bumping one of
+    # them alone cannot pass CodeQL, and three such pull requests can
+    # only go green by being merged together, which is not something the
+    # pull request list can express. Grouping them makes the proposal
+    # match the unit that actually moves. See .github/workflows/codeql.yml
+    # and "rake codeql_version_check", which fails the build if the pins
+    # ever drift apart despite this.
+    #
+    # Everything else stays ungrouped, and so still arrives as one pull
+    # request per action, to be judged on its own.
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -94,11 +94,22 @@ jobs:
       - name: Validate branch name
         run: script/validate_branch_name "$GITHUB_REF_NAME"
 
-      # Pinned to the same github/codeql-action release already used (and kept
-      # up to date by Dependabot) in scorecard.yml; init and analyze live in
-      # that same repository and release, so they share one commit SHA.
+      # INIT AND ANALYZE MUST BE THE SAME RELEASE, and not merely as a
+      # tidiness preference: init writes its own version into the config
+      # file it leaves behind, analyze reloads that file and compares, and
+      # any difference is a hard error ("Loaded a configuration file for
+      # version X, but running version Y") with no fallback. A one-line
+      # bump to either step alone therefore fails every language in the
+      # matrix. Dependabot treats each subdirectory of github/codeql-action
+      # as a separate dependency and would propose exactly that one-line
+      # bump, so .github/dependabot.yml groups them into a single pull
+      # request, and "rake codeql_version_check" fails the build if the
+      # pins ever drift apart anyway. upload-sarif in scorecard.yml is in
+      # the group too: it does not read init's config and so is not part of
+      # the constraint, but moving the whole action at once is one less
+      # thing to reason about.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -108,6 +119,6 @@ jobs:
           # manageable; revisit once the baseline is clean.
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -75,6 +75,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           sarif_file: results.sarif

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -88,6 +88,7 @@ STATIC_CHECKS = %w[
   license_okay
   yaml_syntax_check
   circleci_config_check
+  codeql_version_check
   html_from_markdown
   eslint
   report_code_statistics
@@ -514,6 +515,59 @@ task circleci_config_check: :no_rails do
     puts 'the characters in comments rather than spelling them out.'
     offenders.each do |line_number, text|
       puts "  #{path}:#{line_number}: #{text}"
+    end
+    exit 1
+  end
+end
+
+# The CodeQL action's "init" step writes the version of itself into the
+# config file it leaves in the work area, and the "analyze" step reloads
+# that file and compares the two. A difference is fatal, reported as
+# "Loaded a configuration file for version X, but running version Y", and
+# there is no fallback: every language in the matrix fails.
+#
+# Nothing in a workflow file expresses that constraint, and the two steps
+# are pinned by commit SHA on separate lines, which is precisely the shape
+# an automated dependency bump edits one line of. Dependabot did, three
+# times, because it keys actions by full path and so sees "init" and
+# "analyze" as unrelated dependencies. .github/dependabot.yml now groups
+# them, and this is the check that notices if they ever come apart
+# regardless: a hand edit, a bad merge, or a future tool with the same
+# blind spot.
+#
+# Only init and analyze are constrained. upload-sarif reads no config
+# from init and is deliberately not checked here, so scorecard.yml stays
+# free to move on its own schedule.
+desc 'Check github/codeql-action init and analyze are pinned alike'
+task codeql_version_check: :no_rails do
+  path = '.github/workflows/codeql.yml'
+  puts "Checking #{path} pins CodeQL init and analyze alike..."
+  raise StandardError, "Missing #{path}" unless File.exist?(path)
+
+  # Capture the SHA and the trailing "# vX.Y.Z" comment for each step, so
+  # a mismatch can be reported in the terms the file is written in.
+  pattern = %r{codeql-action/(init|analyze)@(\S+)\s*(?:\#\s*(\S+))?}
+  pins =
+    File.read(path).scan(pattern).to_h do |step, sha, tag|
+      [step, [sha, tag]]
+    end
+
+  missing = %w[init analyze] - pins.keys
+  if missing.any?
+    raise StandardError,
+          "No CodeQL #{missing.join(' or ')} step in #{path}"
+  end
+
+  if pins['init'].first == pins['analyze'].first
+    puts "CodeQL version check completed successfully (#{pins['init'].last})."
+  else
+    puts 'ERROR: CodeQL init and analyze are pinned to different releases.'
+    puts 'The analyze step reloads the config file init wrote and rejects'
+    puts 'any version difference, so every language in the matrix fails.'
+    puts 'Move both lines to the same commit SHA of github/codeql-action.'
+    %w[init analyze].each do |step|
+      sha, tag = pins[step]
+      puts "  #{step}: #{sha} #{tag}"
     end
     exit 1
   end


### PR DESCRIPTION
Three Dependabot pull requests were open (#2915, #2916, #2917) and two of them could not pass CodeQL no matter how often they were rebased. The failure is real, and it is not CodeQL misjudging things.

The CodeQL action's "init" step writes its own version into the config file it leaves in the work area, and "analyze" reloads that file and compares.  Any difference in version number is fatal, since otherwise they won't necessarily work together:

  Error: Loaded a configuration file for version '4.37.1',
  but running version '4.37.5'

Dependabot keys actions by their full path, so "codeql-action/init", ".../analyze" and ".../upload-sarif" look like three *unrelated* dependencies to Dependabot. As a result, it proposed each update as its own. In this case, that's won't work; a pull request bumping one line of a two-line handshake cannot pass.

This happened in PR #2915 (init) and #2917 (analyze) since each left the pair on different releases and failed all three, not merely the "actions" language quoted in the report.  Those two could only ever have gone green by being merged together, which is not something a list of pull requests can express.

Four changes:

* .github/dependabot.yml gets a "codeql-action" group, which is the fixes things. All of github/codeql-action now arrives as one pull request, matching the unit that actually moves.  Everything else stays ungrouped and still arrives one action per pull request, to be judged on its own.

* codeql.yml moves init AND analyze to v4.37.5.  The SHA was confirmed by dereferencing the annotated v4.37.5 tag through the GitHub API rather than trusting the comment in the proposed diff.

* scorecard.yml moves upload-sarif to the same SHA.  It is not under the constraint, but moving the whole action at once is one less thing to reason about.

* "rake codeql_version_check" fails the build if the two pins ever drift apart, and is added to STATIC_CHECKS.  Grouping stops Dependabot from splitting them; this catches a hand edit, a bad merge, or some future tool with the same blind spot.  Modeled on circleci_config_check, which exists for the same reason: a constraint the file format cannot state, so a grep states it instead.  Verified in both directions, by mismatching a pin deliberately and confirming exit 1 with a message that says what to do.

I will separately close #2915, #2916 and #2917 as superseded.