### PR TITLE
Make deploying easier, and possible without a development environment

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -239,9 +239,177 @@ changes.
 This is designed to be easily deployed simply by doing a `git push`
 to an appropriate destination.
 
-We currently run a `rake deploy_staging` command that does a `git push`
-to deploy to a staging site, and later `rake deploy_production` to push
-to the production site.
+Deploying to either tier needs no Ruby, no bundle and no rbenv, just
+`git` and the right to push. The `rake` tasks below are thin wrappers
+around the same commands, so use whichever you have to hand.
+
+If you have no clone, get one. Clone the canonical repository rather
+than a fork, since deploying pushes to its branches:
+
+~~~~sh
+git clone https://github.com/ossf/best-practices-badge.git
+cd best-practices-badge
+~~~~
+
+### Deploying to staging
+
+Deploying copies one branch into the next: `main` into `staging`, and
+later `staging` into `production`. CircleCI notices the push, runs the
+suite again, and deploys that branch to its tier.
+
+With a development environment, deploying to staging is the whole of it:
+
+~~~~sh
+rake deploy_staging
+~~~~
+
+That copies `main` **as it exists on GitHub** into `staging`, so an
+unpushed commit of your own cannot reach staging.
+
+It also brings your **local** `staging` branch up to date, which is the
+point of doing it this way: `git log staging` and `git diff staging` tell
+the truth afterwards. Nothing else moves, your working tree is left
+alone, and a dirty tree is fine. The one restriction is that **you
+cannot be on `staging`** when you run it: git refuses to fetch into a
+checked-out branch. That is a fair trade, since `staging` is a branch to
+read rather than work on, and the refusal tells you something odd is
+going on.
+
+**It need not wait for main's checks to finish.** Staging is a test
+tier, and CircleCI runs the suite again on the staging branch, so
+starting a staging deploy while main is still being checked simply runs
+two suites at once.
+
+**Afterwards it tells you about your own `main`, if there is anything to
+say.** Behind GitHub, the usual case, it gives you the one command to
+catch up. Ahead of GitHub, which is what happens when you start work
+without branching first, it warns, lists the commits that exist only on
+your machine, and gives you the two commands that move them onto a
+branch and put `main` back. Either way the deploy has already happened,
+so nothing there can delay it.
+
+**Do not deploy by merging a pull request.** GitHub has no fast-forward
+merge, and the merge commit it makes instead would break every later
+deploy.
+
+### Deploying to staging without a development environment
+
+These two commands deploy to staging, and are exactly what
+`rake deploy_staging` runs:
+
+~~~~sh
+git fetch origin main:staging +main:refs/remotes/origin/main &&
+  git push origin staging
+~~~~
+
+Read that as "bring origin's `main` down as my `staging`, then push my
+`staging` up", which is what it does. It creates your local `staging` if
+you have none, and works from any branch except `staging` itself.
+
+It also refreshes `origin/main`, which is what keeps `git status` honest:
+an explicit `main:staging` overrides the clone's configured refspec, so
+without that second refspec no remote-tracking ref would be updated and
+`git status` on `main` would stop telling you how far behind you are.
+That half writes to a remote-tracking ref rather than to your `main`, so
+it works even while you are standing on `main`.
+
+Every part earns its place:
+
+* **`&&`, not two commands.** If your local `staging` has diverged, the
+  fetch is rejected as a non-fast-forward and the divergent commit stays
+  put. An unguarded push would then send that commit to the deploy
+  branch. The `&&` is what prevents it.
+* **No `--force`, on either command.** Git refuses a fetch that is not a
+  fast-forward of your local branch, and refuses a push that is not one
+  on GitHub's side. Adding `--force` to either would defeat the point.
+* **The leading `+` on the second refspec only.** A remote-tracking ref
+  is a mirror of GitHub, where a forced update is normal; `main:staging`
+  stays unforced so a divergence stops the deploy.
+
+The push reports what moved, as `old..new staging -> staging`.
+
+### Deploying to staging with gh, without a checkout
+
+With [gh](https://cli.github.com/), GitHub's own command-line tool, you
+don't need a clone:
+
+~~~~sh
+main_sha=$(gh api repos/ossf/best-practices-badge/git/ref/heads/main \
+  --jq .object.sha) &&
+  gh api --method PATCH \
+    repos/ossf/best-practices-badge/git/refs/heads/staging -f sha="$main_sha"
+~~~~
+
+`--jq` is built into `gh`, so the separate `jq` program is not needed;
+it picks the commit id out of the reply so the second call can use it.
+Leaving out `force` is the safety, as with `--force` above: GitHub
+rejects an update that is not a fast-forward. Do not add it.
+
+For why deploying works this way, see
+[deploying in detail](./implementation.md#deploying-in-detail).
+
+### Deploying to production
+
+Deploying to production has the same shape as staging, one branch further
+along, with one difference.
+In our normal setup, **production waits for evidence from staging.**
+A staging deploy may start before main's checks finish, because CircleCI
+tests the tree again on the staging branch. Production has no such excuse,
+so check that `staging` passed everything first.
+
+With a development environment:
+
+~~~~sh
+rake deploy_production
+~~~~
+
+That runs the check below, refuses to deploy if anything on `staging` is
+not green, and otherwise behaves like `rake deploy_staging` one branch
+along: it brings your local `production` up to date and cannot be run
+while `production` is checked out.
+
+### Deploying to production without a development environment
+
+First ask GitHub whether `staging` passed. This needs no account, no
+token and no `jq`:
+
+~~~~sh
+api=https://api.github.com/repos/ossf/best-practices-badge/commits/staging
+curl -sSf "$api/status" "$api/check-runs?per_page=100" |
+  grep -E '"(state|status|conclusion)":' | grep -vE '"(success|completed)"'
+~~~~
+
+**No output means everything passed.** Any output means something is not
+green, so open the `staging` commit on GitHub and look before going
+further. Both URLs are needed: they report different things, and asking
+only the first would once have called a commit green whose CodeQL
+analyses had failed.
+
+Then copy `staging` into `production`:
+
+~~~~sh
+git fetch origin staging:production \
+    +staging:refs/remotes/origin/staging &&
+  git push origin production
+~~~~
+
+The same notes apply as for staging: the `&&` guards against pushing a
+diverged local `production`, no `--force` except on the tracking ref,
+your local `production` is brought up to date, `origin/staging` is
+refreshed so `git status` stays accurate there too, and you cannot be
+standing on `production` when you run it.
+
+### Deploying to production with gh, without a checkout
+
+~~~~sh
+staging_sha=$(gh api repos/ossf/best-practices-badge/git/ref/heads/staging \
+  --jq .object.sha) &&
+  gh api --method PATCH \
+    repos/ossf/best-practices-badge/git/refs/heads/production \
+    -f sha="$staging_sha"
+~~~~
+
+Check `staging` status first; these `gh` commands will not do that for you.
 
 ## See also
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -378,6 +378,10 @@ we removed the `main` tier to save money.
 If you have write authorization to the GitHub repository,
 the commands `rake deploy_staging` and `rake deploy_production`
 will update the staging and production branches (respectively).
+Those commands are only a few `git` commands each, so you can advance
+the branches without a development environment, with plain `git` or
+with `gh` and no checkout at all; see
+[deployment instructions](./INSTALL.md#deployment-instructions).
 Those updates will trigger tests by CircleCI as usual (via webhooks).
 If those tests pass, CirccleIC will then deploy that updated branch to
 its respective tier.

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -381,9 +381,15 @@ the time-consuming process of recalculating all projects.)
 **If your migration will change some percentage calculations**,
 the tier it runs on needs current production data first, or projects
 will get spurious warnings about losing badges.
-You don't have to remember to do this: `rake deploy_staging` depends on
-`rake production_to_staging`, which restores the latest production
-backup into staging before the deploy.
+You don't have to remember to do this: CircleCI's deploy job restores
+production's latest backup into staging, under maintenance mode,
+whenever the branch being deployed is exactly `staging`. That happens
+however the `staging` branch was advanced, so it does not depend on
+using `rake deploy_staging`; see
+[deployment instructions](./INSTALL.md#deployment-instructions) for the
+ways to advance it, including ones needing no development environment.
+`rake production_to_staging` still exists for refreshing staging out of
+band, without a deploy.
 
 Once you've created the migration file, check it first by running
 "rake rubocop".  This will warn you of some potential issues, and
@@ -1148,6 +1154,132 @@ ALL_DETECTIVES =
 We use the ZAP web application scanner to find potential
 vulnerabilities.
 This lets us fulfill the "dynamic analysis" criterion.
+
+## Deploying in detail
+
+The commands are in
+[INSTALL.md](./INSTALL.md#deploying-to-staging-without-a-development-environment).
+This is why they are what they are.
+
+**Deploying is copying one branch into the next, and nothing else.**
+`main` goes into `staging`, and later `staging` goes into `production`.
+CircleCI watches those branches, runs the suite again, and deploys the
+branch to its tier. No deploy command holds a Heroku credential; the
+credential lives in CircleCI, which is the only thing that needs it.
+
+**That is why no development environment is needed.** `rake
+deploy_staging` is two `git` commands. What made deploying appear to
+need a development environment was never the task: it is that `rake`
+loads `config/boot`, and therefore Bundler, whatever task you ask for.
+Running the `git` commands directly skips that.
+
+**The copy must be a fast-forward.** `staging` has to stay a commit that
+also exists on `main`, because that is what lets the next deploy copy
+`main` in cleanly, and what makes the deployed tree identical to a tree
+that passed on `main`. Nothing enforces this by policy: it is enforced
+by not passing `--force` to `git push`, and by not passing `force` over
+the API, both of which make the far end refuse an update that is not a
+fast-forward.
+
+**Why it fetches into the deploy branch** rather than checking out
+`staging` and merging, which is what it used to do. `git fetch origin
+main:staging` needs no checkout, so it works from any branch, leaves the
+working tree alone and tolerates a dirty one. The checkout-and-merge
+form assumed you were on `main`, moved you if you were not, carried
+uncommitted changes across two branch switches, and failed outright in a
+`--single-branch` or `--depth` clone where `git switch staging` answers
+"invalid reference".
+
+**The fetch source is origin's branch, not your clone's.** That is the
+property that keeps unreviewed work out of production:
+`git push origin main:staging` would have deployed your local `main`,
+unpushed commits and all, and it is four characters shorter than the
+right thing.
+
+**Fetching into the branch is why your local copy stays honest.** Local
+`staging` is created if absent and fast-forwarded if present, so
+`git log staging` describes what is deployed rather than wherever the
+branch sat when you last looked. In a full clone the push updates
+`origin/staging` as well; in a `--single-branch` clone it does not,
+because that clone's configured refspec never mapped it.
+
+**The second refspec exists because the first one silences the usual
+one.** Giving `git fetch` an explicit `src:dst` overrides the clone's
+configured `+refs/heads/*:refs/remotes/origin/*`, so no remote-tracking
+ref is touched at all. Left there, `origin/main` would go stale while
+deploys kept succeeding, and `git status` on `main` would stop reporting
+how far behind you were: the deploy would be quietly costing you the
+normal way of noticing drift. `+main:refs/remotes/origin/main` puts that
+back. It writes to a tracking ref rather than to `refs/heads/main`, so
+it works while `main` is checked out, and it is forced because a tracking
+ref is a mirror of the remote, unlike `main:staging`, which must stay
+unforced so a divergence stops the deploy.
+
+**The price is that you cannot be standing on the branch you deploy.**
+Git refuses to fetch into a checked-out branch, stopping with "refusing
+to fetch into branch". `staging` and `production` are branches to read
+rather than work on, so this costs nothing in practice, and the refusal
+is a useful signal when it does fire.
+
+**The `&&` carries more weight than it looks.** A rejected fetch, which
+is what a diverged local `staging` produces, exits 1 and leaves the
+divergent commit in place. An unguarded push would then send exactly
+that commit to the deploy branch. Not passing `--force` is the other
+half: the fetch must be a fast-forward of your local branch and the push
+must be one on GitHub's side.
+
+**Never deploy by merging a pull request.** GitHub can merge only by
+creating a merge commit, squashing, or rebasing; it has no fast-forward
+merge. Each of those leaves a commit on `staging` that is not on `main`,
+so the two diverge and every later deploy is refused as a
+non-fast-forward. One convenient pull request breaks deploying from then
+on, and the repair is manual.
+
+**A staging deploy reports on your local `main` afterwards**, and only
+when there is something to report. Being behind is ordinary and gets the
+cure without a number, since how far behind you are does not change what
+to do. Being *ahead* is not ordinary: it means commits exist on your
+machine and nowhere else, unreviewed, untested and undeployed, which is
+what happens when work starts without a branch. That case names the
+commits and offers `git branch SAVED-WORK main` followed by
+`git switch main && git reset --keep origin/main`. `--keep` rather than
+`--hard` because it refuses rather than discards when uncommitted
+changes are in the way. Both comparisons use `origin/main`, which the
+fetch has just refreshed, so they cost nothing and need no network, and
+the report runs after the push so it can neither delay nor fail a
+deploy.
+
+**Staging deploys need not wait for main's checks, production deploys
+must.** Staging is a test tier, and CircleCI runs the suite again on the
+staging branch, so starting a staging deploy while main is still being
+checked simply runs two suites at once. Production gets no such excuse,
+so `rake deploy_production` asks GitHub whether `staging` passed and
+refuses otherwise.
+
+**That question needs two endpoints, and neither is redundant.**
+`ci/circleci: static` is reported as a commit STATUS and never appears
+among the check runs, while CodeQL, brakeman and codespell are check
+RUNS and never appear among the statuses. Asking only for statuses once
+reported a commit as green whose three CodeQL analyses had failed, which
+is how we know to ask for both.
+
+**The grep pair is inverted on purpose.** It reports anything that is
+not `success` or `completed`, rather than hunting for known bad words,
+so a conclusion GitHub invents later stops a deploy instead of slipping
+past. A `null` conclusion, meaning a check still running, stops it too.
+`curl -sSf` and its `|| exit 1` matter for the same reason: curl exits
+22 when `-f` meets an error, and without that check an empty reply would
+read as an empty list of problems, which is to say as success.
+
+**Deploying refreshes staging's database.** CircleCI's deploy job
+restores production's latest backup into staging, under maintenance
+mode, whenever the branch being deployed is exactly `staging`. It is
+keyed on the branch, not on how the branch was advanced, so every route
+in INSTALL.md gets it. `rake production_to_staging` remains for doing
+that refresh out of band, without a deploy.
+
+**One detail about the `gh` form**: reading a ref uses `git/ref` and
+updating one uses `git/refs`. That is GitHub's inconsistency, not a typo.
 
 ## Setup for deployment
 

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -685,14 +685,143 @@ end
 # in the CircleCI deploy job on HEROKU_API_KEY, which never needs a
 # browser, and under maintenance mode rather than against a live site.
 # See .circleci/config.yml and docs/build-environment-staleness.md.
+# FETCHES ORIGIN'S main INTO LOCAL staging, THEN PUSHES THAT.
+#
+# The fetch source is origin's main, never your local main, so an
+# unpushed commit of yours cannot reach staging.
+#
+# WHAT IT UPDATES LOCALLY, deliberately: your local "staging" branch is
+# created if absent and fast-forwarded if present, so "git log staging"
+# and "git diff staging" tell the truth after a deploy instead of
+# describing wherever staging sat when you last looked. In a full clone
+# the push updates "origin/staging" too; in a --single-branch or --depth
+# clone it does not, because that clone's refspec never mapped it.
+# Nothing else is touched: no other branch moves, the working tree is
+# left alone, and a dirty tree is fine.
+#
+# WHAT YOU CANNOT BE ON: "staging" itself. Git refuses to fetch into a
+# checked-out branch and stops with "refusing to fetch into branch". That
+# is a fair limitation, since staging is a branch to read rather than
+# work on, and the refusal is a useful signal that something odd is
+# going on.
+#
+# THE SECOND REFSPEC KEEPS "git status" HONEST. "+main:refs/..." updates
+# origin/main, which the first refspec does not, because an explicit
+# src:dst overrides the clone's configured refspec and so no
+# remote-tracking ref would be touched otherwise. Without it origin/main
+# goes stale as deploys succeed and "git status" on main stops reporting
+# how far behind you are. It writes to a remote-tracking ref rather than
+# to refs/heads/main, so it works even while you are standing on main.
+# The leading "+" is deliberate and the asymmetry is the point: a
+# tracking ref is a mirror of the remote, where a forced update is
+# normal, while "main:staging" stays unforced so a divergence stops the
+# deploy.
+#
+# THE "&&" IS THE SAFETY, more than it looks. If your local staging has
+# diverged, the fetch is REJECTED as a non-fast-forward and exits 1,
+# leaving the divergent commit in place; an unguarded push would then
+# send that commit to the deploy branch. Not passing --force is the other
+# half: the push refuses a non-fast-forward on the far end too.
+#
+# The same two commands are documented for people without a development
+# environment in docs/INSTALL.md.
+#
+# AFTER THE DEPLOY, IT REPORTS ON YOUR LOCAL main, and only when there is
+# something to say. The deploy has already happened by then, so nothing
+# here can delay or fail it. origin/main was just refreshed above, so
+# both comparisons are free and need no network, so it makes sense to
+# add the checks specifically *here* since within this command we *can*
+# know for certain what difference there is (if any) between the
+# remote origin's main and our local main.
+#
+# Behind is the ordinary case and only needs the cure. AHEAD IS NOT: it
+# means commits exist here and nowhere else, which is what happens when
+# you forget to branch before starting work, so it names them and offers
+# the way out. "git reset --keep" rather than "--hard" because it refuses
+# rather than discarding uncommitted changes.
+#
+# "--ff-only" ON THE SUGGESTED PULL LOOKS REDUNDANT AND IS NOT. This
+# message appears only when main is behind and not ahead, where a plain
+# "git pull" fast-forwards anyway. The flag is there for the reader's
+# configuration rather than for the ordinary case: with pull.rebase=true,
+# a common setting, a plain pull silently rewrites their commits if main
+# has diverged since this ran, and with pull.rebase=false it puts a merge
+# commit on main. Git's own default refuses either way, so this guards
+# against configuration, not against git.
+#
+# The heredoc below is unquoted, so keep Ruby out of it: no "#{...}", and
+# no backslash escapes, which Ruby would consume before the shell saw
+# them. deploy_production quotes its delimiter for exactly that reason.
 desc 'Deploy current origin/main to staging'
 task deploy_staging: :no_rails do
-  sh 'git checkout staging && git pull && git merge --ff-only origin/main && git push && git checkout main'
+  sh <<~SHELL
+    git fetch origin main:staging +main:refs/remotes/origin/main &&
+      git push origin staging || exit 1
+
+    ahead=$(git rev-list --count origin/main..main 2>/dev/null || echo 0)
+    behind=$(git rev-list --count main..origin/main 2>/dev/null || echo 0)
+    if [ "$ahead" -gt 0 ]; then
+      echo
+      echo "WARNING: your local main has commits that are not on GitHub,"
+      echo 'so they are not reviewed, not tested and not deployed:'
+      git log --oneline origin/main..main
+      echo 'If you meant to work on a branch, move them onto one and put'
+      echo 'main back where GitHub has it:'
+      echo '  git branch SAVED-WORK main'
+      echo '  git switch main && git reset --keep origin/main'
+    elif [ "$behind" -gt 0 ]; then
+      echo
+      echo 'Your local main is out of date. To catch up:'
+      echo '  git switch main && git pull --ff-only'
+    fi
+  SHELL
 end
 
+# Same shape as deploy_staging, one branch further along, so the same
+# notes apply: it reads origin's staging rather than your local one,
+# updates your local "production" branch so it tells the truth
+# afterwards, refuses if you are standing on "production", and relies on
+# the "&&" and on not passing --force to keep every step a
+# fast-forward.
+#
+# The one difference that matters: PRODUCTION WAITS FOR EVIDENCE. A staging
+# deploy may legitimately start before main's checks finish, because
+# CircleCI tests the tree again on the staging branch and the two suites
+# then run in parallel. Production has no such excuse, so this refuses
+# unless everything on staging passed.
+#
+# BOTH ENDPOINTS ARE ASKED, and neither is redundant. CircleCI's
+# "ci/circleci: static" is reported as a commit STATUS and never appears
+# among the check runs, while CodeQL, brakeman and codespell are check
+# RUNS and never appear among the statuses. Asking only for statuses
+# once called a commit green whose three CodeQL analyses had failed.
+#
+# The grep pair is inverted on purpose: it reports anything that is not
+# "success" or "completed" rather than looking for known bad words, so a
+# conclusion GitHub invents later stops the deploy instead of slipping
+# past. A null conclusion, meaning still running, stops it too.
+#
+# "|| exit 1" after the curl is not decoration. curl exits 22 when -f
+# meets an error, and without that the empty reply would look like an
+# empty list of problems, which is to say like success.
 desc 'Deploy current origin/staging to production'
 task deploy_production: :no_rails do
-  sh 'git checkout production && git pull && git merge --ff-only origin/staging && git push && git checkout main'
+  sh <<~'SHELL'
+    api=https://api.github.com/repos/ossf/best-practices-badge/commits/staging
+    checks=$(curl -sSf "$api/status" "$api/check-runs?per_page=100") || exit 1
+    not_green=$(printf '%s\n' "$checks" |
+      grep -E '"(state|status|conclusion)":' |
+      grep -vE '"(success|completed)"')
+    if [ -n "$not_green" ]; then
+      echo 'Refusing to deploy: staging has not passed everything.'
+      printf '%s\n' "$not_green"
+      echo 'Open the staging commit on GitHub to see what.'
+      exit 1
+    fi
+    git fetch origin staging:production \
+        +staging:refs/remotes/origin/staging &&
+      git push origin production
+  SHELL
 end
 
 rule '.html' => '.md' do |t|


### PR DESCRIPTION
Deploying is copying one branch into the next: main into staging, then staging into production. CircleCI notices the push, runs the suite again and deploys that branch to its tier. This makes that a pair of git commands anyone with push rights can run, documents them, and leaves the deploy tasks as thin wrappers around the same pair.

NO NEW WORKFLOW, NO BUTTON, NO BOT CREDENTIAL. A GitHub Actions job advancing the branch was considered and rejected: it would need a token that can write to a deploy branch, and the SBOM generation keyed on pushes to staging and production does not run for events raised by GITHUB_TOKEN, so it would have gone quietly missing. Using a person's own credentials keeps authorization where branch protection already puts it and keeps every push-triggered workflow firing as before.

  rake deploy_staging
  rake deploy_production

Each is now one fetch and one push:

  git fetch origin main:staging +main:refs/remotes/origin/main &&
    git push origin staging

The same two commands are in docs/INSTALL.md for anyone without a development environment, along with a gh form needing no clone at all. Nothing here needs Ruby, a bundle or rbenv: the tasks never did anything but run git, and "rake" itself was the only reason deploying appeared to need a working environment.

WHAT THIS FIXES about the old form, which checked out the deploy branch, pulled, merged and checked out main again:

* It no longer disturbs local work. No branch is switched, the working tree is untouched, and a dirty tree is fine, so it is safe to run in the middle of something.
* It works in a --single-branch or --depth clone, where "git switch staging" answers "invalid reference".
* It keeps local copies honest. Local staging and production are created or fast-forwarded, so "git log staging" describes what is deployed, and the tracking refs are refreshed so "git status" on main keeps reporting how far behind you are.
* The one new limitation: you cannot be standing on the branch you are deploying, because git refuses to fetch into a checked-out branch. These are branches to read rather than work on, and the refusal is a useful signal.

Both forms read origin's branch rather than your clone's, so an unpushed commit cannot reach a deployed tier. "git push origin main:staging", four characters shorter, would deploy local main instead; that is why the documentation names "origin/main, not main" first among the parts to keep. Every step is a fast-forward, enforced by not passing --force rather than by policy, and the "&&" is what stops a rejected fetch from being followed by a push of a diverged local branch.

PRODUCTION WAITS FOR EVIDENCE, staging does not. A staging deploy may start before main's checks finish, because CircleCI tests the tree again on the staging branch and the two suites then run in parallel. Before production, "rake deploy_production" asks GitHub whether staging passed and refuses otherwise. The public status of a public repository needs no account, no token and no jq:

  api=https://api.github.com/repos/ossf/best-practices-badge/commits/staging
  curl -sSf "$api/status" "$api/check-runs?per_page=100" |
    grep -E '"(state|status|conclusion)":' | grep -vE '"(success|completed)"'

No output means everything passed. Both URLs are required: CircleCI's "static" job is reported as a commit status and never appears among the check runs, while CodeQL, brakeman and codespell are check runs and never appear among the statuses. Asking only for statuses reports a commit as green whose CodeQL analyses have failed.

DEPLOYING STAGING ALSO REPORTS ON YOUR OWN main, and says nothing when there is nothing to say. Behind, the ordinary case, it gives the one command to catch up. Ahead, which is what happens when work starts before a branch does, it warns that those commits are unreviewed, untested and undeployed, lists them, and gives the two commands that move them onto a branch and put main back. It runs after the push, so it can neither delay nor fail a deploy.

Never deploy by merging a pull request. GitHub has no fast-forward merge, and the merge commit it makes instead leaves a commit on staging that is not on main, after which every later deploy is refused as a non-fast-forward. One convenient pull request breaks deploying until someone repairs it by hand.

The reasoning behind each of these choices is in
docs/implementation.md#deploying-in-detail, so docs/INSTALL.md can stay commands and one-line reasons. docs/design.md and the migration guidance in docs/implementation.md point at both; the latter also stopped claiming that "rake deploy_staging" depends on "rake production_to_staging", which has not been true since #2906. CircleCI's deploy job does that restore whenever the branch is exactly staging, so it happens however the branch was advanced.